### PR TITLE
ENH NumPy 2D Back/Frontend [3b]

### DIFF
--- a/kymatio/frontend/numpy_frontend.py
+++ b/kymatio/frontend/numpy_frontend.py
@@ -1,4 +1,4 @@
-class ScatteringNumPy(object):
+class ScatteringNumPy:
     def __init__(self):
         self.frontend_name = 'numpy'
 

--- a/kymatio/frontend/numpy_frontend.py
+++ b/kymatio/frontend/numpy_frontend.py
@@ -1,6 +1,5 @@
 class ScatteringNumPy(object):
     def __init__(self):
-        super(ScatteringNumPy, self).__init__()
         self.frontend_name = 'numpy'
 
     def scattering(self, x):

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -1,0 +1,194 @@
+# Authors: Edouard Oyallon, Sergey Zagoruyko
+
+import numpy as np
+from collections import namedtuple
+
+BACKEND_NAME = 'numpy'
+
+class Pad(object):
+    def __init__(self, pad_size, input_size, pre_pad=False):
+        """
+            Padding which allows to simultaneously pad in a reflection fashion
+            and map to complex.
+
+            Parameters
+            ----------
+            pad_size : list of 4 integers
+                size of padding to apply.
+            input_size : list of 2 integers
+                size of the original signal
+            pre_pad : boolean
+                if set to true, then there is no padding, one simply converts
+                from real to complex.
+
+        """
+        self.pre_pad = pre_pad
+        self.pad_size = pad_size
+
+    def __call__(self, x):
+        if self.pre_pad:
+            return x
+        else:
+            np_pad = ((self.pad_size[0], self.pad_size[1]), (self.pad_size[2], self.pad_size[3]))
+            batch_shape = x.shape[:-2]
+            signal_shape = x.shape[-2:]
+            x = x.reshape((-1, 1) + signal_shape)
+            output = np.pad(x, ((0,0), (0,0), np_pad[0], np_pad[1]), mode='reflect')
+            output = output.reshape(batch_shape + output.shape[-2:])
+            return output
+
+
+def unpad(in_):
+    """
+        Slices the input tensor at indices between 1::-1
+
+        Parameters
+        ----------
+        in_ : tensor_like
+            input tensor
+
+        Returns
+        -------
+        in_[..., 1:-1, 1:-1]
+
+    """
+    return np.expand_dims(in_[..., 1:-1, 1:-1], -3)
+
+class SubsampleFourier(object):
+    """ Subsampling of a 2D image performed in the Fourier domain.
+
+        Subsampling in the spatial domain amounts to periodization
+        in the Fourier domain, hence the formula.
+
+        Parameters
+        ----------
+        x : tensor_like
+            input tensor with at least 5 dimensions, the last being the real
+             and imaginary parts.
+            Ideally, the last dimension should be a power of 2 to avoid errors.
+        k : int
+            integer such that x is subsampled by 2**k along the spatial variables.
+
+        Returns
+        -------
+        res : tensor_like
+            tensor such that its fourier transform is the Fourier
+            transform of a subsampled version of x, i.e. in
+            FFT^{-1}(res)[u1, u2] = FFT^{-1}(x)[u1 * (2**k), u2 * (2**k)]
+
+    """
+    def __call__(self, x, k):
+        batch_shape = x.shape[:-2]
+        signal_shape = x.shape[-2:]
+
+        x = x.reshape((-1,) + signal_shape)
+        y = x.reshape(-1, k, x.shape[1] // k, k, x.shape[2] // k)
+
+        out = np.zeros_like(y, dtype=x.dtype)
+        out = y.mean(axis=(1, 3))
+
+        return out
+
+
+class Modulus(object):
+    """
+        This class implements a modulus transform for complex numbers.
+
+        Usage
+        -----
+        modulus = Modulus()
+        x_mod = modulus(x)
+
+        Parameters
+        ---------
+        x: input complex tensor.
+
+        Returns
+        -------
+        output: a real tensor equal to the modulus of x.
+
+    """
+    def __call__(self, x):
+        norm = np.abs(x)
+        return norm
+
+
+
+
+def fft(x, direction='C2C', inverse=False):
+    """
+        Interface with torch FFT routines for 2D signals.
+
+        Example
+        -------
+        x = torch.randn(128, 32, 32, 2)
+        x_fft = fft(x, inverse=True)
+
+        Parameters
+        ----------
+        input : tensor
+            complex input for the FFT
+        direction : string
+            'C2R' for complex to real, 'C2C' for complex to complex
+        inverse : bool
+            True for computing the inverse FFT.
+            NB : if direction is equal to 'C2R', then an error is raised.
+
+    """
+    if direction == 'C2R':
+        if not inverse:
+            raise RuntimeError('C2R mode can only be done with an inverse FFT.')
+
+    if direction == 'C2R':
+        output = np.real(np.fft.ifft2(x))*x.shape[-1]*x.shape[-2]
+    elif direction == 'C2C':
+        if inverse:
+            output = np.fft.ifft2(x)*x.shape[-1]*x.shape[-2]
+        else:
+            output = np.fft.fft2(x)
+
+    return output
+
+
+
+
+def cdgmm(A, B, inplace=False):
+    """
+        Complex pointwise multiplication between (batched) tensor A and tensor B.
+
+        Parameters
+        ----------
+        A : tensor
+            A is a complex tensor of size (B, C, M, N, 2)
+        B : tensor
+            B is a complex tensor of size (M, N) or real tensor of (M, N)
+        inplace : boolean, optional
+            if set to True, all the operations are performed inplace
+
+        Returns
+        -------
+        C : tensor
+            output tensor of size (B, C, M, N, 2) such that:
+            C[b, c, m, n, :] = A[b, c, m, n, :] * B[m, n, :]
+
+    """
+    if B.ndim != 2:
+        raise RuntimeError('The dimension of the second input must be 2.')
+
+    if inplace:
+        return np.multiply(A, B, out=A)
+    else:
+        return A * B
+
+def empty_like(x, shape):
+    return np.empty(shape, x.dtype)
+
+backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like'])
+backend.name = 'numpy'
+backend.cdgmm = cdgmm
+backend.modulus = Modulus()
+backend.subsample_fourier = SubsampleFourier()
+backend.fft = fft
+backend.Pad = Pad
+backend.unpad = unpad
+backend.empty_like = empty_like

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -79,13 +79,8 @@ class SubsampleFourier(object):
 
     """
     def __call__(self, x, k):
-        batch_shape = x.shape[:-2]
-        signal_shape = x.shape[-2:]
-
-        x = x.reshape((-1,) + signal_shape)
         y = x.reshape(-1, k, x.shape[1] // k, k, x.shape[2] // k)
 
-        out = np.zeros_like(y, dtype=x.dtype)
         out = y.mean(axis=(1, 3))
 
         return out

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -3,7 +3,9 @@
 import numpy as np
 from collections import namedtuple
 
+
 BACKEND_NAME = 'numpy'
+
 
 class Pad(object):
     def __init__(self, pad_size, input_size, pre_pad=False):
@@ -53,6 +55,7 @@ def unpad(in_):
 
     """
     return np.expand_dims(in_[..., 1:-1, 1:-1], -3)
+
 
 class SubsampleFourier(object):
     """ Subsampling of a 2D image performed in the Fourier domain.
@@ -113,8 +116,6 @@ class Modulus(object):
         return norm
 
 
-
-
 def fft(x, direction='C2C', inverse=False):
     """
         Interface with torch FFT routines for 2D signals.
@@ -140,16 +141,14 @@ def fft(x, direction='C2C', inverse=False):
             raise RuntimeError('C2R mode can only be done with an inverse FFT.')
 
     if direction == 'C2R':
-        output = np.real(np.fft.ifft2(x))*x.shape[-1]*x.shape[-2]
+        output = np.real(np.fft.ifft2(x)) * x.shape[-1] * x.shape[-2]
     elif direction == 'C2C':
         if inverse:
-            output = np.fft.ifft2(x)*x.shape[-1]*x.shape[-2]
+            output = np.fft.ifft2(x) * x.shape[-1] * x.shape[-2]
         else:
             output = np.fft.fft2(x)
 
     return output
-
-
 
 
 def cdgmm(A, B, inplace=False):
@@ -180,8 +179,10 @@ def cdgmm(A, B, inplace=False):
     else:
         return A * B
 
+
 def empty_like(x, shape):
     return np.empty(shape, x.dtype)
+
 
 backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like'])
 backend.name = 'numpy'

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -1,4 +1,4 @@
-# Authors: Edouard Oyallon, Sergey Zagoruyko
+# Authors: Edouard Oyallon, Sergey Zagoruyko, Muawiz Chaudhary
 
 import numpy as np
 from collections import namedtuple

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -7,6 +7,14 @@ from collections import namedtuple
 BACKEND_NAME = 'numpy'
 
 
+def _iscomplex(x):
+    return x.dtype == np.complex64 or x.dtype == np.complex128
+
+
+def _isreal(x):
+    return x.dtype == np.float32 or x.dtype == np.float64
+
+
 class Pad(object):
     def __init__(self, pad_size, input_size, pre_pad=False):
         """
@@ -160,8 +168,18 @@ def cdgmm(A, B, inplace=False):
             C[b, c, m, n, :] = A[b, c, m, n, :] * B[m, n, :]
 
     """
+    if not _iscomplex(A):
+        raise TypeError('The first input must be complex.')
+
     if B.ndim != 2:
         raise RuntimeError('The dimension of the second input must be 2.')
+
+    if not _iscomplex(B) and not _isreal(B):
+        raise TypeError('The second input must be complex or real.')
+
+    if A.shape[-2:] != B.shape[-2:]:
+        raise RuntimeError('The inputs are not compatible for '
+                           'multiplication.')
 
     if inplace:
         return np.multiply(A, B, out=A)

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -32,11 +32,7 @@ class Pad(object):
             return x
         else:
             np_pad = ((self.pad_size[0], self.pad_size[1]), (self.pad_size[2], self.pad_size[3]))
-            batch_shape = x.shape[:-2]
-            signal_shape = x.shape[-2:]
-            x = x.reshape((-1, 1) + signal_shape)
-            output = np.pad(x, ((0,0), (0,0), np_pad[0], np_pad[1]), mode='reflect')
-            output = output.reshape(batch_shape + output.shape[-2:])
+            output = np.pad(x, ((0,0), np_pad[0], np_pad[1]), mode='reflect')
             return output
 
 

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -66,18 +66,16 @@ class SubsampleFourier(object):
         Parameters
         ----------
         x : tensor_like
-            input tensor with at least 5 dimensions, the last being the real
-             and imaginary parts.
-            Ideally, the last dimension should be a power of 2 to avoid errors.
+            input tensor with at least three dimensions.
         k : int
-            integer such that x is subsampled by 2**k along the spatial variables.
+            integer such that x is subsampled by k along the spatial variables.
 
         Returns
         -------
         res : tensor_like
             tensor such that its fourier transform is the Fourier
             transform of a subsampled version of x, i.e. in
-            FFT^{-1}(res)[u1, u2] = FFT^{-1}(x)[u1 * (2**k), u2 * (2**k)]
+            F^{-1}(res)[u1, u2] = F^{-1}(x)[u1 * k, u2 * k]
 
     """
     def __call__(self, x, k):

--- a/kymatio/scattering2d/core/scattering2d.py
+++ b/kymatio/scattering2d/core/scattering2d.py
@@ -28,7 +28,6 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order):
     S_0 = unpad(S_0)
 
     output_shape = (x.shape[0], output_size) + S_0.shape[-2:]
-    print(output_shape)
 
     S = empty_like(x, output_shape)
 

--- a/kymatio/scattering2d/frontend/__init__.py
+++ b/kymatio/scattering2d/frontend/__init__.py
@@ -5,12 +5,14 @@ import importlib
 
 class Scattering2D(object):
     def __init__(self, *args, **kwargs):
+        frontend_suffixes = {'torch' : 'Torch', 'numpy' : 'NumPy', 'tensorflow'
+                : 'TensorFlow'}
         if 'frontend' not in kwargs:
             warnings.warn("Torch frontend is currently the default, but NumPy will become the default in the next"
                           " version.", PendingDeprecationWarning)
             frontend = 'torch'
         else:
-            frontend = kwargs['frontend']
+            frontend = kwargs['frontend'].lower()
             kwargs.pop('frontend')
 
         try:
@@ -18,9 +20,10 @@ class Scattering2D(object):
 
             # Create frontend-specific class name by inserting frontend name
             # after `Scattering`.
+            frontend = frontend_suffixes[frontend]
+
             class_name = self.__class__.__name__
-            class_name = (class_name[:-2] + frontend.capitalize()
-                          + class_name[-2:])
+            class_name = (class_name[:-2] + frontend + class_name[-2:])
 
             self.__class__ = getattr(module, class_name)
             self.__init__(*args, **kwargs)

--- a/kymatio/scattering2d/frontend/numpy_frontend.py
+++ b/kymatio/scattering2d/frontend/numpy_frontend.py
@@ -1,0 +1,45 @@
+from ...frontend.numpy_frontend import ScatteringNumPy
+from kymatio.scattering2d.core.scattering2d import scattering2d
+from .base_frontend import ScatteringBase2D
+from ..utils import compute_padding
+from ..filter_bank import filter_bank
+import numpy as np
+
+class ScatteringNumPy2D(ScatteringNumPy, ScatteringBase2D):
+    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False, backend='numpy'):
+        ScatteringNumPy.__init__(self)
+        ScatteringBase2D.__init__(self, J, shape, L, max_order, pre_pad, backend)
+        ScatteringBase2D._instantiate_backend(self, 'kymatio.scattering2d.backend.')
+        ScatteringBase2D.build(self)
+        ScatteringBase2D.create_filters(self)
+
+    def scattering(self, input):
+        if not type(input) is np.ndarray:
+            raise TypeError('The input should be a NumPy array.')
+
+        if len(input.shape) < 2:
+            raise RuntimeError('Input array must have at least two dimensions.')
+
+        #if not input.is_contiguous():
+        #    raise RuntimeError('Tensor must be contiguous.')
+
+        if (input.shape[-1] != self.N or input.shape[-2] != self.M) and not self.pre_pad:
+            raise RuntimeError('NumPy array must be of spatial size (%i,%i).' % (self.M, self.N))
+
+        if (input.shape[-1] != self.N_padded or input.shape[-2] != self.M_padded) and self.pre_pad:
+            raise RuntimeError('Padded array must be of spatial size (%i,%i).' % (self.M_padded, self.N_padded))
+
+        batch_shape = input.shape[:-2]
+        signal_shape = input.shape[-2:]
+
+        input = input.reshape((-1,) + signal_shape)
+
+        S = scattering2d(input, self.pad, self.unpad, self.backend, self.J, self.L, self.phi, self.psi, self.max_order)
+
+        scattering_shape = S.shape[-3:]
+
+        S = S.reshape(batch_shape + scattering_shape)
+
+        return S
+
+__all__ = ['ScatteringNumPy2D']

--- a/kymatio/scattering2d/frontend/numpy_frontend.py
+++ b/kymatio/scattering2d/frontend/numpy_frontend.py
@@ -20,9 +20,6 @@ class ScatteringNumPy2D(ScatteringNumPy, ScatteringBase2D):
         if len(input.shape) < 2:
             raise RuntimeError('Input array must have at least two dimensions.')
 
-        #if not input.is_contiguous():
-        #    raise RuntimeError('Tensor must be contiguous.')
-
         if (input.shape[-1] != self.N or input.shape[-2] != self.M) and not self.pre_pad:
             raise RuntimeError('NumPy array must be of spatial size (%i,%i).' % (self.M, self.N))
 

--- a/kymatio/scattering2d/frontend/numpy_frontend.py
+++ b/kymatio/scattering2d/frontend/numpy_frontend.py
@@ -1,8 +1,6 @@
 from ...frontend.numpy_frontend import ScatteringNumPy
 from kymatio.scattering2d.core.scattering2d import scattering2d
 from .base_frontend import ScatteringBase2D
-from ..utils import compute_padding
-from ..filter_bank import filter_bank
 import numpy as np
 
 class ScatteringNumPy2D(ScatteringNumPy, ScatteringBase2D):

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -1,0 +1,70 @@
+import os
+import io
+import numpy as np
+from kymatio.scattering2d import Scattering2D
+import torch
+from collections import namedtuple
+import pytest
+
+class TestScattering2DNumpy:
+    def reorder_coefficients_from_interleaved(self, J, L):
+        # helper function to obtain positions of order0, order1, order2 from interleaved
+        order0, order1, order2 = [], [], []
+        n_order0, n_order1, n_order2 = 1, J * L, L ** 2 * J * (J - 1) // 2
+        n = 0
+        order0.append(n)
+        for j1 in range(J):
+            for l1 in range(L):
+                n += 1
+                order1.append(n)
+                for j2 in range(j1 + 1, J):
+                    for l2 in range(L):
+                        n += 1
+                        order2.append(n)
+        assert len(order0) == n_order0
+        assert len(order1) == n_order1
+        assert len(order2) == n_order2
+        return order0, order1, order2
+
+    def test_Scattering2D(self):
+        test_data_dir = os.path.dirname(__file__)
+        data = None
+        with open(os.path.join(test_data_dir, 'test_data_2d.pt'), 'rb') as f:
+            buffer = io.BytesIO(f.read())
+            data = torch.load(buffer)
+
+        x = data['x'].numpy()
+        S = data['Sx'].numpy()
+        J = data['J']
+
+        # we need to reorder S from interleaved (how it's saved) to o0, o1, o2
+        # (which is how it's now computed)
+
+        o0, o1, o2 = self.reorder_coefficients_from_interleaved(J, 8)
+        reorder = np.concatenate((o0, o1, o2))
+        S = S[..., reorder, :, :]
+
+        pre_pad = data['pre_pad']
+
+        M = x.shape[2]
+        N = x.shape[3]
+
+        # Then, let's check when using pure pytorch code
+        scattering = Scattering2D(J, shape=(M, N), pre_pad=pre_pad, frontend='numpy')
+
+        x = x
+        S = S
+        Sg = scattering(x)
+        assert np.allclose(Sg, S)
+
+    def test_inputs(self):
+        fake_backend = namedtuple('backend', ['name',])
+        fake_backend.name = 'fake'
+
+        with pytest.raises(ImportError) as ve:
+            scattering = Scattering2D(2, shape=(10, 10), frontend='numpy', backend=fake_backend)
+        assert 'not supported' in ve.value.args[0]
+
+        with pytest.raises(RuntimeError) as ve:
+            scattering = Scattering2D(10, shape=(10, 10), frontend='numpy')
+        assert 'smallest dimension' in ve.value.args[0]

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -219,6 +219,37 @@ class TestScattering2DNumpy:
         S1x = scattering(x)
         assert np.allclose(S1x, S[..., 0:len(o0 + o1), :, :])
 
+    @pytest.mark.parametrize('backend', backends)
+    def test_batch_shape_agnostic(self, backend):
+        J = 3
+        L = 8
+        shape = (32, 32)
+
+        shape_ds = tuple(n // (2 ** J) for n in shape)
+
+        S = Scattering2D(J, shape, L, backend=backend, frontend='numpy')
+
+        x = np.zeros(shape)
+
+        Sx = S(x)
+
+        assert len(Sx.shape) == 3
+        assert Sx.shape[-2:] == shape_ds
+
+        n_coeffs = Sx.shape[-3]
+
+        test_shapes = ((1,) + shape, (2,) + shape, (2, 2) + shape,
+                       (2, 2, 2) + shape)
+
+        for test_shape in test_shapes:
+            x = np.zeros(test_shape)
+
+            Sx = S(x)
+
+            assert len(Sx.shape) == len(test_shape) + 1
+            assert Sx.shape[-2:] == shape_ds
+            assert Sx.shape[-3] == n_coeffs
+            assert Sx.shape[:-3] == test_shape[:-2]
 
     @pytest.mark.parametrize('backend', backends)
     def test_scattering2d_errors(self, backend):

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -19,15 +19,16 @@ class TestPad:
         pad = backend.Pad((2, 2, 2, 2), (4, 4), pre_pad=False)
 
         x = np.random.randn(4, 4) + 1J * np.random.randn(4, 4)
+        x = x[np.newaxis, ...]
 
         z = pad(x)
 
-        assert z.shape == (8, 8)
-        assert z[2, 2] == x[0, 0]
-        assert z[1, 0] == x[1, 2]
-        assert z[1, 1] == x[1, 1]
-        assert z[1, 2] == x[1, 0]
-        assert z[1, 3] == x[1, 1]
+        assert z.shape == (1, 8, 8)
+        assert z[0, 2, 2] == x[0, 0, 0]
+        assert z[0, 1, 0] == x[0, 1, 2]
+        assert z[0, 1, 1] == x[0, 1, 1]
+        assert z[0, 1, 2] == x[0, 1, 0]
+        assert z[0, 1, 3] == x[0, 1, 1]
 
         pad = backend.Pad((2, 2, 2, 2), (4, 4), pre_pad=True)
 

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -112,10 +112,25 @@ class TestCDGMM:
 
     @pytest.mark.parametrize('backend', backends)
     def test_cdgmm_exceptions(self, backend):
+        with pytest.raises(TypeError) as record:
+            backend.cdgmm(np.empty((3, 4, 5)).astype(np.float64),
+                          np.empty((4, 5)).astype(np.complex128))
+        assert 'first input must be complex' in record.value.args[0]
+
         with pytest.raises(RuntimeError) as record:
             backend.cdgmm(np.empty((3, 4, 5)).astype(np.complex128),
                           np.empty((3, 4, 5)).astype(np.complex128))
         assert 'second input must be 2' in record.value.args[0]
+
+        with pytest.raises(TypeError) as record:
+            backend.cdgmm(np.empty((3, 4, 5)).astype(np.complex128),
+                          np.empty((4, 5)).astype(np.int64))
+        assert 'second input must be complex or real' in record.value.args[0]
+
+        with pytest.raises(RuntimeError) as record:
+            backend.cdgmm(np.empty((3, 4, 5)).astype(np.complex128),
+                          np.empty((4, 6)).astype(np.complex128))
+        assert 'not compatible for multiplication' in record.value.args[0]
 
 
 class TestFFT:

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -6,6 +6,7 @@ import torch
 from collections import namedtuple
 import pytest
 
+
 class TestScattering2DNumpy:
     def reorder_coefficients_from_interleaved(self, J, L):
         # helper function to obtain positions of order0, order1, order2 from interleaved
@@ -25,6 +26,7 @@ class TestScattering2DNumpy:
         assert len(order1) == n_order1
         assert len(order2) == n_order2
         return order0, order1, order2
+
 
     def test_Scattering2D(self):
         test_data_dir = os.path.dirname(__file__)
@@ -56,6 +58,7 @@ class TestScattering2DNumpy:
         S = S
         Sg = scattering(x)
         assert np.allclose(Sg, S)
+
 
     def test_inputs(self):
         fake_backend = namedtuple('backend', ['name',])

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -59,6 +59,32 @@ class TestScattering2DNumpy:
         assert np.allclose(Sg, S)
 
 
+    def test_scattering2d_errors(self):
+        S = Scattering2D(3, (32, 32), frontend='numpy')
+
+        with pytest.raises(TypeError) as record:
+            S(None)
+        assert 'input should be' in record.value.args[0]
+
+        x = np.random.randn(32)
+
+        with pytest.raises(RuntimeError) as record:
+            S(x)
+        assert 'have at least two dimensions' in record.value.args[0]
+
+        x = np.random.randn(31, 31)
+
+        with pytest.raises(RuntimeError) as record:
+            S(x)
+        assert 'NumPy array must be of spatial size' in record.value.args[0]
+
+        S = Scattering2D(3, (32, 32), pre_pad=True, frontend='numpy')
+
+        with pytest.raises(RuntimeError) as record:
+            S(x)
+        assert 'Padded array must be of spatial size' in record.value.args[0]
+
+
     def test_inputs(self):
         fake_backend = namedtuple('backend', ['name',])
         fake_backend.name = 'fake'

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -51,7 +51,6 @@ class TestScattering2DNumpy:
         M = x.shape[2]
         N = x.shape[3]
 
-        # Then, let's check when using pure pytorch code
         scattering = Scattering2D(J, shape=(M, N), pre_pad=pre_pad, frontend='numpy')
 
         x = x

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -113,7 +113,8 @@ class TestCDGMM:
     @pytest.mark.parametrize('backend', backends)
     def test_cdgmm_exceptions(self, backend):
         with pytest.raises(RuntimeError) as record:
-            backend.cdgmm(np.empty((3, 4, 5)), np.empty((3, 4, 5)))
+            backend.cdgmm(np.empty((3, 4, 5)).astype(np.complex128),
+                          np.empty((3, 4, 5)).astype(np.complex128))
         assert 'second input must be 2' in record.value.args[0]
 
 

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -153,7 +153,7 @@ class TestFFT:
 
         z = backend.fft(x, direction='C2R', inverse=True)
 
-        assert z.dtype == np.float64
+        assert not np.iscomplexobj(z)
         assert np.allclose(np.real(y), z)
 
 

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -7,6 +7,12 @@ from collections import namedtuple
 import pytest
 
 
+backends = []
+
+from kymatio.scattering2d.backend.numpy_backend import backend
+backends.append(backend)
+
+
 class TestScattering2DNumpy:
     def reorder_coefficients_from_interleaved(self, J, L):
         # helper function to obtain positions of order0, order1, order2 from interleaved
@@ -28,7 +34,8 @@ class TestScattering2DNumpy:
         return order0, order1, order2
 
 
-    def test_Scattering2D(self):
+    @pytest.mark.parametrize('backend', backends)
+    def test_Scattering2D(self, backend):
         test_data_dir = os.path.dirname(__file__)
         data = None
         with open(os.path.join(test_data_dir, 'test_data_2d.pt'), 'rb') as f:
@@ -51,7 +58,8 @@ class TestScattering2DNumpy:
         M = x.shape[2]
         N = x.shape[3]
 
-        scattering = Scattering2D(J, shape=(M, N), pre_pad=pre_pad, frontend='numpy')
+        scattering = Scattering2D(J, shape=(M, N), pre_pad=pre_pad,
+                                  frontend='numpy', backend=backend)
 
         x = x
         S = S
@@ -59,8 +67,9 @@ class TestScattering2DNumpy:
         assert np.allclose(Sg, S)
 
 
-    def test_scattering2d_errors(self):
-        S = Scattering2D(3, (32, 32), frontend='numpy')
+    @pytest.mark.parametrize('backend', backends)
+    def test_scattering2d_errors(self, backend):
+        S = Scattering2D(3, (32, 32), frontend='numpy', backend=backend)
 
         with pytest.raises(TypeError) as record:
             S(None)
@@ -78,7 +87,8 @@ class TestScattering2DNumpy:
             S(x)
         assert 'NumPy array must be of spatial size' in record.value.args[0]
 
-        S = Scattering2D(3, (32, 32), pre_pad=True, frontend='numpy')
+        S = Scattering2D(3, (32, 32), pre_pad=True, frontend='numpy',
+                         backend=backend)
 
         with pytest.raises(RuntimeError) as record:
             S(x)


### PR DESCRIPTION
This is the PR for the NumPy back/frontends. This is up next for review, then TF. 

I tried to make some fixes, however the tests do not run. The current error I am getting is `E       TypeError: __init__() missing 2 required positional arguments: 'J' and 'shape'`, and this is occurring in the numpy_frontend abstract class. I'm not sure why its giving this error, when the torch frontend is initalized in the same way and there is no difference between the two. Perhaps this difference is due to the numpy abstract frontend subclassing off of object?

