### PR TITLE
MAINT set DISTNAME to lowercase kymatio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 from setuptools import setup, find_packages
 
 # Constants
-DISTNAME = 'Kymatio'
+DISTNAME = 'kymatio'
 DESCRIPTION = 'Wavelet scattering transforms in Python with GPU acceleration'
 URL = 'https://kymatio.github.io'
 LICENSE = 'BSD-3-Clause'


### PR DESCRIPTION
The name of the library is Kymatio while the name of the module is kymatio
That said, virtually all other libraries which have fancy capitalization in their names use the lowercase capitalization in their PyPI and conda distributions.

ex: SciPy is `scipy`, NumPy is `numpy`, TensorFlow is `tensorflow`, PyTorch is `torch`, Pandas is `pandas`, BLAS is `blas`, IPython is `ipython`, etc. The list goes on.
The only exceptions I'm aware of are Keras (`Keras`), Theano (`Theano`), PySoundFile (`PySoundFile`), and Sphinx (`Sphinx`).
The reason why I'm proposing this change is that otherwise it might lead to users trying to do `import Kymatio` whereas the correct capitalization is `import kymatio`. So it's good to hint at the correct capitalization in the PyPI distribution.