### PR TITLE
set version to 0.2.a0

### DIFF
--- a/kymatio/version.py
+++ b/kymatio/version.py
@@ -1,3 +1,3 @@
 short_version = '0.2'
-version = '0.2.0-dev'
+version = '0.2.a0'
 


### PR DESCRIPTION
follows PEP 440 formatting

```
# PEP0440 compatible formatted version, see:
# https://www.python.org/dev/peps/pep-0440/
#
# Generic release markers:
#   X.Y
#   X.Y.Z   # For bugfix releases
#
# Admissible pre-release markers:
#   X.YaN   # Alpha release
#   X.YbN   # Beta release
#   X.YrcN  # Release Candidate
#   X.Y     # Final release
#
# Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
# 'X.Y.dev0' is the canonical version of 'X.Y.dev'
#
```

once this gets merged i will make a PR on master to advertise