### PR TITLE
BUG Fix error when calling `unique` on CUDA tensor

### DIFF
--- a/examples/1d/plot_classif.py
+++ b/examples/1d/plot_classif.py
@@ -204,7 +204,7 @@ Sx_tr = (Sx_tr - mu_tr) / std_tr
 # Here we define a Logistic Regression model using PyTorch. We train it using
 # Adam with a negative log-likelihood loss.
 num_input = Sx_tr.shape[-1]
-num_classes = y_tr.unique().numel()
+num_classes = y_tr.cpu().unique().numel()
 model = Sequential(Linear(num_input, num_classes), LogSoftmax(dim=1))
 optimizer = Adam(model.parameters())
 criterion = NLLLoss()


### PR DESCRIPTION
To get the number of classes in `plot_classif.py`, we need to
transfer the Tensor to CPU memory before calling `unique`, since
it is not implemented for CUDA Tensors.