### PR TITLE
ENH Suppress warnings related to scipy.fftpack

### DIFF
--- a/examples/2d/plot_filters.py
+++ b/examples/2d/plot_filters.py
@@ -7,7 +7,7 @@ See :meth:`scattering.scattering1d.filter_bank` for more informations about the 
 import numpy as np
 import matplotlib.pyplot as plt
 from scattering.scattering2d.filter_bank import filter_bank
-import scipy.fftpack as fft
+from scattering.scattering2d.utils import fft2
 
 
 ###############################################################################
@@ -50,7 +50,7 @@ for filter in filters_set['psi']:
     f_r = filter[0][...,0].numpy()
     f_i = filter[0][..., 1].numpy()
     f = f_r + 1j*f_i
-    filter_c = fft.fft2(f)
+    filter_c = fft2(f)
     filter_c = np.fft.fftshift(filter_c)
     axs[i // L, i % L].imshow(colorize(filter_c))
     axs[i // L, i % L].axis('off')
@@ -70,7 +70,7 @@ for z in range(L):
 f_r = filters_set['phi'][0][...,0].numpy()
 f_i = filters_set['phi'][0][..., 1].numpy()
 f = f_r + 1j*f_i
-filter_c = fft.fft2(f)
+filter_c = fft2(f)
 filter_c = np.fft.fftshift(filter_c)
 axs[J, L // 2].imshow(colorize(filter_c))
 

--- a/scattering/scattering2d/filter_bank.py
+++ b/scattering/scattering2d/filter_bank.py
@@ -7,10 +7,8 @@ __all__ = ['filter_bank']
 
 import torch
 import numpy as np
-import scipy.fftpack as fft
+from .utils import fft2
 from ..caching import get_cache_dir
-
-
 
 
 def filter_bank_real(M, N, J, L=8):
@@ -47,7 +45,7 @@ def filter_bank_real(M, N, J, L=8):
             psi['j'] = j
             psi['theta'] = theta
             psi_signal = morlet_2d(M, N, 0.8 * 2**j, (int(L-L/2-1)-theta) * np.pi / L, 3.0 / 4.0 * np.pi /2**j, 4.0/L, offset=offset_unpad)
-            psi_signal_fourier = fft.fft2(psi_signal)
+            psi_signal_fourier = fft2(psi_signal)
             for res in range(j + 1):
                 psi_signal_fourier_res = periodize_filter_fft(psi_signal_fourier, res)
                 psi[res]=torch.FloatTensor(np.stack((np.real(psi_signal_fourier_res), np.imag(psi_signal_fourier_res)), axis=2))
@@ -57,7 +55,7 @@ def filter_bank_real(M, N, J, L=8):
 
     filters['phi'] = {}
     phi_signal = gabor_2d(M, N, 0.8 * 2**(J-1), 0, 0, offset=offset_unpad)
-    phi_signal_fourier = fft.fft2(phi_signal)
+    phi_signal_fourier = fft2(phi_signal)
     filters['phi']['j'] = J
     for res in range(J):
         phi_signal_fourier_res = periodize_filter_fft(phi_signal_fourier, res)

--- a/scattering/scattering2d/utils.py
+++ b/scattering/scattering2d/utils.py
@@ -1,3 +1,6 @@
+import scipy.fftpack
+import warnings
+
 def compute_padding(M, N, J):
     """
          Precomputes the future padded size.
@@ -15,3 +18,8 @@ def compute_padding(M, N, J):
     M_padded = ((M + 2 ** J) // 2 ** J + 1) * 2 ** J
     N_padded = ((N + 2 ** J) // 2 ** J + 1) * 2 ** J
     return M_padded, N_padded
+
+def fft2(x):
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FutureWarning)
+        return scipy.fftpack.fft2(x)


### PR DESCRIPTION
Specifically, a FutureWarning is emitted during each `fft2` call,
so we wrap it with a `warnings.simplefilter` to suppress the
warning. Partially addresses #108.