### PR TITLE
Removal of torch averaging functions

### DIFF
--- a/kymatio/scattering3d/backend/torch_backend.py
+++ b/kymatio/scattering3d/backend/torch_backend.py
@@ -66,85 +66,6 @@ def modulus_rotation(x, module=None):
     return torch.sqrt(module)
 
 
-def _compute_standard_scattering_coefs(input_array, filter_list, J, subsample):
-    """Computes convolution and downsamples.
-
-        Computes the convolution of input_array with a lowpass filter phi_J
-        and downsamples by a factor J.
-
-        Parameters
-        ----------
-        input_array : torch Tensor
-            Size (batchsize, M, N, O, 2).
-        filter_list : list of torch Tensors
-            Size (M, N, O, 2).
-        J : int
-            Low pass scale of phi_J.
-        subsample : function
-            Subsampling function.
-
-        Returns
-        -------
-        output : tensor
-            The result of input_array \\star phi_J downsampled by a factor J.
-
-    """
-    low_pass = filter_list[J]
-    convolved_input = cdgmm3d(input_array, low_pass)
-    convolved_input = fft(convolved_input, inverse=True)
-    return subsample(convolved_input, J)
-
-
-def _compute_local_scattering_coefs(input_array, filter_list, j, points):
-    """Compute convolution and returns particular points.
-
-        Computes the convolution of input_array with a lowpass filter phi_j+1
-        and returns the value of the output at particular points.
-        Parameters
-        ----------
-        input_array : torch tensor
-            Size (batchsize, M, N, O, 2).
-        filter_list : list of torch Tensors
-            Size (M, N, O, 2).
-        j : int
-            The lowpass scale j of phi_j.
-        points : torch tensor
-            Size (batchsize, number of points, 3).
-        Returns
-        -------
-        output : torch tensor
-            Torch tensor of size (batchsize, number of points, 1) with the values
-            of the lowpass filtered moduli at the points given.
-    """
-    local_coefs = torch.zeros(input_array.shape[0], points.shape[1], 1)
-    low_pass = filter_list[j + 1]
-    convolved_input = cdgmm3d(input_array, low_pass)
-    convolved_input = fft(convolved_input, inverse=True)
-    for i in range(input_array.shape[0]):
-        for j in range(points[i].shape[0]):
-            x, y, z = points[i, j, 0], points[i, j, 1], points[i, j, 2]
-            local_coefs[i, j, 0] = convolved_input[
-                i, int(x), int(y), int(z), 0]
-    return local_coefs
-
-
-def subsample(input_array, j):
-    """Downsamples.
-        Parameters
-        ----------
-        input_array : tensor
-            Input tensor of shape (batch, channel, M, N, O, 2).
-        j : int
-            Downsampling factor.
-        Returns
-        -------
-        out : tensor
-            Downsampled tensor of shape (batch, channel, M // 2 ** j, N // 2
-            ** j, O // 2 ** j, 2).
-    """
-    return input_array[..., ::2 ** j, ::2 ** j, ::2 ** j, :].contiguous()
-
-
 def compute_integrals(input_array, integral_powers):
     """Computes integrals.
 
@@ -164,7 +85,8 @@ def compute_integrals(input_array, integral_powers):
             Tensor of size (B, P) containing the integrals of the input_array
             to the powers p (l_p norms).
     """
-    integrals = torch.zeros(input_array.shape[0], len(integral_powers), 1)
+    integrals = torch.zeros((input_array.shape[0], len(integral_powers)),
+            device=input_array.device)
     for i_q, q in enumerate(integral_powers):
         integrals[:, i_q, 0] = (input_array ** q).view(
             input_array.shape[0], -1).sum(1).cpu()
@@ -272,9 +194,7 @@ def cdgmm3d(A, B, inplace=False):
 
 def concatenate(arrays, L):
     S = torch.stack(arrays, dim=1)
-
     S = S.reshape((S.shape[0], S.shape[1] // (L + 1), (L + 1)) + S.shape[2:])
-
     return S
 
 
@@ -296,5 +216,3 @@ backend.modulus = complex_modulus
 backend.modulus_rotation = modulus_rotation
 backend.subsample = subsample
 backend.compute_integrals = compute_integrals
-backend._compute_standard_scattering_coefs = _compute_standard_scattering_coefs
-backend._compute_local_scattering_coefs = _compute_local_scattering_coefs

--- a/kymatio/scattering3d/backend/torch_backend.py
+++ b/kymatio/scattering3d/backend/torch_backend.py
@@ -88,8 +88,8 @@ def compute_integrals(input_array, integral_powers):
     integrals = torch.zeros((input_array.shape[0], len(integral_powers)),
             device=input_array.device)
     for i_q, q in enumerate(integral_powers):
-        integrals[:, i_q, 0] = (input_array ** q).view(
-            input_array.shape[0], -1).sum(1).cpu()
+        integrals[:, i_q] = (input_array ** q).view(
+            input_array.shape[0], -1).sum(1)
     return integrals
 
 

--- a/kymatio/scattering3d/backend/torch_backend.py
+++ b/kymatio/scattering3d/backend/torch_backend.py
@@ -204,7 +204,6 @@ backend = namedtuple('backend',
                       'fft',
                       'modulus',
                       'modulus_rotation',
-                      'subsample',
                       'compute_integrals',
                       'concatenate'])
 
@@ -214,5 +213,4 @@ backend.fft = fft
 backend.concatenate = concatenate
 backend.modulus = complex_modulus
 backend.modulus_rotation = modulus_rotation
-backend.subsample = subsample
 backend.compute_integrals = compute_integrals

--- a/kymatio/scattering3d/backend/torch_skcuda_backend.py
+++ b/kymatio/scattering3d/backend/torch_skcuda_backend.py
@@ -80,13 +80,10 @@ def cdgmm3d(A, B, inplace=False):
 from .torch_backend import complex_modulus
 from .torch_backend import fft
 from .torch_backend import modulus_rotation
-from .torch_backend import subsample
 from .torch_backend import compute_integrals
 from .torch_backend import concatenate
-from .torch_backend import _compute_local_scattering_coefs
-from .torch_backend import _compute_standard_scattering_coefs
 
-backend = namedtuple('backend', ['name', 'cdgmm3d', 'fft', 'modulus', 'modulus_rotation', 'subsample',
+backend = namedtuple('backend', ['name', 'cdgmm3d', 'fft', 'modulus', 'modulus_rotation',
                                  'compute_integrals', 'concatenate'])
 
 backend.name = 'torch_skcuda'
@@ -95,7 +92,4 @@ backend.fft = fft
 backend.concatenate = concatenate
 backend.modulus = complex_modulus
 backend.modulus_rotation = modulus_rotation
-backend.subsample = subsample
 backend.compute_integrals = compute_integrals
-backend._compute_standard_scattering_coefs = _compute_standard_scattering_coefs
-backend._compute_local_scattering_coefs = _compute_local_scattering_coefs

--- a/kymatio/scattering3d/core/scattering3d.py
+++ b/kymatio/scattering3d/core/scattering3d.py
@@ -41,7 +41,7 @@ def scattering3d(x, filters, rotation_covariant, L, J, max_order, backend, avera
                 U_1_m = modulus(U_1_c)
 
             U_1_c = fft(U_1_m)
-            S_1_l = averaging(U_1_c, j_1)[..., 0]
+            S_1_l = averaging(U_1_c, j_1)
             s_order_1_l.append(S_1_l)
 
             if max_order > 1:
@@ -57,7 +57,7 @@ def scattering3d(x, filters, rotation_covariant, L, J, max_order, backend, avera
                         U_2_c = fft(U_2_c, inverse=True)
                         U_2_m = modulus(U_2_c)
                     U_2_c = fft(U_2_m)
-                    S_2_l = averaging(U_2_c, j_2)[..., 0]
+                    S_2_l = averaging(U_2_c, j_2)
                     s_order_2_l.append(S_2_l)
 
         s_order_1.append(s_order_1_l)

--- a/kymatio/scattering3d/core/scattering3d.py
+++ b/kymatio/scattering3d/core/scattering3d.py
@@ -40,11 +40,11 @@ def scattering3d(x, filters, rotation_covariant, L, J, max_order, backend, avera
                 U_1_c = fft(U_1_c , inverse=True)
                 U_1_m = modulus(U_1_c)
 
-            U_1_c = fft(U_1_m)
-            S_1_l = averaging(U_1_c, j_1)
+            S_1_l = averaging(U_1_m)
             s_order_1_l.append(S_1_l)
 
             if max_order > 1:
+                U_1_c = fft(U_1_m)
                 for j_2 in range(j_1 + 1, J + 1):
                     U_2_m = None
                     if rotation_covariant:
@@ -56,8 +56,7 @@ def scattering3d(x, filters, rotation_covariant, L, J, max_order, backend, avera
                         U_2_c = cdgmm3d(U_1_c, filters[l][j_2][0])
                         U_2_c = fft(U_2_c, inverse=True)
                         U_2_m = modulus(U_2_c)
-                    U_2_c = fft(U_2_m)
-                    S_2_l = averaging(U_2_c, j_2)
+                    S_2_l = averaging(U_2_m)
                     s_order_2_l.append(S_2_l)
 
         s_order_1.append(s_order_1_l)

--- a/kymatio/scattering3d/frontend/base_frontend.py
+++ b/kymatio/scattering3d/frontend/base_frontend.py
@@ -46,7 +46,7 @@ class ScatteringBase3D(ScatteringBase):
 
     """
     def __init__(self, J, shape, L=3, sigma_0=1, max_order=2,
-                 rotation_covariant=True, method='standard', points=None,
+                 rotation_covariant=True, method='integral', points=None,
                  integral_powers=(0.5, 1., 2.), backend=None):
         super(ScatteringBase3D, self).__init__()
         self.J = J

--- a/kymatio/scattering3d/frontend/torch_frontend.py
+++ b/kymatio/scattering3d/frontend/torch_frontend.py
@@ -80,9 +80,10 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
         methods = ['integral']
         if not self.method in methods:
             raise ValueError('method must be in {}'.format(methods))
+
         if self.method == 'integral': \
-                self.averaging = lambda x, j: self.backend.compute_integrals(self.backend.fft(x, inverse=True),
-                                                                             self.integral_powers)
+                self.averaging = lambda x: self.backend.compute_integrals(x, self.integral_powers)
+
         return scattering3d(input_array, filters=self.filters, rotation_covariant=self.rotation_covariant, L=self.L,
                             J=self.J, max_order=self.max_order, backend=self.backend, averaging=self.averaging)
 

--- a/kymatio/scattering3d/frontend/torch_frontend.py
+++ b/kymatio/scattering3d/frontend/torch_frontend.py
@@ -82,7 +82,7 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
         if not self.method in methods:
             raise ValueError('method must be in {}'.format(methods))
         if self.method == 'integral': \
-                self.averaging = lambda x, j: self.backend.compute_integrals(self.backend.fft(x, inverse=True)[..., 0],
+                self.averaging = lambda x, j: self.backend.compute_integrals(self.backend.fft(x, inverse=True),
                                                                              self.integral_powers)
         return scattering3d(input_array, filters=self.filters, rotation_covariant=self.rotation_covariant, L=self.L,
                             J=self.J, max_order=self.max_order, backend=self.backend, averaging=self.averaging)

--- a/kymatio/scattering3d/frontend/torch_frontend.py
+++ b/kymatio/scattering3d/frontend/torch_frontend.py
@@ -78,22 +78,12 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
             self.filters[k] = buffer_dict['tensor' + str(k)]
 
         # NOTE: 'local' isn't really used anywhere and could be removed.
-        methods = ['standard', 'local', 'integral']
+        methods = ['integral']
         if not self.method in methods:
             raise ValueError('method must be in {}'.format(methods))
         if self.method == 'integral': \
                 self.averaging = lambda x, j: self.backend.compute_integrals(self.backend.fft(x, inverse=True)[..., 0],
                                                                              self.integral_powers)
-        elif self.method == 'local':
-            self.averaging = lambda x, j: \
-                self.backend._compute_local_scattering_coefs(x,
-                                                             self.tensor_gaussian_filter, j, self.points)
-        elif self.method == 'standard':
-            self.averaging = lambda x, j: \
-                self.backend._compute_standard_scattering_coefs(x,
-                                                                self.tensor_gaussian_filter, self.J,
-                                                                self.backend.subsample)
-
         return scattering3d(input_array, filters=self.filters, rotation_covariant=self.rotation_covariant, L=self.L,
                             J=self.J, max_order=self.max_order, backend=self.backend, averaging=self.averaging)
 

--- a/kymatio/scattering3d/frontend/torch_frontend.py
+++ b/kymatio/scattering3d/frontend/torch_frontend.py
@@ -42,7 +42,7 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
         List of exponents to the power of which moduli are raised before
         integration. Used with method == 'standard', method == 'integral'
     """
-    def __init__(self, J, shape, L=3, sigma_0=1, max_order=2, rotation_covariant=True, method='local', points=None,
+    def __init__(self, J, shape, L=3, sigma_0=1, max_order=2, rotation_covariant=True, method='integral', points=None,
                  integral_powers=(0.5, 1., 2.), backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase3D.__init__(self, J, shape, L, sigma_0, max_order,
@@ -77,7 +77,6 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
         for k in range(len(self.filters)):
             self.filters[k] = buffer_dict['tensor' + str(k)]
 
-        # NOTE: 'local' isn't really used anywhere and could be removed.
         methods = ['integral']
         if not self.method in methods:
             raise ValueError('method must be in {}'.format(methods))

--- a/kymatio/scattering3d/frontend/torch_frontend.py
+++ b/kymatio/scattering3d/frontend/torch_frontend.py
@@ -42,7 +42,7 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
         List of exponents to the power of which moduli are raised before
         integration. Used with method == 'standard', method == 'integral'
     """
-    def __init__(self, J, shape, L=3, sigma_0=1, max_order=2, rotation_covariant=True, method='standard', points=None,
+    def __init__(self, J, shape, L=3, sigma_0=1, max_order=2, rotation_covariant=True, method='local', points=None,
                  integral_powers=(0.5, 1., 2.), backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase3D.__init__(self, J, shape, L, sigma_0, max_order,

--- a/kymatio/scattering3d/tests/test_torch_scattering3d.py
+++ b/kymatio/scattering3d/tests/test_torch_scattering3d.py
@@ -284,8 +284,6 @@ def test_scattering_batch_shape_agnostic(device, backend):
     J = 2
     shape = (16, 16, 16)
 
-    shape_ds = tuple(n // (2 **J ) for n in shape)
-
     S = HarmonicScattering3D(J=J, shape=shape)
 
     for k in range(3):
@@ -300,10 +298,9 @@ def test_scattering_batch_shape_agnostic(device, backend):
 
     Sx = S(x)
 
-    assert len(Sx.shape) == 5
-    assert Sx.shape[-3:] == shape_ds
+    assert len(Sx.shape) == 3
 
-    coeffs_shape = Sx.shape[-4:-2]
+    coeffs_shape = Sx.shape[-3:]
 
     test_shapes = ((1,) + shape, (2,) + shape, (2, 2) + shape,
                    (2, 2, 2) + shape)
@@ -315,7 +312,6 @@ def test_scattering_batch_shape_agnostic(device, backend):
 
         Sx = S(x)
 
-        assert len(Sx.shape) == len(test_shape) + 2
-        assert Sx.shape[-3:] == shape_ds
-        assert Sx.shape[-4:-2] == coeffs_shape
-        assert Sx.shape[:-5] == test_shape[:-3]
+        assert len(Sx.shape) == len(test_shape) 
+        assert Sx.shape[-3:] == coeffs_shape
+        assert Sx.shape[:-3] == test_shape[:-3]

--- a/kymatio/scattering3d/tests/test_torch_scattering3d.py
+++ b/kymatio/scattering3d/tests/test_torch_scattering3d.py
@@ -277,35 +277,6 @@ def test_larger_scales(device, backend):
 
 @pytest.mark.parametrize("device", devices)
 @pytest.mark.parametrize("backend", backends)
-def test_scattering_methods(device, backend):
-    if backend.name == "torch_skcuda" and device == "cpu":
-        pytest.skip("The skcuda backend does not support CPU tensors.")
-
-    shape = (32, 32, 32)
-    J = 4
-    L = 3
-    sigma_0 = 1
-    x = torch.randn((1,) + shape).to(device)
-
-    scattering = HarmonicScattering3D(J=J, shape=shape, L=L, sigma_0=sigma_0,
-            frontend='torch',backend=backend).to(device)
-
-    scattering.method = 'standard'
-    Sx = scattering(x)
-    scattering.rotation_covariant = False
-    Sx = scattering(x)
-
-    points = torch.zeros(1, 1, 3)
-    points[0,0,:] = torch.tensor(shape)/2
-
-    scattering.method = 'local'
-    scattering.points = points
-    Sx = scattering(x)
-    scattering.rotation_covariant = False
-    Sx = scattering(x)
-
-@pytest.mark.parametrize("device", devices)
-@pytest.mark.parametrize("backend", backends)
 def test_scattering_batch_shape_agnostic(device, backend):
     if backend.name == "torch_skcuda" and device == "cpu":
         pytest.skip("The skcuda backend does not support CPU tensors.")


### PR DESCRIPTION
Two tests were removed. Attention should be paid attention to the final torch test (test_scattering_batch_shape_agnostic). This test had the assumption that the output shape was of length 5, not sure if this is the case for the integrals output size.

@eickenberg @edouardoyallon thoughts on the final test?
