### PR TITLE
FIX Jenkins code coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,8 @@ pipeline {
 	  source $HOME/bin/activate
 	  python3 setup.py develop
 	  KYMATIO_BACKEND=$STAGE_NAME python3 -m pytest --cov=kymatio
-	  bash <(curl -s https://codecov.io/bash) -t 3941b784-370b-4e50-a162-e5018b7c2861 -F jenkins_$STAGE_NAME -s $HOME
+	  python3 -m coverage xml
+	  bash <(curl -s https://codecov.io/bash) -t 3941b784-370b-4e50-a162-e5018b7c2861 -F jenkins_$STAGE_NAME -s $WORKSPACE
 	'''
       }
     }
@@ -41,7 +42,8 @@ pipeline {
 	  source $HOME/bin/activate
 	  python3 setup.py develop
 	  KYMATIO_BACKEND=$STAGE_NAME python3 -m pytest --cov=kymatio
-	  bash <(curl -s https://codecov.io/bash) -t 3941b784-370b-4e50-a162-e5018b7c2861 -F jenkins_$STAGE_NAME -s $HOME
+	  python3 -m coverage xml
+	  bash <(curl -s https://codecov.io/bash) -t 3941b784-370b-4e50-a162-e5018b7c2861 -F jenkins_$STAGE_NAME -s $WORKSPACE
 	'''
       }
     }


### PR DESCRIPTION
The codecov uploader looks for a `coverage.xml` file in the main directory (the $WORKSPACE environment variable in the Jenkinsfile). If it can't find one, it tries to call `coverage xml` which converts the
Python coverage file `.coverage` into `coverage.xml`. For some reason, the uploader was able to do this conversion automatically before, but now (probably because `coverage` is only accessible through `python3 -m coverage` now) it fails. The fix is therefore to manually call `python3 -m coverage xml` after running the tests.