### PR TITLE
ENH Remove dependence on sklearn in 1D code

### DIFF
--- a/examples/1d/synthetic.py
+++ b/examples/1d/synthetic.py
@@ -3,7 +3,6 @@ from torch.autograd import Variable
 from scattering import Scattering1D
 import matplotlib.pyplot as plt
 import numpy as np
-from sklearn.utils import check_random_state
 
 
 def generate_harmonic_signal(T, num_intervals=4, gamma=0.9, random_state=42):
@@ -11,7 +10,7 @@ def generate_harmonic_signal(T, num_intervals=4, gamma=0.9, random_state=42):
     Generates a harmonic signal, which is made of piecewise constant notes
     (of random fundamental frequency), with half overlap
     """
-    rng = check_random_state(random_state)
+    rng = np.random.RandomState(random_state)
     num_notes = 2 * (num_intervals - 1) + 1
     support = T // num_intervals
     half_support = support // 2

--- a/scattering/scattering1d/tests/test_filters.py
+++ b/scattering/scattering1d/tests/test_filters.py
@@ -11,7 +11,6 @@ from scattering.scattering1d.filter_bank import calibrate_scattering_filters
 from scattering.scattering1d.filter_bank import get_max_dyadic_subsampling
 from scattering.scattering1d.filter_bank import gauss1D
 import numpy as np
-from sklearn.utils import check_random_state
 import math
 
 
@@ -41,7 +40,7 @@ def test_periodize_filter_fft(random_state=42):
     Tests whether the periodization in Fourier corresponds to
     a subsampling in time
     """
-    rng = check_random_state(random_state)
+    rng = np.random.RandomState(random_state)
     size_signal = [2**j for j in range(5, 10)]
     periods = [2**k for k in range(0, 6)]
 
@@ -59,7 +58,7 @@ def test_normalizing_factor(random_state=42):
     Tests whether the computation of the normalizing factor does the correct
     job (i.e. actually normalizes the signal in l1 or l2)
     """
-    rng = check_random_state(random_state)
+    rng = np.random.RandomState(random_state)
     size_signal = [2**j for j in range(5, 10)]
     norm_type = ['l1', 'l2']
     for N in size_signal:

--- a/scattering/scattering1d/tests/test_scattering.py
+++ b/scattering/scattering1d/tests/test_scattering.py
@@ -3,7 +3,6 @@ from torch.autograd import Variable
 from scattering import Scattering1D
 import math
 import os
-from sklearn.utils import check_random_state
 
 # Signal-related tests
 
@@ -13,7 +12,7 @@ def test_simple_scatterings(random_state=42):
     Checks the behaviour of the scattering on simple signals
     (zero, constant, pure cosine)
     """
-    rng = check_random_state(random_state)
+    rng = np.random.RandomState(random_state)
     J = 6
     Q = 8
     T = 2**12

--- a/scattering/scattering1d/tests/test_utils.py
+++ b/scattering/scattering1d/tests/test_utils.py
@@ -3,7 +3,6 @@ from torch.autograd import Variable
 from scattering.scattering1d.utils import pad1D, modulus, subsample_fourier
 from scattering.scattering1d.utils import compute_border_indices
 import numpy as np
-from sklearn.utils import check_random_state
 import pytest
 
 
@@ -86,7 +85,7 @@ def test_subsample_fourier(random_state=42):
     Tests whether the periodization in Fourier performs a good subsampling
     in time
     """
-    rng = check_random_state(random_state)
+    rng = np.random.RandomState(random_state)
     J = 10
     x = rng.randn(100, 4, 2**J) + 1j * rng.randn(100, 4, 2**J)
     x_fft = np.fft.fft(x, axis=-1)[..., np.newaxis]
@@ -104,7 +103,7 @@ def test_border_indices(random_state=42):
     """
     Tests whether the border indices to unpad are well computed
     """
-    rng = check_random_state(random_state)
+    rng = np.random.RandomState(random_state)
     J_signal = 10  # signal lives in 2**J_signal
     J = 6  # maximal subsampling
 


### PR DESCRIPTION
Used `check_random_state`, which was not necessary. Replaced with
numpy call. Fixes #48.