### PR TITLE
TST Update Jenkins for TF-2.0 compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,11 +17,12 @@ pipeline {
       }
       steps {
 	sh 'python3 -c "import torch; torch.cuda.current_device()"'
+	sh 'python3 -c "import tensorflow as tf; tf.test.is_gpu_available()"'
 	sh 'python3 -m venv --system-site-packages --without-pip $HOME'
 	sh '''#!/bin/bash -ex
 	  source $HOME/bin/activate
 	  python3 setup.py develop
-	  KYMATIO_BACKEND=$STAGE_NAME python3 -m pytest --cov=kymatio
+	  TF_FORCE_GPU_ALLOW_GROWTH=true KYMATIO_BACKEND=$STAGE_NAME python3 -m pytest --cov=kymatio
 	  python3 -m coverage xml
 	  bash <(curl -s https://codecov.io/bash) -t 3941b784-370b-4e50-a162-e5018b7c2861 -F jenkins_$STAGE_NAME -s $WORKSPACE
 	'''
@@ -41,7 +42,7 @@ pipeline {
 	sh '''#!/bin/bash -ex
 	  source $HOME/bin/activate
 	  python3 setup.py develop
-	  KYMATIO_BACKEND=$STAGE_NAME python3 -m pytest --cov=kymatio
+	  TF_FORCE_GPU_ALLOW_GROWTH=true KYMATIO_BACKEND=$STAGE_NAME python3 -m pytest --cov=kymatio
 	  python3 -m coverage xml
 	  bash <(curl -s https://codecov.io/bash) -t 3941b784-370b-4e50-a162-e5018b7c2861 -F jenkins_$STAGE_NAME -s $WORKSPACE
 	'''

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,8 +1,8 @@
-FROM nvidia/cuda:9.2-devel
+FROM nvidia/cuda:10.0-devel-ubuntu18.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      python3-scipy \
+      libcudnn7 \
       python3-appdirs \
       python3-mako \
       python3-pytest \
@@ -17,7 +17,10 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 RUN pip3 install \
+      'numpy>=1.16' \
+      scipy \
       configparser \
       torchvision \
       scikit-cuda \
-      cupy
+      cupy \
+      'tensorflow-gpu>=2.0.0a0'


### PR DESCRIPTION
This includes updating the Dockerfile (upgrading the base Docker image,
installing TF-2.0 for GPU, etc.), adding a check for TF accessing the
GPU in the Jenkinsfile, and setting `TF_FORCE_GPU_ALLOW_GROWTH` to
prevent TF from allocating all the GPU memory for itself.