### PR TITLE
TST Improve test coverage in 1D

### DIFF
--- a/kymatio/scattering1d/backend/backend_torch.py
+++ b/kymatio/scattering1d/backend/backend_torch.py
@@ -95,17 +95,12 @@ class ModulusStable(Function):
             grad_output = grad_output.unsqueeze(ctx.dim)
             output = output.unsqueeze(ctx.dim)
 
-        if ctx.p == 2:
-            grad_input = x.mul(grad_output).div(output)
-        else:
-            input_pow = x.abs().pow(ctx.p - 2)
-            output_pow = output.pow(ctx.p - 1)
-            grad_input = x.mul(input_pow).mul(grad_output).div(output_pow)
+        grad_input = x.mul(grad_output).div(output)
 
         # Special case at 0 where we return a subgradient containing 0
         grad_input.masked_fill_(output == 0, 0)
 
-        return grad_input, None, None, None
+        return grad_input
 
 # shortcut for ModulusStable.apply
 modulus = ModulusStable.apply

--- a/kymatio/scattering1d/tests/test_scattering1d.py
+++ b/kymatio/scattering1d/tests/test_scattering1d.py
@@ -303,10 +303,6 @@ def test_differentiability_scattering(random_state=42):
     scattering = Scattering1D(J, T, Q)
     x = torch.randn(128, T, requires_grad=True)
 
-    if force_gpu:
-        scattering.cuda()
-        x = x.cuda()
-
     s = scattering.forward(x)
     loss = torch.sum(torch.abs(s))
     loss.backward()

--- a/kymatio/scattering1d/tests/test_utils.py
+++ b/kymatio/scattering1d/tests/test_utils.py
@@ -120,8 +120,6 @@ def test_modulus(random_state=42):
 
     # Test the differentiation with a vector made of zeros
     x0 = torch.zeros(100, 4, 128, 2, requires_grad=True)
-    if force_gpu:
-        x0 = x0.cuda()
     x_abs0 = modulus_complex(x0)
     loss0 = torch.sum(x_abs0)
     loss0.backward()

--- a/kymatio/scattering1d/tests/test_utils.py
+++ b/kymatio/scattering1d/tests/test_utils.py
@@ -105,6 +105,19 @@ def test_modulus(random_state=42):
     diff = x.grad - x_grad
     assert torch.max(torch.abs(diff)) <= 1e-7
 
+    # Manually check `forward`/`backward` using fake context object. This
+    # ensures that `backward` is included in code coverage since going through
+    # the PyTorch C extension seems to not play well with `coverage.py`.
+    class FakeContext:
+        def save_for_backward(self, *args):
+            self.saved_tensors = args
+
+    ctx = FakeContext()
+    y = backend.ModulusStable.forward(ctx, x)
+    y_grad = torch.ones_like(y)
+    x_grad_manual = backend.ModulusStable.backward(ctx, y_grad)
+    assert (x_grad_manual - x_grad).abs().max() < 1e-7
+
     # Test the differentiation with a vector made of zeros
     x0 = torch.zeros(100, 4, 128, 2, requires_grad=True)
     if force_gpu:


### PR DESCRIPTION
Remove unnecessary `cuda()` calls, add manual tests for `ModulusStable.backward`, and clean that function up to eliminate unused code paths.