### PR TITLE
TST Fix tests for skcuda backend

### DIFF
--- a/kymatio/scattering1d/tests/test_scattering1d.py
+++ b/kymatio/scattering1d/tests/test_scattering1d.py
@@ -292,6 +292,11 @@ def test_batch_shape_agnostic():
     assert "at least one axis" in ve.value.args[0]
 
     x = torch.zeros(shape)
+
+    if force_gpu:
+        x = x.cuda()
+        S.cuda()
+
     Sx = S(x)
 
     assert Sx.dim() == 2
@@ -303,6 +308,9 @@ def test_batch_shape_agnostic():
 
     for test_shape in test_shapes:
         x = torch.zeros(test_shape)
+
+        if force_gpu:
+            x = x.cuda()
 
         S.vectorize = True
         Sx = S(x)

--- a/kymatio/scattering2d/tests/test_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_scattering2d.py
@@ -234,6 +234,11 @@ def test_batch_shape_agnostic():
     assert "at least two" in ve.value.args[0]
 
     x = torch.zeros(shape)
+
+    if backend.NAME == 'skcuda':
+        x = x.cuda()
+        S.cuda()
+
     Sx = S(x)
 
     assert len(Sx.shape) == 3
@@ -246,6 +251,9 @@ def test_batch_shape_agnostic():
 
     for test_shape in test_shapes:
         x = torch.zeros(test_shape)
+
+        if backend.NAME == 'skcuda':
+            x = x.cuda()
 
         Sx = S(x)
 


### PR DESCRIPTION
Since it only supports CUDA tensors, we need to cast the tensors and
transform objects before calling `forward`.

Fixes #253.