### PR TITLE
fix 2D example: plot_filters.py

### DIFF
--- a/examples/2d/plot_filters.py
+++ b/examples/2d/plot_filters.py
@@ -47,9 +47,7 @@ plt.rc('text', usetex=True)
 plt.rc('font', family='serif')
 i=0
 for filter in filters_set['psi']:
-    f_r = filter[0][...,0]
-    f_i = filter[0][..., 1]
-    f = f_r + 1j*f_i
+    f = filter[0][...,0]
     filter_c = fft2(f)
     filter_c = np.fft.fftshift(filter_c)
     axs[i // L, i % L].imshow(colorize(filter_c))
@@ -71,9 +69,7 @@ plt.rc('font', family='serif')
 plt.axis('off')
 plt.set_cmap('gray_r')
 
-f_r = filters_set['phi'][0][..., 0]
-f_i = filters_set['phi'][0][..., 1]
-f = f_r + 1j*f_i
+f = filters_set['phi'][0][..., 0]
 
 filter_c = fft2(f)
 filter_c = np.fft.fftshift(filter_c)

--- a/examples/2d/plot_filters.py
+++ b/examples/2d/plot_filters.py
@@ -4,6 +4,7 @@ Plot the 2D wavelet filters
 See :meth:`kymatio.scattering2d.filter_bank` for more informations about the used wavelets.
 """
 
+from colorsys import hls_to_rgb
 import matplotlib.pyplot as plt
 import numpy as np
 from kymatio.scattering2d.filter_bank import filter_bank
@@ -22,7 +23,8 @@ filters_set = filter_bank(M, M, J, L=L)
 # Imshow complex images
 # ---------------------
 # Thanks to https://stackoverflow.com/questions/17044052/mathplotlib-imshow-complex-2d-array
-from colorsys import hls_to_rgb
+
+
 def colorize(z):
     n, m = z.shape
     c = np.zeros((n, m, 3))
@@ -32,8 +34,8 @@ def colorize(z):
     idx = ~(np.isinf(z) + np.isnan(z))
     A = (np.angle(z[idx]) + np.pi) / (2*np.pi)
     A = (A + 0.5) % 1.0
-    B =  1.0/(1.0+abs(z[idx])**0.3)
-    c[idx] = [hls_to_rgb(a, b, 0.8) for a,b in zip(A,B)]
+    B = 1.0/(1.0 + abs(z[idx])**0.3)
+    c[idx] = [hls_to_rgb(a, b, 0.8) for a, b in zip(A, B)]
     return c
 
 ###############################################################################
@@ -45,18 +47,20 @@ fig.set_figheight(6)
 fig.set_figwidth(6)
 plt.rc('text', usetex=True)
 plt.rc('font', family='serif')
-i=0
+i = 0
 for filter in filters_set['psi']:
-    f = filter[0][...,0]
+    f = filter[0][..., 0]
     filter_c = fft2(f)
     filter_c = np.fft.fftshift(filter_c)
     axs[i // L, i % L].imshow(colorize(filter_c))
     axs[i // L, i % L].axis('off')
-    axs[i // L, i % L].set_title("$j = {}$ \n $\\theta={}$".format(i // L, i % L))
+    axs[i // L, i % L].set_title(
+        "$j = {}$ \n $\\theta={}$".format(i // L, i % L))
     i = i+1
 
-fig.suptitle("Wavelets for each scales $j$ and angles $\\theta$ used."
-"\n Color saturation and color hue respectively denote complex magnitude and complex phase.", fontsize=13)
+fig.suptitle((r"Wavelets for each scales $j$ and angles $\theta$ used."
+              "\nColor saturation and color hue respectively denote complex "
+              "magnitude and complex phase."), fontsize=13)
 fig.show()
 
 ###############################################################################
@@ -73,7 +77,8 @@ f = filters_set['phi'][0][..., 0]
 
 filter_c = fft2(f)
 filter_c = np.fft.fftshift(filter_c)
-plt.suptitle("The corresponding low-pass filter, also known as scaling function."
-"Color saturation and color hue respectively denote complex magnitude and complex phase", fontsize=13)
+plt.suptitle(("The corresponding low-pass filter, also known as scaling "
+              "function.\nColor saturation and color hue respectively denote "
+              "complex magnitude and complex phase"), fontsize=13)
 filter_c = np.abs(filter_c)
 plt.imshow(filter_c)

--- a/examples/2d/plot_filters.py
+++ b/examples/2d/plot_filters.py
@@ -47,8 +47,8 @@ plt.rc('text', usetex=True)
 plt.rc('font', family='serif')
 i=0
 for filter in filters_set['psi']:
-    f_r = filter[0][...,0].numpy()
-    f_i = filter[0][..., 1].numpy()
+    f_r = filter[0][...,0]
+    f_i = filter[0][..., 1]
     f = f_r + 1j*f_i
     filter_c = fft2(f)
     filter_c = np.fft.fftshift(filter_c)
@@ -71,8 +71,8 @@ plt.rc('font', family='serif')
 plt.axis('off')
 plt.set_cmap('gray_r')
 
-f_r = filters_set['phi'][0][..., 0].numpy()
-f_i = filters_set['phi'][0][..., 1].numpy()
+f_r = filters_set['phi'][0][..., 0]
+f_i = filters_set['phi'][0][..., 1]
 f = f_r + 1j*f_i
 
 filter_c = fft2(f)

--- a/examples/2d/plot_filters.py
+++ b/examples/2d/plot_filters.py
@@ -82,3 +82,5 @@ plt.suptitle(("The corresponding low-pass filter, also known as scaling "
               "complex magnitude and complex phase"), fontsize=13)
 filter_c = np.abs(filter_c)
 plt.imshow(filter_c)
+
+plt.show()


### PR DESCRIPTION
This PR fixes one of the 2D examples that became outdated after PRs #345 and #320 

I can squash to one commit if you prefer, but left it separated for now in case you don't want the stylistic changes in the third commit.

I added `plt.show()` so that the plots will stay around for users running the example from the command line rather than an interactive session. Otherwise the figures pop up and immediately disappear when the script reaches the end.