### PR TITLE
ENH Fix `requirements_optional_cuda.txt` file

### DIFF
--- a/requirements_optional_cuda.txt
+++ b/requirements_optional_cuda.txt
@@ -1,2 +1,2 @@
-skcuda
+scikit-cuda
 cupy


### PR DESCRIPTION
The package name for `skcuda` is `scikit-cuda`, so we need to have
that here.