### PR TITLE
start AUTHORS.md. 12 authors [ci skip]

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,15 @@
+Contributors
+============
+
+* Joakim Andén <https://github.com/janden>
+* Mathieu Andreux <https://github.com/AndreuxMath>
+* Tomás Angles <https://github.com/tomas-angles>
+* Eugene Belilovsky <https://github.com/eugenium>
+* Michael Eickenberg <https://github.com/eickenberg>
+* Georgios Exarchakis <https://github.com/gexarcha>
+* Gabriel Huang <https://github.com/gabrielhuang>
+* Roberto Leonarduzzi <https://github.com/rleonarduzzi>
+* Vincent Lostanlen <https://github.com/lostanlen>
+* Edouard Oyallon <https://github.com/edouardoyallon>
+* Louis Thiry <https://github.com/louity>
+* Sergey Zagoruyko <https://github.com/szagoruyko>


### PR DESCRIPTION
I'm working towards making this module more accessible to new contributors, and eventually publishing it into PyPI
This will include AUTHORS.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, ISSUE_TEMPLATE.md, MANIFEST.in, and PULL_REQUEST_TEMPLATE.md
I am following the same templates as in librosa (of which I'm among the co-admins)

I'm starting with AUTHORS.md. There are 12 authors as of Nov 9, 2018, who contributed to the package by at least one commit. We can update this list once more people contribute