### PR TITLE
MAINT no longer pass unknown globals and locals

### DIFF
--- a/kymatio/scattering2d/frontend/__init__.py
+++ b/kymatio/scattering2d/frontend/__init__.py
@@ -16,7 +16,7 @@ class Scattering2D(object):
             kwargs.pop('frontend')
 
         try:
-            module = importlib.__import__(frontend + '_frontend', globals(), locals(), [], 1)
+            module = importlib.import_module('kymatio.scattering2d.frontend.' + frontend + '_frontend')
 
             # Create frontend-specific class name by inserting frontend name
             # after `Scattering`.


### PR DESCRIPTION
Use import_module instead of passing in unknown globals/locals. This resolves #484 .