### PR TITLE
3 d skcuda backend

### DIFF
--- a/examples/3d/compute_speed.py
+++ b/examples/3d/compute_speed.py
@@ -66,6 +66,8 @@ times = 10
 
 if backend.NAME == 'torch':
     devices = ['cpu', 'gpu']
+elif backend.NAME == 'skcuda':
+    devices = ['gpu']
 
 ###############################################################################
 # Set up the scattering object and the test data

--- a/kymatio/scattering3d/backend/__init__.py
+++ b/kymatio/scattering3d/backend/__init__.py
@@ -62,6 +62,8 @@ BACKEND = os.environ.get("KYMATIO_BACKEND_3D", BACKEND)
 
 if BACKEND == 'torch':
     from .backend_torch import *
+elif BACKEND == 'skcuda':
+    from .backend_skcuda import *
 else:
     # For now, raise and error
     raise ValueError("Backend {} unknown".format(BACKEND))

--- a/kymatio/scattering3d/backend/backend_skcuda.py
+++ b/kymatio/scattering3d/backend/backend_skcuda.py
@@ -5,6 +5,7 @@ from skcuda import cublas
 
 NAME = 'skcuda'
 
+
 def getDtype(t):
     if isinstance(t, torch.cuda.FloatTensor):
         return 'float'
@@ -12,14 +13,19 @@ def getDtype(t):
         return 'double'
 
 
+def iscomplex(input):
+    return input.size(-1) == 2
+
+
+def to_complex(input):
+    output = input.new(input.size() + (2,)).fill_(0)
+    output[..., 0] = input
+    return output
+
 def complex_modulus(input_array):
     modulus = torch.zeros_like(input_array)
     modulus[..., 0] += torch.sqrt((input_array ** 2).sum(-1))
     return modulus
-
-
-def iscomplex(input):
-    return input.size(-1) == 2
 
 
 def fft(input, inverse=False):
@@ -46,7 +52,7 @@ def fft(input, inverse=False):
     return torch.fft(input, 3)
 
 
-def cdgmm(A, B, inplace=False):
+def cdgmm3d(A, B, inplace=False):
     """
         Complex pointwise multiplication between (batched) tensor A and tensor B.
 

--- a/kymatio/scattering3d/backend/backend_skcuda.py
+++ b/kymatio/scattering3d/backend/backend_skcuda.py
@@ -1,0 +1,93 @@
+# Authors: Edouard Oyallon, Sergey Zagoruyko, Louis Thiry
+
+import torch
+from skcuda import cublas
+
+NAME = 'skcuda'
+
+def getDtype(t):
+    if isinstance(t, torch.cuda.FloatTensor):
+        return 'float'
+    elif isinstance(t, torch.cuda.DoubleTensor):
+        return 'double'
+
+
+def complex_modulus(input_array):
+    modulus = torch.zeros_like(input_array)
+    modulus[..., 0] += torch.sqrt((input_array ** 2).sum(-1))
+    return modulus
+
+
+def iscomplex(input):
+    return input.size(-1) == 2
+
+
+def fft(input, inverse=False):
+    """
+        fft of a 3d signal
+
+        Example
+        -------
+        x = torch.randn(128, 32, 32, 32, 2)
+        x_fft = fft(x, inverse=True)
+
+        Parameters
+        ----------
+        input : tensor
+            complex input for the FFT
+        inverse : bool
+            True for computing the inverse FFT.
+.
+    """
+    if not iscomplex(input):
+        raise(TypeError('The input should be complex (e.g. last dimension is 2)'))
+    if inverse:
+        return torch.ifft(input, 3)
+    return torch.fft(input, 3)
+
+
+def cdgmm(A, B, inplace=False):
+    """
+        Complex pointwise multiplication between (batched) tensor A and tensor B.
+
+        Parameters
+        ----------
+        A : tensor
+            input tensor with size (batch_size, M, N, O, 2)
+        B : tensor
+            B is a complex tensor of size (M, N, O, 2)
+        inplace : boolean, optional
+            if set to True, all the operations are performed inplace
+
+        Returns
+        -------
+        C : tensor
+            output tensor of size (batch_size, M, N, 0, 2) such that:
+            C[b, m, n, o, :] = A[b, m, n, o, :] * B[m, n, o, :]
+    """
+    A, B = A.contiguous(), B.contiguous()
+    if A.size()[-4:] != B.size():
+        raise RuntimeError('The filters are not compatible for multiplication!')
+
+    if not iscomplex(A) or not iscomplex(B):
+        raise TypeError('The input, filter and output should be complex')
+
+    if B.ndimension() != 4:
+        raise RuntimeError('The filters must be simply a complex array!')
+
+    if type(A) is not type(B):
+        raise RuntimeError('A and B should be same type!')
+
+    if not A.is_cuda:
+        raise RuntimeError('Use the torch backend for cpu tensors!')
+
+    C = A.new(A.size()) if not inplace else A
+    m, n = B.nelement() // 2, A.nelement() // B.nelement()
+    lda = m
+    ldc = m
+    incx = 1
+    handle = torch.cuda.current_blas_handle()
+    stream = torch.cuda.current_stream()._as_parameter_
+    cublas.cublasSetStream(handle, stream)
+    cublas.cublasCdgmm(handle, 'l', m, n, A.data_ptr(), lda, B.data_ptr(), incx, C.data_ptr(), ldc)
+    return C


### PR DESCRIPTION
With skcuda backend :
==> Testing Float32 with skcuda backend, on GPU, forward
Elapsed time: 26.044302 [s / 10 evals], avg: 2.60 (s/batch)
With torch backend:
==> Testing Float32 with torch backend, on GPU, forward
Elapsed time: 29.869728 [s / 10 evals], avg: 2.99 (s/batch)

13% speedup