### PR TITLE
[DO NOT MERGE]  ENH(WIP) Add 1d wavelets: Battle-Lemarie and Meyer

### DIFF
--- a/examples/1d/plot_filters.py
+++ b/examples/1d/plot_filters.py
@@ -25,6 +25,12 @@ import matplotlib.pyplot as plt
 ###############################################################################
 # Filter parameters and generation
 # --------------------------------
+# Kymatio implements different wavelets: 'morlet', 'battle-lemarie' and 'meyer'.
+# We start by choosing morlet, and we will compare it with other filter banks
+# later.
+wavelet_type = 'morlet'
+
+
 # The filters are defined for a certain support size `T` which corresponds to
 # the size of the input signal. The only restriction is that `T` must be a
 # power of two. Since we are not computing any scattering transforms here, we
@@ -60,12 +66,13 @@ Q = 8
 # first-order wavelet filters (`psi1_f`), and the second-order filters
 # (`psi2_f`).
 
-phi_f, psi1_f, psi2_f, _ = scattering_filter_factory(np.log2(T), J, Q)
+phi_f, psi1_f, psi2_f, _ = scattering_filter_factory(np.log2(T), J, Q,
+                                                     wav_type=wavelet_type)
 
 ###############################################################################
 # The `phi_f` output is a dictionary where each integer key corresponds points
 # to the instantiation of the filter at a certain resolution. In other words,
-# `phi_f[0]` corresponds to the lowpass filter at resolution `T`, while 
+# `phi_f[0]` corresponds to the lowpass filter at resolution `T`, while
 # `phi_f[1]` corresponds to the filter at resolution `T/2`, and so on.
 #
 # While `phi_f` only contains a single filter (at different resolutions),
@@ -91,7 +98,7 @@ plt.xlim(0, 0.5)
 
 plt.xlabel(r'$\omega$', fontsize=18)
 plt.ylabel(r'$\hat\psi_j(\omega)$', fontsize=18)
-plt.title('First-order filters (Q = {})'.format(Q), fontsize=18)
+plt.title('First-order Morlet filters (Q = {})'.format(Q), fontsize=18)
 
 ###############################################################################
 # Do the same plot for the second-order filters. Note that since here `Q = 1`,
@@ -105,7 +112,25 @@ plt.xlim(0, 0.5)
 plt.ylim(0, 1.2)
 plt.xlabel(r'$\omega$', fontsize=18)
 plt.ylabel(r'$\hat\psi_j(\omega)$', fontsize=18)
-plt.title('Second-order filters (Q = 1)', fontsize=18)
+plt.title('Second-order Morlet filters (Q = 1)', fontsize=18)
+
+###############################################################################
+# Now we will compare the available filter banks, for `Q=1`
+Q = 1
+wavelets = ['Morlet', 'Battle-Lemarie', 'Meyer']
+
+plt.figure()
+for k, wav_type in enumerate(wavelets):
+    phi_f, psi1_f, _, _ = scattering_filter_factory(np.log2(T), J, Q,
+                                                    wav_type=wav_type.lower())
+    plt.subplot(len(wavelets), 1, k + 1)
+    plt.plot(np.arange(T)/T, phi_f[0])
+    for psi_f in psi1_f:
+        plt.plot(np.arange(T)/T, psi_f[0], 'b')
+    plt.title('{} filter bank'.format(wav_type), fontsize=18)
+    plt.ylabel(r'$\hat\psi_j(\omega)$', fontsize=18)
+plt.xlabel(r'$\omega$', fontsize=18)
+plt.tight_layout()
 
 ###############################################################################
 # Display the plots!

--- a/kymatio/scattering1d/scattering1d.py
+++ b/kymatio/scattering1d/scattering1d.py
@@ -373,7 +373,7 @@ class Scattering1D(object):
         return self.forward(x)
 
     @staticmethod
-    def compute_meta_scattering(J, Q, max_order=2):
+    def compute_meta_scattering(J, Q, max_order=2, T=-1, wav_type='morlet'):
         """Get metadata on the transform.
 
         This information specifies the content of each scattering coefficient,
@@ -390,6 +390,10 @@ class Scattering1D(object):
         max_order : int, optional
             The maximum order of scattering coefficients to compute.
             Must be either equal to `1` or `2`. Defaults to `2`.
+        T : int
+            Temporal support of the data. Not needed for morlet wavelets.
+        wav_type: string
+            Wavelet type.
 
         Returns
         -------
@@ -416,7 +420,7 @@ class Scattering1D(object):
                 in the non-vectorized output.
         """
         sigma_low, xi1s, sigma1s, j1s, xi2s, sigma2s, j2s = \
-            calibrate_scattering_filters(J, Q)
+            calibrate_scattering_filters(J, Q, T, wav_type=wav_type)
 
         meta = {}
 
@@ -471,7 +475,7 @@ class Scattering1D(object):
         return meta
 
     @staticmethod
-    def precompute_size_scattering(J, Q, max_order=2, detail=False):
+    def precompute_size_scattering(J, Q, max_order=2, detail=False, T=-1, wav_type='morlet'):
         """Get size of the scattering transform
 
         The number of scattering coefficients depends on the filter
@@ -492,6 +496,10 @@ class Scattering1D(object):
         detail : boolean, optional
             Specifies whether to provide a detailed size (number of coefficient
             per order) or an aggregate size (total number of coefficients).
+        T : int
+            Temporal support of the data.
+        wav_type: string
+            Wavelet type.
 
         Returns
         -------
@@ -501,7 +509,7 @@ class Scattering1D(object):
             the number of coefficients in each order.
         """
         sigma_low, xi1, sigma1, j1, xi2, sigma2, j2 = \
-            calibrate_scattering_filters(J, Q)
+            calibrate_scattering_filters(J, Q, T, wav_type=wav_type)
 
         size_order0 = 1
         size_order1 = len(xi1)

--- a/kymatio/scattering1d/tests/test_filters.py
+++ b/kymatio/scattering1d/tests/test_filters.py
@@ -1,24 +1,24 @@
 """
 Testing all functions in filters_bank
 """
-from kymatio.scattering1d.filter_bank import adaptive_choice_P
+from kymatio.scattering1d.filter_bank import adaptive_choice_P_morlet
 from kymatio.scattering1d.filter_bank import periodize_filter_fourier
 from kymatio.scattering1d.filter_bank import get_normalizing_factor
-from kymatio.scattering1d.filter_bank import compute_sigma_psi
+from kymatio.scattering1d.filter_bank import compute_sigma_psi_morlet
 from kymatio.scattering1d.filter_bank import compute_temporal_support
-from kymatio.scattering1d.filter_bank import compute_xi_max
+from kymatio.scattering1d.filter_bank import compute_xi_max_morlet
 from kymatio.scattering1d.filter_bank import morlet_1d
 from kymatio.scattering1d.filter_bank import calibrate_scattering_filters
-from kymatio.scattering1d.filter_bank import get_max_dyadic_subsampling
+from kymatio.scattering1d.filter_bank import get_max_dyadic_subsampling_morlet
 from kymatio.scattering1d.filter_bank import gauss_1d
 import numpy as np
 import math
 import pytest
 
 
-def test_adaptive_choice_P():
+def test_adaptive_choice_P_morlet():
     """
-    Tests whether adaptive_choice_P provides a bound P which satisfies
+    Tests whether adaptive_choice_P_morlet provides a bound P which satisfies
     the adequate requirements
     """
     sigma_range = np.logspace(-5, 2, num=10)
@@ -28,7 +28,7 @@ def test_adaptive_choice_P():
             sigma = sigma_range[i]
             eps = eps_range[j]
             # choose the formula
-            P = adaptive_choice_P(sigma, eps=eps)
+            P = adaptive_choice_P_morlet(sigma, eps=eps)
             # check at the boundaries
             denom = 2 * (sigma**2)
             lim_left = np.exp(-((1 - P)**2) / denom)
@@ -96,11 +96,11 @@ def test_morlet_1d():
     P_range = [1, 5]
     for N in size_signal:
         for Q in Q_range:
-            xi_max = compute_xi_max(Q)
+            xi_max = compute_xi_max_morlet(Q)
             xi_range = xi_max / np.power(2, np.arange(7))
             for xi in xi_range:
                 for P in P_range:
-                    sigma = compute_sigma_psi(xi, Q)
+                    sigma = compute_sigma_psi_morlet(xi, Q)
                     # get the morlet for these parameters
                     psi_f = morlet_1d(N, xi, sigma, normalize='l2', P_max=P)
                     # make sure that it has zero mean
@@ -116,8 +116,8 @@ def test_morlet_1d():
                     assert np.abs(xi_emp - xi) / xi < 1e-2
 
     Q = 1
-    xi = compute_xi_max(Q)
-    sigma = compute_sigma_psi(xi, Q)
+    xi = compute_xi_max_morlet(Q)
+    sigma = compute_sigma_psi_morlet(xi, Q)
 
     with pytest.raises(ValueError) as ve:
         morlet_1d(size_signal[0], xi, sigma, P_max=5.1)
@@ -151,8 +151,8 @@ def test_gauss_1d():
             assert np.min(np.abs(phi)) / np.max(np.abs(phi)) < 1e-4
 
     Q = 1
-    xi = compute_xi_max(Q)
-    sigma = compute_sigma_psi(xi, Q)
+    xi = compute_xi_max_morlet(Q)
+    sigma = compute_sigma_psi_morlet(xi, Q)
 
     with pytest.raises(ValueError) as ve:
         gauss_1d(N, xi, sigma, P_max=5.1)
@@ -192,18 +192,18 @@ def test_calibrate_scattering_filters():
     assert "should always be >= 1" in ve.value.args[0]
 
 
-def test_compute_xi_max():
+def test_compute_xi_max_morlet():
     """
     Tests that 0.25 <= xi_max(Q) <= 0.5, whatever Q
     """
     Q_range = np.arange(1, 21, dtype=int)
     for Q in Q_range:
-        xi_max = compute_xi_max(Q)
+        xi_max = compute_xi_max_morlet(Q)
         assert xi_max <= 0.5
         assert xi_max >= 0.25
 
 
-def test_get_max_dyadic_subsampling():
+def test_get_max_dyadic_subsampling_morlet():
     """
     Tests on the subsampling formula for wavelets, to check that the retained
     value does not create aliasing (the wavelet should have decreased by
@@ -213,11 +213,11 @@ def test_get_max_dyadic_subsampling():
     Q_range = np.arange(1, 20, dtype=int)
     J = 7
     for Q in Q_range:
-        xi_max = compute_xi_max(Q)
+        xi_max = compute_xi_max_morlet(Q)
         xi_range = xi_max * np.power(0.5, np.arange(J * Q) / float(Q))
         for xi in xi_range:
-            sigma = compute_sigma_psi(xi, Q)
-            j = get_max_dyadic_subsampling(xi, sigma)
+            sigma = compute_sigma_psi_morlet(xi, Q)
+            j = get_max_dyadic_subsampling_morlet(xi, sigma)
             # Check for subsampling. If there is no subsampling, the filters
             # cannot be aliased, so no need to check them.
             if j > 0:


### PR DESCRIPTION
This pull request adds (cubic) Battle-Lemarie and Meyer wavelets in 1d.

Changes in the example `plot_filters.py` show the new filters.

I've tried to minimize the intrusiveness of the changes as much as possible, trying to preserve structure as much as possible. This leads to a clear inefficiency in one place: the maximum dyadic subsamplings are computed numerically by precomputing the filters. These extra computations could be avoided in the future by restructuring the factory function, but I've kept it simple for now.

These filters work only for Q=1. I'm not sure about how to extend them for Q>1, but they are still useful in cases where dyadic wavelets are enough.