### PR TITLE
MAINT define __version__

### DIFF
--- a/kymatio/__init__.py
+++ b/kymatio/__init__.py
@@ -1,13 +1,3 @@
-__all__ = [
-            'Scattering3D',
-            'Scattering2D',
-            'Scattering1D'
-            ]
-
-from .scattering2d.scattering2d import Scattering2D
-from .scattering1d.scattering1d import Scattering1D
-from .scattering3d.scattering3d import Scattering3D
-
 # Make sure that DeprecationWarning within this package always gets printed
 ### Snippet copied from sklearn.__init__
 import warnings
@@ -16,4 +6,14 @@ warnings.filterwarnings('always', category=DeprecationWarning,
                         module=r'^{0}.*'.format(re.escape(__name__)))
 ### End Snippet
 
+__all__ = [
+            'Scattering1D',
+            'Scattering2D',
+            'Scattering3D'
+            ]
 
+from .scattering1d.scattering1d import Scattering1D
+from .scattering2d.scattering2d import Scattering2D
+from .scattering3d.scattering3d import Scattering3D
+
+from .version import version as __version__


### PR DESCRIPTION
Closes #182
from .version import version as __version__ in __init__.py allows kymatio.__version__ to be equal to kymatio.version.version
This is compliant with PEP 396
I'm taking the opportunity of this PR to reorder 1D, 2D, and 3D imports