### PR TITLE
ENH Make 1D input shapes `(B, T)`, not `(B, 1, T)`

### DIFF
--- a/examples/1d/compute_speed.py
+++ b/examples/1d/compute_speed.py
@@ -78,7 +78,7 @@ if backend.NAME == 'skcuda' and torch.cuda.is_available():
 
 scattering = Scattering1D(J, T, Q)
 
-x = torch.randn(batch_size, 1, T, dtype=torch.float32)
+x = torch.randn(batch_size, T, dtype=torch.float32)
 
 ###############################################################################
 # Run the benchmark

--- a/examples/1d/plot_classif.py
+++ b/examples/1d/plot_classif.py
@@ -105,7 +105,7 @@ path_dataset = info_data['path_dataset']
 ###############################################################################
 # Set up Tensors to hold the audio signals (`x_all`), the labels (`y_all`), and
 # whether the signal is in the train or test set (`subset`).
-x_all = torch.zeros(len(files), 1, T, dtype=torch.float32)
+x_all = torch.zeros(len(files), T, dtype=torch.float32)
 y_all = torch.zeros(len(files), dtype=torch.int64)
 subset = torch.zeros(len(files), dtype=torch.int64)
 
@@ -143,7 +143,7 @@ for k, f in enumerate(files):
     # If it's too short, zero-pad it.
     start = (T - x.numel()) // 2
 
-    x_all[k,0,start:start + x.numel()] = x
+    x_all[k,start:start + x.numel()] = x
     y_all[k] = y
 
 ###############################################################################

--- a/examples/1d/plot_real_signal.py
+++ b/examples/1d/plot_real_signal.py
@@ -56,7 +56,7 @@ _, x = scipy.io.wavfile.read(file_path)
 
 x = torch.from_numpy(x).float()
 x /= x.abs().max()
-x = x.view(1, 1, -1)
+x = x.view(1, -1)
 
 ###############################################################################
 # We are now ready to set up the parameters for the scattering transform.
@@ -106,7 +106,7 @@ order2 = (meta['order'] == 2)
 # numpy array using the `numpy()` method.
 
 plt.figure(figsize=(8, 2))
-plt.plot(x[0,0,:].numpy())
+plt.plot(x[0,:].numpy())
 plt.title('Original signal')
 
 ###############################################################################

--- a/examples/1d/plot_synthetic.py
+++ b/examples/1d/plot_synthetic.py
@@ -51,7 +51,7 @@ def generate_harmonic_signal(T, num_intervals=4, gamma=0.9, random_state=42):
                      np.cos(u * (k + 1) * base_freq[i] + phase[i]))
         x[ind_start:ind_start + support] += note * window
     # Transform x into a torch Tensor
-    x = torch.from_numpy(x[np.newaxis, np.newaxis])
+    x = torch.from_numpy(x[np.newaxis])
     return x
 
 ###############################################################################

--- a/kymatio/scattering1d/scattering1d.py
+++ b/kymatio/scattering1d/scattering1d.py
@@ -111,7 +111,7 @@ class Scattering1D(object):
     GPU, if available. A `Scattering1D` object may be transferred from one
     to the other using the `cuda()` and `cpu()` methods.
 
-    Given an input Tensor `x` of size `(B, 1, T)`, where `B` is the number of
+    Given an input Tensor `x` of size `(B, T)`, where `B` is the number of
     signals to transform (the batch size) and `T` is the length of the signal,
     we compute its scattering transform by passing it to the `forward()`
     method.
@@ -386,7 +386,7 @@ class Scattering1D(object):
     def forward(self, x):
         """Apply the scattering transform
 
-        Given an input Tensor of size `(B, 1, T0)`, where `B` is the batch
+        Given an input Tensor of size `(B, T0)`, where `B` is the batch
         size and `T0` is the length of the individual signals, this function
         computes its scattering transform. If the `vectorize` flag is set to 
         `True`, the output is in the form of a Tensor or size `(B, C, T1)`,
@@ -404,7 +404,7 @@ class Scattering1D(object):
         Parameters
         ----------
         x : tensor
-            An input Tensor of size `(B, 1, T0)`.
+            An input Tensor of size `(B, T0)`.
 
         Returns
         -------
@@ -414,14 +414,12 @@ class Scattering1D(object):
             is `False`, it is a dictionary indexed by tuples of filter indices.
         """
         # basic checking, should be improved
-        if len(x.shape) != 3:
+        if len(x.shape) != 2:
             raise ValueError(
-                'Input tensor x should have 3 axis, got {}'.format(
+                'Input tensor x should have 2 axis, got {}'.format(
                     len(x.shape)))
-        if x.shape[1] != 1:
-            raise ValueError(
-                'Input tensor should only have 1 channel, got {}'.format(
-                    x.shape[1]))
+        x = x.unsqueeze(1)
+
         # get the arguments before calling the scattering
         # treat the arguments
         if self.vectorize:

--- a/kymatio/scattering1d/tests/test_scattering1d.py
+++ b/kymatio/scattering1d/tests/test_scattering1d.py
@@ -27,7 +27,7 @@ def test_simple_scatterings(random_state=42):
     if force_gpu:
         scattering = scattering.cuda()
     # zero signal
-    x0 = torch.zeros(128, 1, T)
+    x0 = torch.zeros(128, T)
     if force_gpu:
         x0 = x0.cuda()
     s = scattering.forward(x0)
@@ -37,7 +37,7 @@ def test_simple_scatterings(random_state=42):
     assert torch.max(torch.abs(s)) < 1e-7
 
     # constant signal
-    x1 = rng.randn(1)[0] * torch.ones(1, 1, T)
+    x1 = rng.randn(1)[0] * torch.ones(1, T)
     if force_gpu:
         x1 = x1.cuda()
     s1 = scattering.forward(x1)
@@ -51,7 +51,7 @@ def test_simple_scatterings(random_state=42):
     for _ in range(50):
         k = rng.randint(1, T // 2, 1)[0]
         x2 = torch.cos(2 * math.pi * float(k) * torch.arange(0, T, dtype=torch.float32) / float(T))
-        x2 = x2.unsqueeze(0).unsqueeze(0)
+        x2 = x2.unsqueeze(0)
         if force_gpu:
             x2 = x2.cuda()
         s2 = scattering.forward(x2)
@@ -76,6 +76,9 @@ def test_sample_scattering():
     Sx0 = data['Sx']
 
     T = x.shape[2]
+
+    # Convert from old (B, 1, T) format.
+    x = x.squeeze(1)
 
     scattering = Scattering1D(J, T, Q)
 
@@ -102,7 +105,7 @@ def test_computation_Ux(random_state=42):
     scattering = Scattering1D(J, T, Q, normalize='l1', average=False,
                               max_order=1, vectorize=False)
     # random signal
-    x = torch.from_numpy(rng.randn(1, 1, T)).float()
+    x = torch.from_numpy(rng.randn(1, T)).float()
 
     if force_gpu:
         scattering.cuda()
@@ -144,7 +147,7 @@ def test_scattering_GPU_CPU(random_state=42, test_cuda=None):
         # build the scattering
         scattering = Scattering1D(J, T, Q)
 
-        x = torch.randn(128, 1, T)
+        x = torch.randn(128, T)
         s_cpu = scattering.forward(x)
 
         scattering = scattering.cuda()
@@ -164,7 +167,7 @@ def test_coordinates(random_state=42):
     Q = 8
     T = 2**12
     scattering = Scattering1D(J, T, Q, max_order=2)
-    x = torch.randn(128, 1, T)
+    x = torch.randn(128, T)
 
     if force_gpu:
         scattering.cuda()
@@ -200,7 +203,7 @@ def test_precompute_size_scattering(random_state=42):
     Q = 8
     T = 2**12
     scattering = Scattering1D(J, T, Q, vectorize=False)
-    x = torch.randn(128, 1, T)
+    x = torch.randn(128, T)
 
     if force_gpu:
         scattering.cuda()
@@ -246,7 +249,7 @@ def test_differentiability_scattering(random_state=42):
     Q = 8
     T = 2**12
     scattering = Scattering1D(J, T, Q)
-    x = torch.randn(128, 1, T, requires_grad=True)
+    x = torch.randn(128, T, requires_grad=True)
 
     if force_gpu:
         scattering.cuda()


### PR DESCRIPTION
Previously, inputs to the scattering transform had to have a
channel axis that was always of dimension one. This is no longer
the case. An input of shape `(B, T)` is converted to a scattering
output of shape `(B, C, T1)`, where `C` is the number of scattering
coefficients and `T1` is the subsampled length of the signal.

Fixes #213.