### PR TITLE
FIX Make sure encoding is explicit

### DIFF
--- a/kymatio/scattering1d/scattering1d.py
+++ b/kymatio/scattering1d/scattering1d.py
@@ -1,5 +1,5 @@
-# Authors: Mathieu Andreux, Joakim Andén, Edouard Oyallon
-# Scientific Ancestry: Joakim Andén, Mathieu Andreux, Vincent Lostanlen
+# Authors: Mathieu Andreux, Joakim Anden, Edouard Oyallon
+# Scientific Ancestry: Joakim Anden, Mathieu Andreux, Vincent Lostanlen
 
 import math
 import numbers

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import csv
 import importlib
 import os


### PR DESCRIPTION
In other words, if it's not specified, encoding is ASCII. Otherwise, we must
specify the encoding according to PEP 263.

Fixes #294.