### PR TITLE
API Change 3D flag from `order_2` to `max_order`

### DIFF
--- a/examples/3d/scattering3d_qm7.py
+++ b/examples/3d/scattering3d_qm7.py
@@ -207,20 +207,20 @@ def compute_qm7_solid_harmonic_scattering_coefficients(
                 grid, pos_batch, full_batch, sigma, cuda=cuda)
         full_order_0 = compute_integrals(full_density_batch, integral_powers)
         full_scattering = scattering(
-                full_density_batch, order_2=True, method='integral',
+                full_density_batch, max_order=2, method='integral',
                 integral_powers=integral_powers)
 
         val_density_batch = generate_weighted_sum_of_gaussians(
                 grid, pos_batch, val_batch, sigma, cuda=cuda)
         val_order_0 = compute_integrals(val_density_batch, integral_powers)
         val_scattering= scattering(
-                val_density_batch, order_2=True, method='integral',
+                val_density_batch, max_order=2, method='integral',
                 integral_powers=integral_powers)
 
         core_density_batch = full_density_batch - val_density_batch
         core_order_0 = compute_integrals(core_density_batch, integral_powers)
         core_scattering = scattering(
-                core_density_batch, order_2=True, method='integral',
+                core_density_batch, max_order=2, method='integral',
                 integral_powers=integral_powers)
 
 

--- a/kymatio/scattering3d/scattering3d.py
+++ b/kymatio/scattering3d/scattering3d.py
@@ -275,7 +275,7 @@ class Scattering3D(object):
             input of size (batchsize, M, N, O)
         max_order: int, optional
             The maximum order of scattering coefficients to compute. Must be
-            either `1` or `2`. Defaults to `2`.
+            either 1 or 2. Defaults to 2.
         rotation_covariant: bool, optional
             if set to True the first order moduli take the form::
 
@@ -303,9 +303,9 @@ class Scattering3D(object):
         output: tuple | torch tensor
             if max_order is 1 it returns a torch tensor with the
             first order scattering coefficients
-            if max_order is 2 it returns a tuple with two elements,
-            the first and second order scattering coefficients
-
+            if max_order is 2 it returns a torch tensor with the
+            first and second order scattering coefficients,
+            concatenated along the feature axis
         """
         self._check_input(input_array)
         if rotation_covariant:

--- a/kymatio/scattering3d/scattering3d.py
+++ b/kymatio/scattering3d/scattering3d.py
@@ -264,7 +264,7 @@ class Scattering3D(object):
         if (input_array.dim() != 4):
             raise (RuntimeError('Input tensor must be 4D'))
 
-    def forward(self, input_array, order_2=True, rotation_covariant=True,
+    def forward(self, input_array, max_order=2, rotation_covariant=True,
                 method='standard', points=None, integral_powers=(.5, 1., 2.)):
         """
         The forward pass of 3D solid harmonic scattering
@@ -273,9 +273,9 @@ class Scattering3D(object):
         ----------
         input_array: torch tensor 
             input of size (batchsize, M, N, O)
-        order_2: bool, optional
-            if set to False|True it also excludes|includes second order
-            scattering coefficients (default: True).
+        max_order: int, optional
+            The maximum order of scattering coefficients to compute. Must be
+            either `1` or `2`. Defaults to `2`.
         rotation_covariant: bool, optional
             if set to True the first order moduli take the form::
 
@@ -301,9 +301,9 @@ class Scattering3D(object):
         Returns
         -------
         output: tuple | torch tensor
-            if order_2 is false it returns a torch tensor with the
+            if max_order is 1 it returns a torch tensor with the
             first order scattering coefficients
-            if order_2 is true it returns a tuple with two elements,
+            if max_order is 2 it returns a tuple with two elements,
             the first and second order scattering coefficients
 
         """
@@ -328,7 +328,7 @@ class Scattering3D(object):
                 conv_modulus = convolution_and_modulus(_input, l, j_1)
                 s_order_1_l.append(compute_scattering_coefs(
                     conv_modulus, method, method_args, j_1))
-                if not order_2:
+                if max_order == 1:
                     continue
                 for j_2 in range(j_1+1, self.J+1):
                     conv_modulus_2 = convolution_and_modulus(
@@ -336,10 +336,10 @@ class Scattering3D(object):
                     s_order_2_l.append(compute_scattering_coefs(
                         conv_modulus_2, method, method_args, j_2))
             s_order_1.append(torch.cat(s_order_1_l, -1))
-            if order_2:
+            if max_order == 2:
                 s_order_2.append(torch.cat(s_order_2_l, -1))
 
-        if order_2:
+        if max_order == 2:
             return torch.cat(
                 [torch.stack(s_order_1, dim=-1),
                 torch.stack(s_order_2, dim=-1)], -2)

--- a/kymatio/scattering3d/tests/test_scattering3d.py
+++ b/kymatio/scattering3d/tests/test_scattering3d.py
@@ -76,7 +76,7 @@ def test_against_standard_computations():
             x = x.cuda()
         order_0 = compute_integrals(x, integral_powers)
         orders_1_and_2 = scattering(
-            x, order_2=True, method='integral',
+            x, max_order=2, method='integral',
             integral_powers=integral_powers)
 
         # WARNING: These are hard-coded values for the setting J = 2.
@@ -128,7 +128,7 @@ def test_solid_harmonic_scattering():
         np.fft.ifftshift(np.mgrid[-M//2:-M//2+M, -N//2:-N//2+N, -O//2:-O//2+O].astype('float32'), axes=(1,2,3)))
     x = generate_weighted_sum_of_gaussians(grid, centers, weights, sigma_gaussian)
     scattering = Scattering3D(J=J, shape=(M, N, O), L=L, sigma_0=sigma_0_wavelet)
-    s = scattering(x, order_2=False, method='integral', integral_powers=[1])
+    s = scattering(x, max_order=1, method='integral', integral_powers=[1])
 
     for j in range(J+1):
         sigma_wavelet = sigma_0_wavelet*2**j


### PR DESCRIPTION
This makes the interface consistent with the 1D and 2D transforms,
which both have `max_order`.

Fixes #196.