### PR TITLE
WIP Simplify and extend 2D torch tests

### DIFF
--- a/kymatio/scattering2d/backend/torch_backend.py
+++ b/kymatio/scattering2d/backend/torch_backend.py
@@ -129,6 +129,9 @@ class SubsampleFourier(object):
 
     """
     def __call__(self, x, k):
+        if not _iscomplex(x):
+            raise TypeError('The x should be complex.')
+
         if not x.is_contiguous():
             raise RuntimeError('Input should be contiguous.')
         batch_shape = x.shape[:-3]
@@ -166,6 +169,9 @@ class Modulus(object):
     def __call__(self, x):
         if not x.is_contiguous():
             raise RuntimeError('Input should be contiguous.')
+
+        if not _iscomplex(x):
+            raise TypeError('The inputs should be complex.')
 
         norm = torch.zeros_like(x)
         norm[...,0] = (x[...,0]*x[...,0] +

--- a/kymatio/scattering2d/tests/test_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_scattering2d.py
@@ -8,11 +8,9 @@ from kymatio.scattering2d import Scattering2D
 from kymatio.scattering2d import backend
 
 
+devices = ['cpu']
 if torch.cuda.is_available():
-    devices = ['cuda', 'cpu']
-else:
-    devices = ['cpu']
-
+    devices.append('cuda')
 
 def reorder_coefficients_from_interleaved(J, L):
     # helper function to obtain positions of order0, order1, order2 from interleaved

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -238,6 +238,26 @@ class TestCDGMM:
                 with pytest.raises(TypeError) as exc:
                     backend.cdgmm(torch.empty(3, 4, 5, 2), torch.empty(4, 5, 1).cuda())
                 assert "input must be on gpu" in exc.value.args[0].lower()
+                with pytest.raises(TypeError) as exc:
+                    backend.cdgmm(torch.empty(3, 4, 5, 2).cuda(), torch.empty(4, 5, 1))
+                assert "input must be on cpu" in exc.value.args[0].lower()
+
+
+    @pytest.mark.parametrize('backend_device', backends_devices)
+    def test_contiguity_exception(self, backend_device):
+        backend, device = backend_device
+
+        x = torch.empty(3, 4, 5, 3).to(device)[..., :2]
+        y = torch.empty(4, 5, 3).to(device)[..., :2]
+
+        with pytest.raises(RuntimeError) as exc:
+            backend.cdgmm(x.contiguous(), y)
+        assert 'be contiguous' in exc.value.args[0]
+
+        with pytest.raises(RuntimeError) as exc:
+            backend.cdgmm(x, y.contiguous())
+        assert 'be contiguous' in exc.value.args[0]
+
 
 class TestFFT:
     @pytest.mark.parametrize('backend', backends)

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -258,6 +258,23 @@ class TestCDGMM:
             backend.cdgmm(x, y.contiguous())
         assert 'be contiguous' in exc.value.args[0]
 
+    @pytest.mark.parametrize('backend_device', backends_devices)
+    def test_device_mismatch(self, backend_device):
+        backend, device = backend_device
+
+        if device == 'cpu':
+            return
+
+        if torch.cuda.device_count() < 2:
+            return
+
+        x = torch.empty(3, 4, 5, 2).to('cuda:0')
+        y = torch.empty(4, 5, 1).to('cuda:1')
+
+        with pytest.raises(TypeError) as exc:
+            backend.cdgmm(x, y)
+        assert 'must be on the same GPU' in exc.value.args[0]
+
 
 class TestFFT:
     @pytest.mark.parametrize('backend', backends)

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -26,7 +26,7 @@ try:
         if 'cuda' in devices:
             backends_devices.append((backend, 'cuda'))
 except:
-    pass
+    Warning('torch_skcuda backend not available.')
 
 
 from kymatio.scattering2d.backend.torch_backend import backend

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -267,6 +267,14 @@ class TestScatteringTorch2D:
         Sg = scattering(x)
         assert torch.allclose(Sg, S)
 
+        scattering = Scattering2D(J, shape=(M, N), pre_pad=pre_pad,
+                                  max_order=1, frontend='torch',
+                                  backend=backend)
+        scattering.to(device)
+
+        S1x = scattering(x)
+        assert torch.allclose(S1x, S[..., 0:len(o0 + o1), :, :])
+
 
     @pytest.mark.parametrize('backend', backends)
     def test_gpu_only(self, backend):

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -96,6 +96,11 @@ class TestModulus:
         v = v.squeeze()
         assert torch.allclose(u, v)
 
+        y = x[..., 0].contiguous()
+        with pytest.raises(TypeError) as record:
+            modulus(y)
+        assert 'should be complex' in record.value.args[0]
+
         y = x[::2, ::2]
         with pytest.raises(RuntimeError) as record:
             modulus(y)
@@ -132,6 +137,11 @@ class TestSubsampleFourier:
 
         z = subsample_fourier(x, k=16)
         assert torch.allclose(y, z)
+
+        y = x[..., 0]
+        with pytest.raises(TypeError) as record:
+            subsample_fourier(y, k=16)
+        assert 'should be complex' in record.value.args[0]
 
         y = x[::2, ::2]
         with pytest.raises(RuntimeError) as record:

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -7,7 +7,15 @@ import pytest
 from kymatio.scattering2d import Scattering2D
 from torch.autograd import gradcheck
 from collections import namedtuple
+
+
+if torch.cuda.is_available():
+    devices = ['cuda', 'cpu']
+else:
+    devices = ['cpu']
+
 backends = []
+backends_devices = []
 
 try:
     if torch.cuda.is_available():
@@ -15,17 +23,17 @@ try:
         import cupy
         from kymatio.scattering2d.backend.torch_skcuda_backend import backend
         backends.append(backend)
+        if 'cuda' in devices:
+            backends_devices.append((backend, 'cuda'))
 except:
     pass
 
 
 from kymatio.scattering2d.backend.torch_backend import backend
 backends.append(backend)
-
-if torch.cuda.is_available():
-    devices = ['cuda', 'cpu']
-else:
-    devices = ['cpu']
+backends_devices.append((backend, 'cpu'))
+if 'cuda' in devices:
+    backends_devices.append((backend, 'cuda'))
 
 
 # Checked the modulus

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -9,10 +9,10 @@ from torch.autograd import gradcheck
 from collections import namedtuple
 
 
+devices = ['cpu']
 if torch.cuda.is_available():
-    devices = ['cuda', 'cpu']
-else:
-    devices = ['cpu']
+    devices.append('cuda')
+
 
 backends = []
 backends_devices = []

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -36,6 +36,50 @@ if 'cuda' in devices:
     backends_devices.append((backend, 'cuda'))
 
 
+class TestPad:
+    @pytest.mark.parametrize('backend_device', backends_devices)
+    def test_Pad(self, backend_device):
+        backend, device = backend_device
+
+        pad = backend.Pad((2, 2, 2, 2), (4, 4), pre_pad=False)
+
+        x = torch.randn(1, 4, 4)
+        x = x.to(device)
+
+        z = pad(x)
+
+        assert z.shape == (1, 8, 8, 2)
+        assert torch.allclose(z[0, 2, 2, 0], x[0, 0, 0])
+        assert torch.allclose(z[0, 1, 0, 0], x[0, 1, 2])
+        assert torch.allclose(z[0, 1, 1, 0], x[0, 1, 1])
+        assert torch.allclose(z[0, 1, 2, 0], x[0, 1, 0])
+        assert torch.allclose(z[0, 1, 3, 0], x[0, 1, 1])
+        assert torch.allclose(z[..., 1], torch.zeros_like(z[..., 1]))
+
+        pad = backend.Pad((2, 2, 2, 2), (4, 4), pre_pad=True)
+
+        x = torch.randn(1, 8, 8)
+        x = x.to(device)
+
+        z = pad(x)
+
+        assert torch.allclose(z[..., 0], x)
+        assert torch.allclose(z[..., 1], torch.zeros_like(z[..., 1]))
+
+    @pytest.mark.parametrize('backend_device', backends_devices)
+    def test_unpad(self, backend_device):
+        backend, device = backend_device
+
+        x = torch.randn(4, 4)
+        x = x.to(device)
+
+        y = backend.unpad(x)
+
+        assert y.shape == (1, 2, 2)
+        assert torch.allclose(y[0, 0, 0], x[1, 1])
+        assert torch.allclose(y[0, 0, 1], x[1, 2])
+
+
 # Checked the modulus
 class TestModulus:
     @pytest.mark.parametrize("backend_device", backends_devices)


### PR DESCRIPTION
We reparametrize the tests using backend–device tuples, extend tests to increase coverage, and make some smaller cosmetic changes. Ideally, this should simplify writing the tests for the TF frontend.