### PR TITLE
TST Improve test coverage in 1D

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -114,6 +114,7 @@ def morlet_1d(N, xi, sigma, normalize='l1', P_max=5, eps=1e-7):
         raise ValueError('P_max should be non-negative, got {}'.format(P_max))
     # Find the adequate value of P
     P = min(adaptive_choice_P(sigma, eps=eps), P_max)
+    assert P >= 1
     # Define the frequencies over [1-P, P[
     freqs = np.arange((1 - P) * N, P * N, dtype=float) / float(N)
     if P == 1:
@@ -122,8 +123,6 @@ def morlet_1d(N, xi, sigma, normalize='l1', P_max=5, eps=1e-7):
         freqs_low = np.fft.fftfreq(N)
     elif P > 1:
         freqs_low = freqs
-    else:
-        raise ValueError('P should be > 0, got ', P)
     # define the gabor at freq xi and the low-pass, both of width sigma
     gabor_f = np.exp(-(freqs - xi)**2 / (2 * sigma**2))
     low_pass_f = np.exp(-(freqs_low**2) / (2 * sigma**2))
@@ -202,13 +201,12 @@ def gauss_1d(N, sigma, normalize='l1', P_max=5, eps=1e-7):
     if P_max < 1:
         raise ValueError('P_max should be non-negative, got {}'.format(P_max))
     P = min(adaptive_choice_P(sigma, eps=eps), P_max)
+    assert P >= 1
     # switch cases
     if P == 1:
         freqs_low = np.fft.fftfreq(N)
     elif P > 1:
         freqs_low = np.arange((1 - P) * N, P * N, dtype=float) / float(N)
-    else:
-        raise ValueError('P should be an integer > 0, got {}'.format(P))
     # define the low pass
     g_f = np.exp(-freqs_low**2 / (2 * sigma**2))
     # periodize it

--- a/kymatio/scattering1d/tests/test_filters.py
+++ b/kymatio/scattering1d/tests/test_filters.py
@@ -83,25 +83,27 @@ def test_morlet_1d():
     """
     size_signal = [2**13]
     Q_range = np.arange(1, 20, dtype=int)
+    P_range = [1, 5]
     for N in size_signal:
         for Q in Q_range:
             xi_max = compute_xi_max(Q)
             xi_range = xi_max / np.power(2, np.arange(7))
             for xi in xi_range:
-                sigma = compute_sigma_psi(xi, Q)
-                # get the morlet for these parameters
-                psi_f = morlet_1d(N, xi, sigma, normalize='l2')
-                # make sure that it has zero mean
-                assert np.isclose(psi_f[0], 0.)
-                # make sure that it has a fast decay in time
-                psi = np.fft.ifft(psi_f)
-                psi_abs = np.abs(psi)
-                assert np.min(psi_abs) / np.max(psi_abs) < 1e-4
-                # Check that the maximal frequency is relatively close to xi,
-                # up to 1 percent
-                k_max = np.argmax(np.abs(psi_f))
-                xi_emp = float(k_max) / float(N)
-                assert np.abs(xi_emp - xi) / xi < 1e-2
+                for P in P_range:
+                    sigma = compute_sigma_psi(xi, Q)
+                    # get the morlet for these parameters
+                    psi_f = morlet_1d(N, xi, sigma, normalize='l2', P_max=P)
+                    # make sure that it has zero mean
+                    assert np.isclose(psi_f[0], 0.)
+                    # make sure that it has a fast decay in time
+                    psi = np.fft.ifft(psi_f)
+                    psi_abs = np.abs(psi)
+                    assert np.min(psi_abs) / np.max(psi_abs) < 1e-3
+                    # Check that the maximal frequency is relatively close to xi,
+                    # up to 1 percent
+                    k_max = np.argmax(np.abs(psi_f))
+                    xi_emp = float(k_max) / float(N)
+                    assert np.abs(xi_emp - xi) / xi < 1e-2
 
 
 def test_gauss_1d():
@@ -112,17 +114,19 @@ def test_gauss_1d():
     """
     N = 2**13
     J = 7
+    P_range = [1, 5]
     sigma0 = 0.1
     tol = 1e-7
     for j in range(1, J + 1):
-        sigma_low = sigma0 / math.pow(2, j)
-        g_f = gauss_1d(N, sigma_low)
-        # check the symmetry of g_f
-        assert np.max(np.abs(g_f[1:N // 2] - g_f[N // 2 + 1:][::-1])) < tol
-        # make sure that it has a fast decay in time
-        phi = np.fft.ifft(g_f)
-        assert np.min(phi) > - tol
-        assert np.min(np.abs(phi)) / np.max(np.abs(phi)) < 1e-4
+        for P in P_range:
+            sigma_low = sigma0 / math.pow(2, j)
+            g_f = gauss_1d(N, sigma_low, P_max=P)
+            # check the symmetry of g_f
+            assert np.max(np.abs(g_f[1:N // 2] - g_f[N // 2 + 1:][::-1])) < tol
+            # make sure that it has a fast decay in time
+            phi = np.fft.ifft(g_f)
+            assert np.min(phi) > - tol
+            assert np.min(np.abs(phi)) / np.max(np.abs(phi)) < 1e-4
 
 
 def test_calibrate_scattering_filters():

--- a/kymatio/scattering1d/tests/test_filters.py
+++ b/kymatio/scattering1d/tests/test_filters.py
@@ -5,6 +5,7 @@ from kymatio.scattering1d.filter_bank import adaptive_choice_P
 from kymatio.scattering1d.filter_bank import periodize_filter_fourier
 from kymatio.scattering1d.filter_bank import get_normalizing_factor
 from kymatio.scattering1d.filter_bank import compute_sigma_psi
+from kymatio.scattering1d.filter_bank import compute_temporal_support
 from kymatio.scattering1d.filter_bank import compute_xi_max
 from kymatio.scattering1d.filter_bank import morlet_1d
 from kymatio.scattering1d.filter_bank import calibrate_scattering_filters
@@ -12,6 +13,7 @@ from kymatio.scattering1d.filter_bank import get_max_dyadic_subsampling
 from kymatio.scattering1d.filter_bank import gauss_1d
 import numpy as np
 import math
+import pytest
 
 
 def test_adaptive_choice_P():
@@ -72,6 +74,14 @@ def test_normalizing_factor(random_state=42):
             elif norm == 'l2':
                 assert np.isclose(np.sqrt(np.sum(np.abs(x_norm)**2)) - 1., 0.)
 
+    with pytest.raises(ValueError) as ve:
+        get_normalizing_factor(np.zeros(4))
+    assert "Zero division error is very likely" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        get_normalizing_factor(np.ones(4), normalize='l0')
+    assert "normalizations only include" in ve.value.args[0]
+
 
 def test_morlet_1d():
     """
@@ -105,6 +115,18 @@ def test_morlet_1d():
                     xi_emp = float(k_max) / float(N)
                     assert np.abs(xi_emp - xi) / xi < 1e-2
 
+    Q = 1
+    xi = compute_xi_max(Q)
+    sigma = compute_sigma_psi(xi, Q)
+
+    with pytest.raises(ValueError) as ve:
+        morlet_1d(size_signal[0], xi, sigma, P_max=5.1)
+    assert "should be an int" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        morlet_1d(size_signal[0], xi, sigma, P_max=-5)
+    assert "should be non-negative" in ve.value.args[0]
+
 
 def test_gauss_1d():
     """
@@ -128,6 +150,17 @@ def test_gauss_1d():
             assert np.min(phi) > - tol
             assert np.min(np.abs(phi)) / np.max(np.abs(phi)) < 1e-4
 
+    Q = 1
+    xi = compute_xi_max(Q)
+    sigma = compute_sigma_psi(xi, Q)
+
+    with pytest.raises(ValueError) as ve:
+        gauss_1d(N, xi, sigma, P_max=5.1)
+    assert "should be an int" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        gauss_1d(N, xi, sigma, P_max=-5)
+    assert "should be non-negative" in ve.value.args[0]
 
 def test_calibrate_scattering_filters():
     """
@@ -153,6 +186,10 @@ def test_calibrate_scattering_filters():
                 assert sig >= sigma_low
             for sig in sigma2:
                 assert sig >= sigma_low
+
+    with pytest.raises(ValueError) as ve:
+        calibrate_scattering_filters(J_range[0], 0.9)
+    assert "should always be >= 1" in ve.value.args[0]
 
 
 def test_compute_xi_max():
@@ -189,3 +226,12 @@ def test_get_max_dyadic_subsampling():
                 # find the integer k such that
                 k = N // 2**(j + 1)
                 assert np.abs(psi_f[k]) / np.max(np.abs(psi_f)) < 1e-2
+
+
+def test_compute_temporal_support():
+    # Define constant averaging filter. This will be "too long" to avoid
+    # border effects.
+    h_f = np.fft.fft(np.ones((1, 4)), axis=1)
+    with pytest.warns(UserWarning) as record:
+        compute_temporal_support(h_f)
+    assert "too small to avoid border effects" in record[0].message.args[0]

--- a/kymatio/scattering1d/tests/test_filters.py
+++ b/kymatio/scattering1d/tests/test_filters.py
@@ -177,14 +177,11 @@ def test_get_max_dyadic_subsampling():
         for xi in xi_range:
             sigma = compute_sigma_psi(xi, Q)
             j = get_max_dyadic_subsampling(xi, sigma)
-            if j > 0:  # if there is subsampling
+            # Check for subsampling. If there is no subsampling, the filters
+            # cannot be aliased, so no need to check them.
+            if j > 0:
                 # compute the corresponding Morlet
                 psi_f = morlet_1d(N, xi, sigma)
                 # find the integer k such that
                 k = N // 2**(j + 1)
                 assert np.abs(psi_f[k]) / np.max(np.abs(psi_f)) < 1e-2
-            else:
-                # pass this case: we have detected that there cannot
-                # be any subsampling, and we assume that the filters are not
-                # aliased already
-                pass

--- a/kymatio/scattering1d/tests/test_scattering1d.py
+++ b/kymatio/scattering1d/tests/test_scattering1d.py
@@ -151,6 +151,26 @@ def test_computation_Ux(random_state=42):
         else:
             assert True
 
+    scattering.max_order = 2
+
+    s = scattering.forward(x)
+
+    count = 1
+    for k1, filt1 in enumerate(scattering.psi1_f):
+        assert (k1,) in s.keys()
+        count += 1
+        for k2, filt2 in enumerate(scattering.psi2_f):
+            if filt2['j'] > filt1['j']:
+                assert (k1, k2) in s.keys()
+                count += 1
+
+    assert count == len(s)
+
+    with pytest.raises(ValueError) as ve:
+        scattering.vectorize = True
+        scattering.forward(x)
+    assert "mutually incompatible" in ve.value.args[0]
+
 
 # Technical tests
 

--- a/kymatio/scattering1d/tests/test_scattering1d.py
+++ b/kymatio/scattering1d/tests/test_scattering1d.py
@@ -202,24 +202,27 @@ def test_coordinates(random_state=42):
         scattering.cuda()
         x = x.cuda()
 
-    scattering.vectorize = False
-    s_dico = scattering.forward(x)
-    s_dico = {k: s_dico[k].data for k in s_dico.keys()}
-    scattering.vectorize = True
-    s_vec = scattering.forward(x)
+    for max_order in [1, 2]:
+        scattering.max_order = max_order
 
-    if force_gpu:
-        s_dico = {k: s_dico[k].cpu() for k in s_dico.keys()}
-        s_vec = s_vec.cpu()
+        scattering.vectorize = False
+        s_dico = scattering.forward(x)
+        s_dico = {k: s_dico[k].data for k in s_dico.keys()}
+        scattering.vectorize = True
+        s_vec = scattering.forward(x)
 
-    meta = scattering.meta()
+        if force_gpu:
+            s_dico = {k: s_dico[k].cpu() for k in s_dico.keys()}
+            s_vec = s_vec.cpu()
 
-    assert len(s_dico) == s_vec.shape[1]
+        meta = scattering.meta()
 
-    for cc in range(s_vec.shape[1]):
-        k = meta['key'][cc]
-        diff = s_vec[:, cc] - torch.squeeze(s_dico[k])
-        assert torch.max(torch.abs(diff)) < 1e-7
+        assert len(s_dico) == s_vec.shape[1]
+
+        for cc in range(s_vec.shape[1]):
+            k = meta['key'][cc]
+            diff = s_vec[:, cc] - torch.squeeze(s_dico[k])
+            assert torch.max(torch.abs(diff)) < 1e-7
 
 
 def test_precompute_size_scattering(random_state=42):

--- a/kymatio/scattering1d/tests/test_scattering1d.py
+++ b/kymatio/scattering1d/tests/test_scattering1d.py
@@ -26,6 +26,8 @@ def test_simple_scatterings(random_state=42):
     scattering = Scattering1D(J, T, Q)
     if force_gpu:
         scattering = scattering.cuda()
+    else:
+        scattering.cpu()
     # zero signal
     x0 = torch.zeros(128, T)
     if force_gpu:

--- a/kymatio/scattering1d/tests/test_utils.py
+++ b/kymatio/scattering1d/tests/test_utils.py
@@ -1,6 +1,6 @@
 import torch
 from kymatio.scattering1d.backend import pad_1d, modulus_complex, subsample_fourier
-from kymatio.scattering1d.utils import compute_border_indices
+from kymatio.scattering1d.utils import compute_border_indices, compute_padding
 import numpy as np
 import pytest
 import kymatio.scattering1d.backend as backend
@@ -151,3 +151,19 @@ def test_border_indices(random_state=42):
             assert np.min(x_sub[:ind_start[j]]) > 0.
         if ind_end[j] < x_sub.shape[-1]:
             assert np.min(x_sub[ind_end[j]:]) > 0.
+
+def test_compute_padding():
+    """
+    Test the compute_padding function
+    """
+
+    pad_left, pad_right = compute_padding(5, 16)
+    assert pad_left == 8 and pad_right == 8
+
+    with pytest.raises(ValueError) as ve:
+        _, _ = compute_padding(3, 16)
+    assert "should be larger" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        _, _ = compute_padding(6, 16)
+    assert "Too large padding value" in ve.value.args[0]

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -55,8 +55,6 @@ def cast_psi(Psi, _type):
         for k in filt.keys():
             if torch.is_tensor(filt[k]):
                 filt[k] = filt[k].type(_type).contiguous().requires_grad_(False)
-            else:
-                pass  # for the float entries
 
 
 def cast_phi(Phi, _type):
@@ -78,8 +76,6 @@ def cast_phi(Phi, _type):
     for k in Phi.keys():
         if torch.is_tensor(Phi[k]):
             Phi[k] = Phi[k].type(_type).contiguous().requires_grad_(False)
-        else:
-            pass
 
 
 def compute_padding(J_pad, T):

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -2,19 +2,6 @@ import numpy as np
 import torch
 
 
-
-def ceiling_strict(s):
-    """
-    String ceiling of an input.
-    """
-    c = np.ceil(s)
-    if c == s:
-        return int(s + 1)
-    else:
-        return int(c)
-
-
-
 def compute_border_indices(J, i0, i1):
     """
     Computes border indices at all scales which correspond to the original


### PR DESCRIPTION
Add tests to cover more cases in the code (mainly catching errors and warning) and remove code that is never executed (such as `pass` statements).

Needs to be merged on top of #298.