### PR TITLE
ENH Make transforms batch shape agnostic

### DIFF
--- a/kymatio/scattering1d/scattering1d.py
+++ b/kymatio/scattering1d/scattering1d.py
@@ -355,17 +355,15 @@ class Scattering1D(object):
             is `False`, it is a dictionary indexed by tuples of filter indices.
         """
         # basic checking, should be improved
-        if x.dim() < 1:
+        if len(x.shape) < 1:
             raise ValueError(
                 'Input tensor x should have at least one axis, got {}'.format(
-                    x.dim()))
+                    len(x.shape)))
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
 
-        batch_length = int(np.prod(batch_shape))
-
-        x = x.view((batch_length, 1) + signal_shape)
+        x = x.reshape((-1, 1) + signal_shape)
 
         # get the arguments before calling the scattering
         # treat the arguments
@@ -388,11 +386,11 @@ class Scattering1D(object):
 
         if self.vectorize:
             scattering_shape = S.shape[-2:]
-            S = S.view(batch_shape + scattering_shape)
+            S = S.reshape(batch_shape + scattering_shape)
         else:
             for k, v in S.items():
                 scattering_shape = v.shape[-2:]
-                S[k] = v.view(batch_shape + scattering_shape)
+                S[k] = v.reshape(batch_shape + scattering_shape)
 
         return S
 

--- a/kymatio/scattering1d/tests/test_scattering1d.py
+++ b/kymatio/scattering1d/tests/test_scattering1d.py
@@ -277,3 +277,46 @@ def test_scattering_shape_input():
         # should invoke the else branch
     assert "1-tuple" in ve.value.args[0]
     assert "integer" in ve.value.args[0]
+
+def test_batch_shape_agnostic():
+    J, Q = 3, 8
+    length = 1024
+    shape = (length,)
+
+    length_ds = length/2**J
+
+    S = Scattering1D(J, shape, Q)
+
+    with pytest.raises(ValueError) as ve:
+        S(torch.zeros(()))
+    assert "at least one axis" in ve.value.args[0]
+
+    x = torch.zeros(shape)
+    Sx = S(x)
+
+    assert Sx.dim() == 2
+    assert Sx.shape[-1] == length_ds
+
+    n_coeffs = Sx.shape[-2]
+
+    test_shapes = ((1,) + shape, (2,) + shape, (2,2) + shape, (2,2,2) + shape)
+
+    for test_shape in test_shapes:
+        x = torch.zeros(test_shape)
+
+        S.vectorize = True
+        Sx = S(x)
+
+        assert Sx.dim() == len(test_shape)+1
+        assert Sx.shape[-1] == length_ds
+        assert Sx.shape[-2] == n_coeffs
+        assert Sx.shape[:-2] == test_shape[:-1]
+
+        S.vectorize = False
+        Sx = S(x)
+
+        assert len(Sx) == n_coeffs
+        for k, v in Sx.items():
+            assert v.shape[-1] == length_ds
+            assert v.shape[-2] == 1
+            assert v.shape[:-2] == test_shape[:-1]

--- a/kymatio/scattering1d/tests/test_scattering1d.py
+++ b/kymatio/scattering1d/tests/test_scattering1d.py
@@ -283,7 +283,7 @@ def test_batch_shape_agnostic():
     length = 1024
     shape = (length,)
 
-    length_ds = length/2**J
+    length_ds = length / 2**J
 
     S = Scattering1D(J, shape, Q)
 


### PR DESCRIPTION
This addresses #218, making the transforms accept any shape input, as long as the last `d` dimensions line up with the shape for which the transform is defined, where `d` is the dimension of the transform.