### PR TITLE
FIX disable caching of 2-d filter banks

### DIFF
--- a/kymatio/scattering2d/filter_bank.py
+++ b/kymatio/scattering2d/filter_bank.py
@@ -50,7 +50,7 @@ def filter_bank(M, N, J, L=8, cache=False):
             for res in range(j + 1):
                 psi_signal_fourier_res = periodize_filter_fft(
                     psi_signal_fourier, res)
-                psi[res] = torch.FloatTensor
+                psi[res] = torch.FloatTensor(
                     np.stack((np.real(psi_signal_fourier_res),
                     np.imag(psi_signal_fourier_res)), axis=2))
                 # Normalization to avoid doing it with the FFT.

--- a/kymatio/scattering2d/filter_bank.py
+++ b/kymatio/scattering2d/filter_bank.py
@@ -11,7 +11,7 @@ from .utils import fft2
 from ..caching import get_cache_dir
 
 
-def filter_bank(M, N, J, L=8, cache=False):
+def filter_bank(M, N, J, L=8):
     """
         Builds in Fourier the Morlet filters used for the scattering transform.
         Each single filter is provided as a dictionary with the following keys:


### PR DESCRIPTION
closes #175
the function filter_bank_real no longer exists
filter_bank does what filter_bank_real used to do and does not cache the filters
+ some docstring and PEP8 improvements