### PR TITLE
TST Set up Jenkins CI at Flatiron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
 script:
   - pytest --cov=kymatio
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -F travis

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,5 +10,6 @@ Vincent Lostanlen
 nshervt
 Jan Schlüter
 Edouard Oyallon
+Dylan Simon
 Louis Thiry
 Sergey Zagoruyko

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,73 @@
+pipeline {
+  agent none
+  options {
+    disableConcurrentBuilds()
+    buildDiscarder(logRotator(numToKeepStr: '8', daysToKeepStr: '20'))
+    timeout(time: 1, unit: 'HOURS')
+  }
+  stages {
+    stage('torch') {
+      agent {
+	dockerfile {
+	  dir 'tools'
+	  args '--device /dev/nvidia0:/dev/nvidia0 --device /dev/nvidiactl:/dev/nvidiactl --device /dev/nvidia-uvm:/dev/nvidia-uvm'
+	}
+      }
+      environment {
+	HOME = pwd(tmp:true)
+      }
+      steps {
+	sh 'python3 -m venv $HOME'
+	sh '''#!/bin/bash -ex
+	  source $HOME/bin/activate
+	  pip3 install -r requirements.txt pytest torchvision
+	  python3 setup.py develop
+	  KYMATIO_BACKEND=$STAGE_NAME pytest
+	'''
+      }
+    }
+    stage('skcuda') {
+      agent {
+	dockerfile {
+	  dir 'tools'
+	  args '--device /dev/nvidia0:/dev/nvidia0 --device /dev/nvidiactl:/dev/nvidiactl --device /dev/nvidia-uvm:/dev/nvidia-uvm'
+	}
+      }
+      environment {
+	HOME = pwd(tmp:true)
+      }
+      steps {
+	sh 'python3 -m venv $HOME'
+	sh '''#!/bin/bash -ex
+	  source $HOME/bin/activate
+	  pip3 install -r requirements.txt pytest scikit-cuda cupy
+	  python3 setup.py develop
+	  KYMATIO_BACKEND=$STAGE_NAME pytest
+	'''
+      }
+    }
+  }
+  post {
+    failure {
+      emailext subject: '$PROJECT_NAME - Build #$BUILD_NUMBER - $BUILD_STATUS',
+	       body: '''$PROJECT_NAME - Build #$BUILD_NUMBER - $BUILD_STATUS
+
+Check console output at $BUILD_URL to view full results.
+
+Building $BRANCH_NAME for $CAUSE
+$JOB_DESCRIPTION
+
+Chages:
+$CHANGES
+
+End of build log:
+${BUILD_LOG,maxLines=60}
+''',
+	       recipientProviders: [
+		 [$class: 'DevelopersRecipientProvider'],
+	       ],
+	       replyTo: '$DEFAULT_REPLYTO',
+	       to: 'janden@flatironinstitute.org'
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,10 @@ pipeline {
 	sh 'python3 -m venv $HOME'
 	sh '''#!/bin/bash -ex
 	  source $HOME/bin/activate
-	  pip3 install -r requirements.txt pytest torchvision
+	  pip3 install -r requirements.txt pytest pytest-cov torchvision
 	  python3 setup.py develop
-	  KYMATIO_BACKEND=$STAGE_NAME pytest
+	  KYMATIO_BACKEND=$STAGE_NAME pytest --cov=kymatio
+	  bash <(curl -s https://codecov.io/bash) -t 3941b784-370b-4e50-a162-e5018b7c2861 -F jenkins_$STAGE_NAME
 	'''
       }
     }
@@ -40,9 +41,10 @@ pipeline {
 	sh 'python3 -m venv $HOME'
 	sh '''#!/bin/bash -ex
 	  source $HOME/bin/activate
-	  pip3 install -r requirements.txt pytest scikit-cuda cupy
+	  pip3 install -r requirements.txt pytest pytest-cov scikit-cuda cupy
 	  python3 setup.py develop
-	  KYMATIO_BACKEND=$STAGE_NAME pytest
+	  KYMATIO_BACKEND=$STAGE_NAME pytest --cov=kymatio
+	  bash <(curl -s https://codecov.io/bash) -t 3941b784-370b-4e50-a162-e5018b7c2861 -F jenkins_$STAGE_NAME
 	'''
       }
     }

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ LICENSE = 'BSD-3-Clause'
 
 
 # Parse description
-with open('README.md') as f:
+with open('README.md', encoding='utf8') as f:
     README = f.read().split('\n')
     LONG_DESCRIPTION = '\n'.join([x for x in README if not x[:3]=='[!['])
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common && \
+    add-apt-repository ppa:graphics-drivers/ppa && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      libnvidia-compute-410 \
+      nvidia-cuda-toolkit \
+      python3-scipy \
+      python3-appdirs \
+      python3-pytest \
+      python3-pip \
+      python3-venv \
+      && \
+    apt-get autoremove --purge -y && \
+    apt-get autoclean -y && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -9,8 +9,10 @@ RUN apt-get update && \
       python3-scipy \
       python3-appdirs \
       python3-pytest \
+      python3-pytest-cov \
       python3-pip \
       python3-venv \
+      curl \
       && \
     apt-get autoremove --purge -y && \
     apt-get autoclean -y && \


### PR DESCRIPTION
This enables us to test the GPU functionality of the package as part of the continuous integration done with each PR and push to branches on the main repo. The test suite is currently run for both the torch and skcuda backends.

Since the Jenkins server is only accessible from within Flatiron, only the status (i.e., pending/failure/success) of the test will be visible publicly. If you would like more detailed information, you'll have to ask me or someone else who works here.

Fixes #267.