### PR TITLE
MAINT Replace some environment variables and config file names

### DIFF
--- a/kymatio/caching.py
+++ b/kymatio/caching.py
@@ -9,9 +9,9 @@ def find_cache_base_dir(cache_base_dir=None):
     ---------
     cache_base_dir: string, optional
         Defaults to None. If None, then the cache directory is searched in the
-        environement variable 'SCATTERING_CACHE'. If the latter does not
+        environement variable 'KYMATIO_CACHE'. If the latter does not
         exist (so returns None), then the default base cache directory is:
-        "~/scattering_cache"
+        "~/kymatio_cache"
 
     Returns
     -------
@@ -19,11 +19,11 @@ def find_cache_base_dir(cache_base_dir=None):
         The path to the cache base directory.
     """
     if cache_base_dir is None:
-        scattering_cache = os.environ.get('SCATTERING_CACHE')
-        if scattering_cache is None:
-            return os.path.join(os.path.expanduser("~"), "scattering_cache")
+        kymatio_cache = os.environ.get('KYMATIO_CACHE')
+        if kymatio_cache is None:
+            return os.path.join(os.path.expanduser("~"), "kymatio_cache")
         else:
-            return scattering_cache
+            return kymatio_cache
     else:
         return cache_base_dir
 

--- a/kymatio/datasets.py
+++ b/kymatio/datasets.py
@@ -17,8 +17,8 @@ def find_datasets_base_dir(datasets_base_dir=None):
     ---------
     datasets_base_dir: string, optional
         Defaults to None. If None, then the datasets directory is searched in the
-        environement variable 'SCATTERING_DATASETS'. If the latter does not
-        exist the default base cache directory is: "~/scattering_datasets"
+        environement variable 'KYMATIO_DATASETS'. If the latter does not
+        exist the default base cache directory is: "~/kymatio_datasets"
 
     Returns
     -------
@@ -28,14 +28,14 @@ def find_datasets_base_dir(datasets_base_dir=None):
 
     Notes
     -----
-    Set the environment variable SCATTERING_DATASETS to direct dataset
+    Set the environment variable KYMATIO_DATASETS to direct dataset
     downloads to a desired download location.
     """
 
 
     if datasets_base_dir is None:
-        datasets_base_dir = os.environ.get('SCATTERING_DATASETS',
-                                os.path.expanduser("~/scattering_datasets"))
+        datasets_base_dir = os.environ.get('KYMATIO_DATASETS',
+                                os.path.expanduser("~/kymatio_datasets"))
     return datasets_base_dir
 
 

--- a/kymatio/scattering1d/backend/__init__.py
+++ b/kymatio/scattering1d/backend/__init__.py
@@ -4,8 +4,8 @@
 
 # Here's how it is decided upon:
 
-# 1. Is there an environment variable SCATTERING_BACKEND_1D?
-# 2. Is there an environment variable SCATTERING_BACKEND?
+# 1. Is there an environment variable KYMATIO_BACKEND_1D?
+# 2. Is there an environment variable KYMATIO_BACKEND?
 # 3. Is there a config file? If so, go and find the backend entry
 # 4. Set the backend to DEFAULT_BACKEND
 
@@ -16,7 +16,7 @@ import appdirs
 DEFAULT_BACKEND = "torch"
 
 # find config file
-config_file = os.path.join(appdirs.user_config_dir("scattering"), "scattering.cfg")
+config_file = os.path.join(appdirs.user_config_dir("kymatio"), "kymatio.cfg")
 cp = configparser.ConfigParser()
 
 if os.path.exists(config_file):
@@ -48,10 +48,10 @@ else:
         pass
 
 # general env:
-BACKEND = os.environ.get("SCATTERING_BACKEND", BACKEND)
+BACKEND = os.environ.get("KYMATIO_BACKEND", BACKEND)
 
 # 1d specific env:
-BACKEND = os.environ.get("SCATTERING_BACKEND_1D", BACKEND)
+BACKEND = os.environ.get("KYMATIO_BACKEND_1D", BACKEND)
 
 if BACKEND == 'torch':
     from .backend_torch import *

--- a/kymatio/scattering2d/backend/__init__.py
+++ b/kymatio/scattering2d/backend/__init__.py
@@ -4,8 +4,8 @@
 
 # Here's how it is decided upon:
 
-# 1. Is there an environment variable SCATTERING_BACKEND_2D?
-# 2. Is there an environment variable SCATTERING_BACKEND?
+# 1. Is there an environment variable KYMATIO_BACKEND_2D?
+# 2. Is there an environment variable KYMATIO_BACKEND?
 # 3. Is there a config file? If so, go and find the backend entry
 # 4. Set the backend to DEFAULT_BACKEND
 
@@ -18,7 +18,7 @@ import appdirs
 
 # find config file
 
-config_file = os.path.join(appdirs.user_config_dir("scattering"), "scattering.cfg")
+config_file = os.path.join(appdirs.user_config_dir("kymatio"), "kymatio.cfg")
 cp = configparser.ConfigParser()
 
 if os.path.exists(config_file):
@@ -53,10 +53,10 @@ else:
 
 
 # general env:
-BACKEND = os.environ.get("SCATTERING_BACKEND", BACKEND)
+BACKEND = os.environ.get("KYMATIO_BACKEND", BACKEND)
 
 # 2d specific env:
-BACKEND = os.environ.get("SCATTERING_BACKEND_2D", BACKEND)
+BACKEND = os.environ.get("KYMATIO_BACKEND_2D", BACKEND)
 
 
 

--- a/kymatio/scattering2d/tests/test_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_scattering2d.py
@@ -140,7 +140,7 @@ def test_Cublas():
 
 # Check the scattering
 # FYI: access the two different tests in here by setting envs
-# SCATTERING_BACKEND=skcuda and SCATTERING_BACKEND=torch
+# KYMATIO_BACKEND=skcuda and KYMATIO_BACKEND=torch
 def test_Scattering2D():
     test_data_dir = os.path.dirname(__file__)
     data = torch.load(os.path.join(test_data_dir, 'test_data_2d.pt'), map_location='cpu')

--- a/kymatio/scattering3d/backend/__init__.py
+++ b/kymatio/scattering3d/backend/__init__.py
@@ -4,8 +4,8 @@
 
 # Here's how it is decided upon:
 
-# 1. Is there an environment variable SCATTERING_BACKEND_3D?
-# 2. Is there an environment variable SCATTERING_BACKEND?
+# 1. Is there an environment variable KYMATIO_BACKEND_3D?
+# 2. Is there an environment variable KYMATIO_BACKEND?
 # 3. Is there a config file? If so, go and find the backend entry
 # 4. Set the backend to DEFAULT_BACKEND
 
@@ -18,7 +18,7 @@ import appdirs
 
 # find config file
 
-config_file = os.path.join(appdirs.user_config_dir("scattering"), "scattering.cfg")
+config_file = os.path.join(appdirs.user_config_dir("kymatio"), "kymatio.cfg")
 cp = configparser.ConfigParser()
 
 if os.path.exists(config_file):
@@ -53,10 +53,10 @@ else:
 
 
 # general env:
-BACKEND = os.environ.get("SCATTERING_BACKEND", BACKEND)
+BACKEND = os.environ.get("KYMATIO_BACKEND", BACKEND)
 
 # 3d specific env:
-BACKEND = os.environ.get("SCATTERING_BACKEND_3D", BACKEND)
+BACKEND = os.environ.get("KYMATIO_BACKEND_3D", BACKEND)
 
 
 


### PR DESCRIPTION
Before, we had `SCATTERING_*` variables. Now we have `KYMATIO_*` variables. This PR also changes the names of some files (config files and caching/datasets directories) to say `kymatio` instead of `scattering`.