### PR TITLE
DOC Fix capitalization of `User guide`

### DIFF
--- a/doc/source/userguide.rst
+++ b/doc/source/userguide.rst
@@ -1,6 +1,6 @@
 .. _user-guide:
 
-User Guide
+User guide
 **********
 
 


### PR DESCRIPTION
Fixes #406.