### PR TITLE
REF Reintroduce lists of coefficients in 2D core

### DIFF
--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -191,7 +191,11 @@ def empty_like(x, shape):
     return np.empty(shape, x.dtype)
 
 
-backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like'])
+def concatenate(arrays):
+    return np.stack(arrays, axis=-3)
+
+
+backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like', 'concatenate'])
 backend.name = 'numpy'
 backend.cdgmm = cdgmm
 backend.modulus = Modulus()
@@ -200,3 +204,4 @@ backend.fft = fft
 backend.Pad = Pad
 backend.unpad = unpad
 backend.empty_like = empty_like
+backend.concatenate = concatenate

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -187,15 +187,11 @@ def cdgmm(A, B, inplace=False):
         return A * B
 
 
-def empty_like(x, shape):
-    return np.empty(shape, x.dtype)
-
-
 def concatenate(arrays):
     return np.stack(arrays, axis=-3)
 
 
-backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like', 'concatenate'])
+backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'concatenate'])
 backend.name = 'numpy'
 backend.cdgmm = cdgmm
 backend.modulus = Modulus()
@@ -203,5 +199,4 @@ backend.subsample_fourier = SubsampleFourier()
 backend.fft = fft
 backend.Pad = Pad
 backend.unpad = unpad
-backend.empty_like = empty_like
 backend.concatenate = concatenate

--- a/kymatio/scattering2d/backend/torch_backend.py
+++ b/kymatio/scattering2d/backend/torch_backend.py
@@ -321,7 +321,12 @@ def empty_like(x, shape):
     # something more standard.
     return x.new(*shape)
 
-backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like'])
+
+def concatenate(arrays):
+    return torch.stack(arrays, axis=-3)
+
+
+backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like', 'concatenate'])
 backend.name = 'torch'
 backend.cdgmm = cdgmm
 backend.modulus = Modulus()
@@ -330,3 +335,4 @@ backend.fft = fft
 backend.Pad = Pad
 backend.unpad = unpad
 backend.empty_like = empty_like
+backend.concatenate = concatenate

--- a/kymatio/scattering2d/backend/torch_backend.py
+++ b/kymatio/scattering2d/backend/torch_backend.py
@@ -316,17 +316,12 @@ def cdgmm(A, B, inplace=False):
 
         return C if not inplace else A.copy_(C)
 
-def empty_like(x, shape):
-    # Note: This function is not documented, so it might be good to switch to
-    # something more standard.
-    return x.new(*shape)
-
 
 def concatenate(arrays):
     return torch.stack(arrays, axis=-3)
 
 
-backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like', 'concatenate'])
+backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'concatenate'])
 backend.name = 'torch'
 backend.cdgmm = cdgmm
 backend.modulus = Modulus()
@@ -334,5 +329,4 @@ backend.subsample_fourier = SubsampleFourier()
 backend.fft = fft
 backend.Pad = Pad
 backend.unpad = unpad
-backend.empty_like = empty_like
 backend.concatenate = concatenate

--- a/kymatio/scattering2d/backend/torch_skcuda_backend.py
+++ b/kymatio/scattering2d/backend/torch_skcuda_backend.py
@@ -265,10 +265,9 @@ def cdgmm(A, B, inplace=False):
 from .torch_backend import unpad
 from .torch_backend import Pad
 from .torch_backend import fft
-from .torch_backend import empty_like
 from .torch_backend import concatenate
 
-backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like', 'concatenate'])
+backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'concatenate'])
 backend.name = 'torch_skcuda'
 backend.cdgmm = cdgmm
 backend.modulus = Modulus()
@@ -276,5 +275,4 @@ backend.subsample_fourier = SubsampleFourier()
 backend.fft = fft
 backend.Pad = Pad
 backend.unpad = unpad
-backend.empty_like = empty_like
 backend.concatenate = concatenate

--- a/kymatio/scattering2d/backend/torch_skcuda_backend.py
+++ b/kymatio/scattering2d/backend/torch_skcuda_backend.py
@@ -266,8 +266,9 @@ from .torch_backend import unpad
 from .torch_backend import Pad
 from .torch_backend import fft
 from .torch_backend import empty_like
+from .torch_backend import concatenate
 
-backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like'])
+backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'empty_like', 'concatenate'])
 backend.name = 'torch_skcuda'
 backend.cdgmm = cdgmm
 backend.modulus = Modulus()
@@ -276,3 +277,4 @@ backend.fft = fft
 backend.Pad = Pad
 backend.unpad = unpad
 backend.empty_like = empty_like
+backend.concatenate = concatenate

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -166,14 +166,7 @@ class TestFFT:
 
 
 class TestBackendUtils:
-    @pytest.mark.parametrize('backend', backends)
-    def test_empty_like(self, backend):
-        x = np.random.randn(2, 2) + 1J * np.random.randn(2, 2)
-        y = backend.empty_like(x, (3, 3))
-
-        assert y.shape == (3, 3)
-        assert y.dtype == x.dtype
-
+    pass
 
 class TestScattering2DNumpy:
     def reorder_coefficients_from_interleaved(self, J, L):

--- a/kymatio/scattering2d/tests/test_numpy_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_numpy_scattering2d.py
@@ -166,7 +166,19 @@ class TestFFT:
 
 
 class TestBackendUtils:
-    pass
+    @pytest.mark.parametrize('backend', backends)
+    def test_concatenate(self, backend):
+        x = np.random.randn(3, 6, 6) + 1J * np.random.randn(3, 6, 6)
+        y = np.random.randn(3, 6, 6) + 1J * np.random.randn(3, 6, 6)
+        z = np.random.randn(3, 6, 6) + 1J * np.random.randn(3, 6, 6)
+
+        w = backend.concatenate((x, y, z))
+
+        assert w.shape == (x.shape[0],) + (3,) + (x.shape[-2:])
+        assert np.allclose(w[:, 0, ...], x)
+        assert np.allclose(w[:, 1, ...], y)
+        assert np.allclose(w[:, 2, ...], z)
+
 
 class TestScattering2DNumpy:
     def reorder_coefficients_from_interleaved(self, J, L):

--- a/kymatio/scattering2d/tests/test_torch_scattering2d.py
+++ b/kymatio/scattering2d/tests/test_torch_scattering2d.py
@@ -346,6 +346,21 @@ class TestFFT:
         assert 'must be contiguous' in record.value.args[0]
 
 
+class TestBackendUtils:
+    @pytest.mark.parametrize('backend', backends)
+    def test_concatenate(self, backend):
+        x = torch.randn(3, 6, 6)
+        y = torch.randn(3, 6, 6)
+        z = torch.randn(3, 6, 6)
+
+        w = backend.concatenate((x, y, z))
+
+        assert w.shape == (x.shape[0],) + (3,) + (x.shape[-2:])
+        assert np.allclose(w[:, 0, ...], x)
+        assert np.allclose(w[:, 1, ...], y)
+        assert np.allclose(w[:, 2, ...], z)
+
+
 class TestScatteringTorch2D:
     def reorder_coefficients_from_interleaved(self, J, L):
         # helper function to obtain positions of order0, order1, order2


### PR DESCRIPTION
This will simplify the TF frontend, since TF doesn't allow item assignment in `Tensor`s. As a result, we must construct list of `Tensor`s beforehand and concatenate them at the end. This implementation is slightly less efficient in NP and Torch, but seems to be the most straightforward way of implementing it in TF.