### PR TITLE
REF Remove calls to `unsqeeze` and `expand_dims`

### DIFF
--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -58,7 +58,7 @@ def unpad(in_):
         in_[..., 1:-1, 1:-1]
 
     """
-    return np.expand_dims(in_[..., 1:-1, 1:-1], -3)
+    return in_[..., 1:-1, 1:-1]
 
 
 class SubsampleFourier(object):

--- a/kymatio/scattering2d/backend/torch_backend.py
+++ b/kymatio/scattering2d/backend/torch_backend.py
@@ -104,7 +104,7 @@ def unpad(in_):
             Output tensor.  Unpadded input.
 
     """
-    return torch.unsqueeze(in_[..., 1:-1, 1:-1], -3)
+    return in_[..., 1:-1, 1:-1]
 
 class SubsampleFourier(object):
     """Subsampling of a 2D image performed in the Fourier domain

--- a/kymatio/scattering2d/core/scattering2d.py
+++ b/kymatio/scattering2d/core/scattering2d.py
@@ -31,7 +31,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order):
 
     S = empty_like(x, output_shape)
 
-    S[..., 0, :, :] = S_0.squeeze(-3)
+    S[..., 0, :, :] = S_0
     n_order1 = 1
     n_order2 = 1 + order1_size
 
@@ -51,7 +51,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order):
         S_1_r = fft(S_1_c, 'C2R', inverse=True)
         S_1_r = unpad(S_1_r)
 
-        S[..., n_order1, :, :] = S_1_r.squeeze(-3)
+        S[..., n_order1, :, :] = S_1_r
         n_order1 += 1
 
         if max_order < 2:
@@ -73,7 +73,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order):
             S_2_r = fft(S_2_c, 'C2R', inverse=True)
             S_2_r = unpad(S_2_r)
 
-            S[..., n_order2, :, :] = S_2_r.squeeze(-3)
+            S[..., n_order2, :, :] = S_2_r
             n_order2 += 1
 
     return S

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -44,9 +44,9 @@ class TestPad:
 
         y = backend.unpad(x)
 
-        assert y.shape == (1, 2, 2)
-        assert y[0, 0, 0] == x[1, 1]
-        assert y[0, 0, 1] == x[1, 2]
+        assert y.shape == (2, 2)
+        assert y[0, 0] == x[1, 1]
+        assert y[0, 1] == x[1, 2]
 
 
 class TestModulus:

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -75,9 +75,9 @@ class TestPad:
 
         y = backend.unpad(x)
 
-        assert y.shape == (1, 2, 2)
-        assert torch.allclose(y[0, 0, 0], x[1, 1])
-        assert torch.allclose(y[0, 0, 1], x[1, 2])
+        assert y.shape == (2, 2)
+        assert torch.allclose(y[0, 0], x[1, 1])
+        assert torch.allclose(y[0, 1], x[1, 2])
 
 
 # Checked the modulus


### PR DESCRIPTION
Fixes #463. To be merged before the TF frontend–backend, which is then to be rebased on top of this to avoid dealing with `squeeze`.