### PR TITLE
DOC Fix link formatting in user's guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We refer to our [official benchmarks](https://www.kymat.io/userguide.html#benchm
 
 If you use this package, please cite the following paper:
 
-Andreux M., Angles T., Exarchakis G., Leonarduzzi R., Rochette G., Thiry L., Zarka J., Mallat S., Andén J., Belilovsky E., Bruna J., Lostanlen V., Hirn M. J., Oyallon E., Zhang S., Cella C., Eickenberg M (2019). Kymatio: Scattering Transforms in Python. arXiv preprint arXiv:1812.11214. [[paper]](https://arxiv.org/abs/1812.11214)
+Andreux M., Angles T., Exarchakis G., Leonarduzzi R., Rochette G., Thiry L., Zarka J., Mallat S., Andén J., Belilovsky E., Bruna J., Lostanlen V., Hirn M. J., Oyallon E., Zhang S., Cella C., Eickenberg M. (2019). Kymatio: Scattering Transforms in Python. arXiv preprint arXiv:1812.11214. [(paper)](https://arxiv.org/abs/1812.11214)
 
 ## Installation
 

--- a/doc/source/userguide.rst
+++ b/doc/source/userguide.rst
@@ -266,7 +266,7 @@ How to cite
 
 If you use this package, please cite the following paper:
 
-Andreux M., Angles T., Exarchakis G., Leonarduzzi R., Rochette G., Thiry L., Zarka J., Mallat S., Andén J., Belilovsky E., Bruna J., Lostanlen V., Hirn M. J., Oyallon E., Zhang S., Cella C., Eickenberg M (2019). Kymatio: Scattering Transforms in Python. arXiv preprint arXiv:1812.11214. `(paper) <https://arxiv.org/abs/1812.11214>`_
+Andreux M., Angles T., Exarchakis G., Leonarduzzi R., Rochette G., Thiry L., Zarka J., Mallat S., Andén J., Belilovsky E., Bruna J., Lostanlen V., Hirn M. J., Oyallon E., Zhang S., Cella C., Eickenberg M. (2019). Kymatio: Scattering Transforms in Python. arXiv preprint arXiv:1812.11214. `(paper) <https://arxiv.org/abs/1812.11214>`_
 
 .. rubric:: References
 

--- a/doc/source/userguide.rst
+++ b/doc/source/userguide.rst
@@ -266,7 +266,7 @@ How to cite
 
 If you use this package, please cite the following paper:
 
-Andreux M., Angles T., Exarchakis G., Leonarduzzi R., Rochette G., Thiry L., Zarka J., Mallat S., Andén J., Belilovsky E., Bruna J., Lostanlen V., Hirn M. J., Oyallon E., Zhang S., Cella C., Eickenberg M (2019). Kymatio: Scattering Transforms in Python. arXiv preprint arXiv:1812.11214. `[paper] <https://arxiv.org/abs/1812.11214>`_
+Andreux M., Angles T., Exarchakis G., Leonarduzzi R., Rochette G., Thiry L., Zarka J., Mallat S., Andén J., Belilovsky E., Bruna J., Lostanlen V., Hirn M. J., Oyallon E., Zhang S., Cella C., Eickenberg M (2019). Kymatio: Scattering Transforms in Python. arXiv preprint arXiv:1812.11214. `(paper) <https://arxiv.org/abs/1812.11214>`_
 
 .. rubric:: References
 


### PR DESCRIPTION
Text nodes of the form `[text]` apparently get treated like BibTeX references,
so if it can't find that reference in the bibliography, it yells at you.
Documented here:

https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/141

Fixes #347.