### PR TITLE
TST Add `set -e` to Travis script

### DIFF
--- a/tools/travis_install.sh
+++ b/tools/travis_install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 sudo apt-get update
 if [[ $CONDA == "1" ]]; then


### PR DESCRIPTION
This way, it'll fail the test early if there are errors installing.