### PR TITLE
ENH Add speed test script for 1D

### DIFF
--- a/examples/1d/compute_speed.py
+++ b/examples/1d/compute_speed.py
@@ -1,7 +1,20 @@
+"""
+Benchmark the speed of the 1D scattering transform
+==================================================
+We compute scattering transforms for signals of length `T = 2**16`, with scale
+`J = 10` and `Q = 8` wavelets per octave. The signals are stacked into batches
+of size `batch_size = 64` and the transform is computed `10` times to get an
+average running time.
+"""
+
 import torch
 import time
 import scattering.scattering1d.backend as backend
 from scattering import Scattering1D
+
+###############################################################################
+# Parameters for the benchmark
+# ----------------------------
 
 T = 2**16
 Q = 8
@@ -11,9 +24,19 @@ batch_size = 64
 
 times = 10
 
+###############################################################################
+# Set up the scattering object and the test data
+# ----------------------------------------------
+
 scattering = Scattering1D(T, J, Q)
 
 x_data = torch.randn(batch_size, 1, T, dtype=torch.float32)
+
+###############################################################################
+# Benchmark the PyTorch backend
+# -----------------------------
+# If we're using the this backend, compute scattering transforms both on CPU
+# and GPU so that we can compare performance.
 
 if backend.NAME == 'torch':
     devices = ['cpu']


### PR DESCRIPTION
Tests CPU and GPU versions of the PyTorch backend. I reduced `T` to `2**16` so we don't have to wait forever to get the results. Otherwise, I have `J = 10`, `Q = 8`, and `batch_size = 64`.

On my desktop (dual six-core Xeon CPUs with Quadro M4000 GPU), I get:
```
==> Testing Float32 with Torch backend, on CPU, forward
Elapsed time: 87.343395 [s / 10 evals], avg: 8.73 (s/batch)
==> Testing Float32 with Torch backend, on GPU, forward
Elapsed time: 29.484811 [s / 10 evals], avg: 2.95 (s/batch)
```
On the friendly neighborhood V100, I get:
```
==> Testing Float32 with Torch backend, on GPU, forward
Elapsed time: 6.374418 [s / 10 evals], avg: 0.64 (s/batch)
```