### PR TITLE
API Create CPU/CUDA interface for 3D

### DIFF
--- a/kymatio/scattering3d/scattering3d.py
+++ b/kymatio/scattering3d/scattering3d.py
@@ -40,6 +40,8 @@ class Scattering3D(object):
         self.L = L
         self.sigma_0 = sigma_0
 
+        self.is_cuda = False
+
         self.build()
 
     def build(self):
@@ -48,6 +50,12 @@ class Scattering3D(object):
                             self.M, self.N, self.O, self.J, self.L, self.sigma_0)
         self.gaussian_filters = gaussian_filter_bank(
                                 self.M, self.N, self.O, self.J + 1, self.sigma_0)
+
+    def cuda(self):
+        self.is_cuda = True
+
+    def cpu(self):
+        self.is_cuda = False
 
     def _fft_convolve(self, input_array, filter_array):
         """
@@ -251,6 +259,14 @@ class Scattering3D(object):
             raise(TypeError(
                 'The input should be a torch.cuda.FloatTensor, '
                 'a torch.FloatTensor or a torch.DoubleTensor'))
+
+        if self.is_cuda and not input_array.is_cuda:
+            raise(TypeError('This transform is in GPU mode, but the input is '
+                            'on the CPU.'))
+
+        if not self.is_cuda and input_array.is_cuda:
+            raise(TypeError('This transform is in CPU mode, but the input is '
+                            'on the GPU.'))
 
         if (not input_array.is_contiguous()):
             input_array = input_array.contiguous()

--- a/kymatio/scattering3d/scattering3d.py
+++ b/kymatio/scattering3d/scattering3d.py
@@ -52,9 +52,17 @@ class Scattering3D(object):
                                 self.M, self.N, self.O, self.J + 1, self.sigma_0)
 
     def cuda(self):
+        """Move to the GPU
+
+        This function prepares the object to accept input Tensors on the GPU.
+        """
         self.is_cuda = True
 
     def cpu(self):
+        """Move to the CPU
+
+        This function prepares the object to accept input Tensors on the CPU.
+        """
         self.is_cuda = False
 
     def _fft_convolve(self, input_array, filter_array):

--- a/kymatio/scattering3d/tests/test_scattering3d.py
+++ b/kymatio/scattering3d/tests/test_scattering3d.py
@@ -72,8 +72,10 @@ def test_against_standard_computations():
     for device in devices:
         if device == 'cpu':
             x = x.cpu()
+            scattering.cpu()
         else:
             x = x.cuda()
+            scattering.cuda()
         order_0 = compute_integrals(x, integral_powers)
         orders_1_and_2 = scattering(
             x, order_2=True, method='integral',


### PR DESCRIPTION
This will make `Scattering3D` behave more like the 1D/2D code and have `cpu()` and `cuda()` methods that make it accept CPU or GPU tensors depending on the state. Right now, this only changes a flag, but it might be useful later to optimize the GPU calculations.

Fixes #220.