### PR TITLE
[BUG] avoid spurious carriage return in PyPI readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LICENSE = 'BSD-3-Clause'
 
 # Parse description
 with open('README.md') as f:
-    README = f.read()
+    README = f.read().split('\n')
     LONG_DESCRIPTION = '\n'.join([x for x in README if not x[:3]=='[!['])
 
 


### PR DESCRIPTION
In #171, I wrote a parser that strips out the badges of the PyPI readme. But I forgot to split by line before that.
This commit bugfixes the previous PR in that it correctly strips out the badges and avoids the unwanted carriage returns after every word.

Closes #169 