### PR TITLE
FIX+TST Emit proper warnings in 3D backends and test for them

### DIFF
--- a/kymatio/scattering3d/backend/backend_skcuda.py
+++ b/kymatio/scattering3d/backend/backend_skcuda.py
@@ -1,4 +1,5 @@
 import torch
+import warnings
 from skcuda import cublas
 
 NAME = 'skcuda'
@@ -54,7 +55,13 @@ def cdgmm3d(A, B, inplace=False):
     output : tensor of the same size as A containing the result of the
              elementwise complex multiplication of  A with B
     """
-    A, B = A.contiguous(), B.contiguous()
+    if not A.is_contiguous():
+        warnings.warn("cdgmm3d: tensor A is converted to a contiguous array")
+        A = A.contiguous()
+    if not B.is_contiguous():
+        warnings.warn("cdgmm3d: tensor B is converted to a contiguous array")
+        B = B.contiguous()
+
     if A.size()[-4:] != B.size():
         raise RuntimeError('The filters are not compatible for multiplication.')
 

--- a/kymatio/scattering3d/tests/test_scattering3d.py
+++ b/kymatio/scattering3d/tests/test_scattering3d.py
@@ -83,6 +83,20 @@ def test_cdgmm3d():
     elif 'gpu' in devices:
         tdev = torch.device('cuda')
 
+    with pytest.warns(UserWarning) as record:
+        x = torch.randn((3, 4, 3, 2), device=tdev)
+        x = x[:,0:3,...]
+        y = torch.randn((3, 3, 3, 2), device=tdev)
+        backend.cdgmm3d(x, y)
+    assert "A is converted" in record[0].message.args[0]
+
+    with pytest.warns(UserWarning) as record:
+        x = torch.randn((3, 3, 3, 2), device=tdev)
+        y = torch.randn((3, 4, 3, 2), device=tdev)
+        y = y[:,0:3,...]
+        backend.cdgmm3d(x, y)
+    assert "B is converted" in record[0].message.args[0]
+
     with pytest.raises(RuntimeError) as record:
         x = torch.randn((3, 3, 3, 2), device=tdev)
         y = torch.randn((4, 4, 4, 2), device=tdev)

--- a/kymatio/scattering3d/tests/test_scattering3d.py
+++ b/kymatio/scattering3d/tests/test_scattering3d.py
@@ -31,6 +31,12 @@ def test_FFT3d_central_freq_batch():
         c = y[:,0,0,0].sum()
         assert (c-a).abs().sum()<1e-6
 
+def test_fft3d_error():
+    x = torch.zeros(8, 1)
+    with pytest.raises(TypeError) as record:
+        backend.fft(x)
+    assert "should be complex" in record.value.args[0]
+
 def test_cdgmm3d():
     # Not all backends currently implement the inplace variant
     if backend.NAME == 'torch':

--- a/kymatio/scattering3d/tests/test_scattering3d.py
+++ b/kymatio/scattering3d/tests/test_scattering3d.py
@@ -132,6 +132,12 @@ def test_cdgmm3d():
         backend.cdgmm3d(x, y)
     assert "should be same type" in record.value.args[0]
 
+    if backend.NAME == 'skcuda':
+        x = torch.randn((3, 3, 3, 2), device=torch.device('cpu'))
+        y = torch.randn((3, 3, 3, 2), device=torch.device('cpu'))
+        with pytest.raises(RuntimeError) as record:
+            backend.cdgmm3d(x, y)
+        assert "for cpu tensors" in record.value.args[0]
 
 def test_iscomplex():
     assert backend.iscomplex(torch.zeros(4, 2))


### PR DESCRIPTION
The first part ensures that the skcuda backend emits the same warnings as the torch backend for non-contiguous arrays in `cdgmm`. The second part ensures that these (and other errors) are appropriately tested.

Fixes #339 and #408.