### PR TITLE
TST+WIP Make Travis test a bare `pip` environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,15 @@
 language: python
+dist: xenial
 python:
-  # We don't actually use the Travis Python, so just put 3.6.
+  - "3.5"
   - "3.6"
+  - "3.7"
 env:
-  - PYTHON_VERSION=3.5
-  - PYTHON_VERSION=3.6
-  - PYTHON_VERSION=3.7
+  - CONDA=0
+  - CONDA=1
 install:
-  - sudo apt-get update
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-
-  - conda create -q -n test-environment python=$PYTHON_VERSION numpy scipy pytest pytest-cov
-  - source activate test-environment
-  - conda install -c pytorch pytorch-cpu
-  - pip install -r requirements.txt
-  - python setup.py develop
-
+  - source ./tools/travis_install.sh
 script:
   - pytest --cov=kymatio
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/tools/travis_install.sh
+++ b/tools/travis_install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+sudo apt-get update
+if [[ $CONDA == "1" ]]; then
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    bash miniconda.sh -b -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"
+    hash -r
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+    conda info -a
+
+    conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pytest pytest-cov
+    source activate test-environment
+    conda install -c pytorch pytorch-cpu
+else
+    pip install --upgrade pytest
+    pip install pytest-cov
+    if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
+        pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp35-cp35m-linux_x86_64.whl
+    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+        pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then
+        pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-linux_x86_64.whl
+    fi
+    pip install torchvision
+fi
+
+pip install -r requirements.txt
+python setup.py develop


### PR DESCRIPTION
For compatibility reasons, we also run the test suite in a bare Python environment, installing all the packages using `pip`. This is done in addition to the existing tests, which are run using the `conda` package manager.

Addresses #319.