### PR TITLE
API Attempt at new meta

### DIFF
--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -2,9 +2,10 @@
 # Scientific Ancestry: Joakim Anden, Mathieu Andreux, Vincent Lostanlen
 
 
-def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0, pad_right=0,
-               ind_start=None, ind_end=None, oversampling=0,
-               max_order=2, average=True, size_scattering=(0, 0, 0), vectorize=False):
+def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
+        pad_right=0, ind_start=None, ind_end=None, oversampling=0,
+        max_order=2, average=True, size_scattering=(0, 0, 0),
+        vectorize=False, out_type='array'):
     """
     Main function implementing the 1-D scattering transform.
 
@@ -173,10 +174,14 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0, pad_rig
     out_S.extend(out_S_1)
     out_S.extend(out_S_2)
 
-    if vectorize:
+    if out_type == 'array' and vectorize:
         out_S = concatenate([x['coef'] for x in out_S])
-    else:
+    elif out_type == 'array' and not vectorize:
         out_S = {x['n']: x['coef'] for x in out_S}
+    elif out_type == 'list':
+        # NOTE: This overrides the vectorize flag.
+        for x in out_S:
+            x.pop('n')
 
     return out_S
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -10,7 +10,8 @@ compute_meta_scattering, precompute_size_scattering)
 
 
 class ScatteringBase1D(ScatteringBase):
-    def __init__(self, J, shape, Q=1, max_order=2, average=True, oversampling=0, vectorize=True, backend=None):
+    def __init__(self, J, shape, Q=1, max_order=2, average=True,
+            oversampling=0, vectorize=True, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -19,6 +20,7 @@ class ScatteringBase1D(ScatteringBase):
         self.average = average
         self.oversampling = oversampling
         self.vectorize = vectorize
+        self.out_type = out_type
         self.backend = backend
 
     def build(self):

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -56,6 +56,12 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         if not self.out_type in ('array', 'list'):
             raise RuntimeError("The out_type must be one of 'array' or 'list'.")
 
+        if not self.average and self.out_type == 'array' and self.vectorize:
+            raise ValueError("Options average=False, out_type='array' and "
+                             "vectorize=True are mutually incompatible. "
+                             "Please set out_type to 'list' or vectorize to "
+                             "False.")
+
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
 
@@ -64,10 +70,6 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         # get the arguments before calling the scattering
         # treat the arguments
         if self.vectorize:
-            if not (self.average):
-                raise ValueError(
-                    'Options average=False and vectorize=True are ' +
-                    'mutually incompatible. Please set vectorize to False.')
             size_scattering = precompute_size_scattering(
                 self.J, self.Q, max_order=self.max_order, detail=True)
         else:

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -1,6 +1,8 @@
 # Authors: Mathieu Andreux, Joakim Anden, Edouard Oyallon
 # Scientific Ancestry: Joakim Anden, Mathieu Andreux, Vincent Lostanlen
 
+import warnings
+
 from ...frontend.numpy_frontend import ScatteringNumPy
 from ..core.scattering1d import scattering1d
 from ..utils import precompute_size_scattering
@@ -61,6 +63,11 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                              "vectorize=True are mutually incompatible. "
                              "Please set out_type to 'list' or vectorize to "
                              "False.")
+        if not self.vectorize:
+            warnings.warn("The vectorize option is deprecated and will be "
+                          "removed in version 0.3. Please set "
+                          "out_type='list' for equivalent functionality.",
+                          DeprecationWarning)
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -58,6 +58,12 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         if not self.out_type in ('array', 'list'):
             raise RuntimeError("The out_type must be one of 'array' or 'list'.")
 
+        if not self.average and self.out_type == 'array' and self.vectorize:
+            raise ValueError("Options average=False, out_type='array' and "
+                             "vectorize=True are mutually incompatible. "
+                             "Please set out_type to 'list' or vectorize to "
+                             "False.")
+
         batch_shape = tuple(x.shape[:-1])
         signal_shape = tuple(x.shape[-1:])
 
@@ -66,10 +72,6 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         # get the arguments before calling the scattering
         # treat the arguments
         if self.vectorize:
-            if not (self.average):
-                raise ValueError(
-                    'Options average=False and vectorize=True are ' +
-                    'mutually incompatible. Please set vectorize to False.')
             size_scattering = precompute_size_scattering(
                 self.J, self.Q, max_order=self.max_order, detail=True)
         else:

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -6,6 +6,7 @@ from ..core.scattering1d import scattering1d
 from ..utils import precompute_size_scattering
 from .base_frontend import ScatteringBase1D
 import tensorflow as tf
+import warnings
 
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
@@ -63,6 +64,12 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
                              "vectorize=True are mutually incompatible. "
                              "Please set out_type to 'list' or vectorize to "
                              "False.")
+
+        if not self.vectorize:
+            warnings.warn("The vectorize option is deprecated and will be "
+                          "removed in version 0.3. Please set "
+                          "out_type='list' for equivalent functionality.",
+                          DeprecationWarning)
 
         batch_shape = tuple(x.shape[:-1])
         signal_shape = tuple(x.shape[-1:])

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -111,6 +111,12 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         if not self.out_type in ('array', 'list'):
             raise RuntimeError("The out_type must be one of 'array' or 'list'.")
 
+        if not self.average and self.out_type == 'array' and self.vectorize:
+            raise ValueError("Options average=False, out_type='array' and "
+                             "vectorize=True are mutually incompatible. "
+                             "Please set out_type to 'list' or vectorize to "
+                             "False.")
+
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
 
@@ -121,10 +127,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         # get the arguments before calling the scattering
         # treat the arguments
         if self.vectorize:
-            if not(self.average):
-                raise ValueError(
-                    'Options average=False and vectorize=True are ' +
-                    'mutually incompatible. Please set vectorize to False.')
             size_scattering = precompute_size_scattering(
                 self.J, self.Q, max_order=self.max_order, detail=True)
         else:

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -2,6 +2,7 @@
 # Scientific Ancestry: Joakim Anden, Mathieu Andreux, Vincent Lostanlen
 
 import torch
+import warnings
 
 from ...frontend.torch_frontend import ScatteringTorch
 from ..core.scattering1d import scattering1d
@@ -116,6 +117,12 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                              "vectorize=True are mutually incompatible. "
                              "Please set out_type to 'list' or vectorize to "
                              "False.")
+
+        if not self.vectorize:
+            warnings.warn("The vectorize option is deprecated and will be "
+                          "removed in version 0.3. Please set "
+                          "out_type='list' for equivalent functionality.",
+                          DeprecationWarning)
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]

--- a/kymatio/scattering2d/core/scattering2d.py
+++ b/kymatio/scattering2d/core/scattering2d.py
@@ -8,8 +8,8 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
     cdgmm = backend.cdgmm
     concatenate = backend.concatenate
 
-    # S is simply a dictionary if we do not perform the averaging...
-    S = {}
+    # Define lists for output.
+    out_S_0, out_S_1, out_S_2 = [], [], []
 
     U_r = pad(x)
 
@@ -22,7 +22,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
     S_0 = fft(U_1_c, 'C2R', inverse=True)
     S_0 = unpad(S_0)
 
-    S[()] = S_0
+    out_S_0.append(S_0)
 
     for n1 in range(len(psi)):
         j1 = psi[n1]['j']
@@ -40,8 +40,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
         S_1_r = fft(S_1_c, 'C2R', inverse=True)
         S_1_r = unpad(S_1_r)
 
-
-        S[(n1,)] = S_1_r
+        out_S_1.append(S_1_r)
 
         if max_order < 2:
             continue
@@ -62,16 +61,17 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
             S_2_r = fft(S_2_c, 'C2R', inverse=True)
             S_2_r = unpad(S_2_r)
 
-            S[(n1, n2)] = S_2_r
+            out_S_2.append(S_2_r)
+
+    out_S = []
+    out_S.extend(out_S_0)
+    out_S.extend(out_S_1)
+    out_S.extend(out_S_2)
 
     if vectorize:
-        sorted_keys = sorted(S.keys(), key=lambda x: (len(x),) + x)
+        out_S = concatenate(out_S)
 
-        S = [S[key] for key in sorted_keys]
-
-        S = concatenate(S)
-
-    return S
+    return out_S
 
 
 __all__ = ['scattering2d']

--- a/kymatio/scattering2d/core/scattering2d.py
+++ b/kymatio/scattering2d/core/scattering2d.py
@@ -22,10 +22,14 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
     S_0 = fft(U_1_c, 'C2R', inverse=True)
     S_0 = unpad(S_0)
 
-    out_S_0.append(S_0)
+    out_S_0.append({'coef': S_0,
+                    'j': (),
+                    'theta': ()})
 
     for n1 in range(len(psi)):
         j1 = psi[n1]['j']
+        theta1 = psi[n1]['theta']
+
         U_1_c = cdgmm(U_0_c, psi[n1][0])
         if j1 > 0:
             U_1_c = subsample_fourier(U_1_c, k=2 ** j1)
@@ -40,14 +44,19 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
         S_1_r = fft(S_1_c, 'C2R', inverse=True)
         S_1_r = unpad(S_1_r)
 
-        out_S_1.append(S_1_r)
+        out_S_1.append({'coef': S_1_r,
+                        'j': (j1,),
+                        'theta': (theta1,)})
 
         if max_order < 2:
             continue
         for n2 in range(len(psi)):
             j2 = psi[n2]['j']
+            theta2 = psi[n2]['theta']
+
             if j2 <= j1:
                 continue
+
             U_2_c = cdgmm(U_1_c, psi[n2][j1])
             U_2_c = subsample_fourier(U_2_c, k=2 ** (j2 - j1))
             U_2_c = fft(U_2_c, 'C2C', inverse=True)
@@ -61,7 +70,9 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
             S_2_r = fft(S_2_c, 'C2R', inverse=True)
             S_2_r = unpad(S_2_r)
 
-            out_S_2.append(S_2_r)
+            out_S_2.append({'coef': S_2_r,
+                            'j': (j1, j2),
+                            'theta': (theta1, theta2)})
 
     out_S = []
     out_S.extend(out_S_0)
@@ -69,7 +80,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
     out_S.extend(out_S_2)
 
     if vectorize:
-        out_S = concatenate(out_S)
+        out_S = concatenate([x['coef'] for x in out_S])
 
     return out_S
 

--- a/kymatio/scattering2d/core/scattering2d.py
+++ b/kymatio/scattering2d/core/scattering2d.py
@@ -1,7 +1,8 @@
 # Authors: Edouard Oyallon, Muawiz Chaudhary
 # Scientific Ancestry: Edouard Oyallon, Laurent Sifre, Joan Bruna
 
-def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=True):
+def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order,
+        out_type='array'):
     subsample_fourier = backend.subsample_fourier
     modulus = backend.modulus
     fft = backend.fft
@@ -79,7 +80,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order, vectorize=Tr
     out_S.extend(out_S_1)
     out_S.extend(out_S_2)
 
-    if vectorize:
+    if out_type == 'array':
         out_S = concatenate([x['coef'] for x in out_S])
 
     return out_S

--- a/kymatio/scattering2d/frontend/base_frontend.py
+++ b/kymatio/scattering2d/frontend/base_frontend.py
@@ -5,7 +5,8 @@ from ..utils import compute_padding
 
 
 class ScatteringBase2D(ScatteringBase):
-    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False, backend=None, vectorize=True):
+    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False,
+            backend=None, out_type='array'):
         super(ScatteringBase2D, self).__init__()
         self.pre_pad = pre_pad
         self.L = L
@@ -13,7 +14,7 @@ class ScatteringBase2D(ScatteringBase):
         self.J = J
         self.shape = shape
         self.max_order = max_order
-        self.vectorize = vectorize
+        self.out_type = out_type
 
     def build(self):
         self.M, self.N = self.shape

--- a/kymatio/scattering2d/frontend/numpy_frontend.py
+++ b/kymatio/scattering2d/frontend/numpy_frontend.py
@@ -32,9 +32,16 @@ class ScatteringNumPy2D(ScatteringNumPy, ScatteringBase2D):
         S = scattering2d(input, self.pad, self.unpad, self.backend, self.J, self.L, self.phi, self.psi, self.max_order,
                          vectorize=self.vectorize)
 
-        scattering_shape = S.shape[-3:]
+        if self.vectorize:
+            scattering_shape = S.shape[-3:]
+            new_shape = batch_shape + scattering_shape
 
-        S = S.reshape(batch_shape + scattering_shape)
+            S = S.reshape(new_shape)
+        else:
+            scattering_shape = S[0].shape[-2:]
+            new_shape = batch_shape + scattering_shape
+
+            S = [x.reshape(new_shape) for x in S]
 
         return S
 

--- a/kymatio/scattering2d/frontend/numpy_frontend.py
+++ b/kymatio/scattering2d/frontend/numpy_frontend.py
@@ -4,9 +4,11 @@ from .base_frontend import ScatteringBase2D
 import numpy as np
 
 class ScatteringNumPy2D(ScatteringNumPy, ScatteringBase2D):
-    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False, backend='numpy'):
+    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False,
+            backend='numpy', out_type='array'):
         ScatteringNumPy.__init__(self)
-        ScatteringBase2D.__init__(self, J, shape, L, max_order, pre_pad, backend)
+        ScatteringBase2D.__init__(self, J, shape, L, max_order, pre_pad,
+                backend, out_type)
         ScatteringBase2D._instantiate_backend(self, 'kymatio.scattering2d.backend.')
         ScatteringBase2D.build(self)
         ScatteringBase2D.create_filters(self)
@@ -24,15 +26,19 @@ class ScatteringNumPy2D(ScatteringNumPy, ScatteringBase2D):
         if (input.shape[-1] != self.N_padded or input.shape[-2] != self.M_padded) and self.pre_pad:
             raise RuntimeError('Padded array must be of spatial size (%i,%i).' % (self.M_padded, self.N_padded))
 
+        if not self.out_type in ('array', 'list'):
+            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
+
+
         batch_shape = input.shape[:-2]
         signal_shape = input.shape[-2:]
 
         input = input.reshape((-1,) + signal_shape)
 
-        S = scattering2d(input, self.pad, self.unpad, self.backend, self.J, self.L, self.phi, self.psi, self.max_order,
-                         vectorize=self.vectorize)
+        S = scattering2d(input, self.pad, self.unpad, self.backend, self.J,
+                self.L, self.phi, self.psi, self.max_order, self.out_type)
 
-        if self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-3:]
             new_shape = batch_shape + scattering_shape
 

--- a/kymatio/scattering2d/frontend/numpy_frontend.py
+++ b/kymatio/scattering2d/frontend/numpy_frontend.py
@@ -38,10 +38,11 @@ class ScatteringNumPy2D(ScatteringNumPy, ScatteringBase2D):
 
             S = S.reshape(new_shape)
         else:
-            scattering_shape = S[0].shape[-2:]
+            scattering_shape = S[0]['coef'].shape[-2:]
             new_shape = batch_shape + scattering_shape
 
-            S = [x.reshape(new_shape) for x in S]
+            for x in S:
+                x['coef'] = x['coef'].reshape(new_shape)
 
         return S
 

--- a/kymatio/scattering2d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering2d/frontend/tensorflow_frontend.py
@@ -36,8 +36,18 @@ class ScatteringTensorFlow2D(ScatteringTensorFlow, ScatteringBase2D):
 
             S = scattering2d(input, self.pad, self.unpad, self.backend, self.J, self.L, self.phi, self.psi,
                              self.max_order, vectorize=self.vectorize)
-            scattering_shape = tuple(S.shape[-3:])
-            S = tf.reshape(S, batch_shape + scattering_shape)
+
+            if self.vectorize:
+                scattering_shape = tuple(S.shape[-3:])
+                new_shape = batch_shape + scattering_shape
+
+                S = tf.reshape(S, new_shape)
+            else:
+                scattering_shape = tuple(S[0].shape[-2:])
+                new_shape = batch_shape + scattering_shape
+
+                S = [tf.reshape(x, new_shape) for x in S]
+
             return S
 
 

--- a/kymatio/scattering2d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering2d/frontend/tensorflow_frontend.py
@@ -43,10 +43,11 @@ class ScatteringTensorFlow2D(ScatteringTensorFlow, ScatteringBase2D):
 
                 S = tf.reshape(S, new_shape)
             else:
-                scattering_shape = tuple(S[0].shape[-2:])
+                scattering_shape = tuple(S[0]['coef'].shape[-2:])
                 new_shape = batch_shape + scattering_shape
 
-                S = [tf.reshape(x, new_shape) for x in S]
+                for x in S:
+                    x['coef'] = tf.reshape(x['coef'], new_shape)
 
             return S
 

--- a/kymatio/scattering2d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering2d/frontend/tensorflow_frontend.py
@@ -4,9 +4,11 @@ from kymatio.scattering2d.core.scattering2d import scattering2d
 from .base_frontend import ScatteringBase2D
 
 class ScatteringTensorFlow2D(ScatteringTensorFlow, ScatteringBase2D):
-    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False, backend='tensorflow', name='Scattering2D'):
+    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False,
+            backend='tensorflow', name='Scattering2D', out_type='array'):
         ScatteringTensorFlow.__init__(self, name)
-        ScatteringBase2D.__init__(self, J, shape, L, max_order, pre_pad, backend)
+        ScatteringBase2D.__init__(self, J, shape, L, max_order, pre_pad,
+                backend, out_type)
         ScatteringBase2D._instantiate_backend(self, 'kymatio.scattering2d.backend.')
         ScatteringBase2D.build(self)
         ScatteringBase2D.create_filters(self)
@@ -28,6 +30,8 @@ class ScatteringTensorFlow2D(ScatteringTensorFlow, ScatteringBase2D):
 
             if (input.shape[-1] != self.N_padded or input.shape[-2] != self.M_padded) and self.pre_pad:
                 raise RuntimeError('Padded tensor must be of spatial size (%i,%i).' % (self.M_padded, self.N_padded))
+            if not self.out_type in ('array', 'list'):
+                raise RuntimeError("The out_type must be one of 'array' or 'list'.")
 
             batch_shape = tuple(input.shape[:-2])
             signal_shape = tuple(input.shape[-2:])
@@ -35,9 +39,9 @@ class ScatteringTensorFlow2D(ScatteringTensorFlow, ScatteringBase2D):
             input = tf.reshape(input, (-1,) + signal_shape)
 
             S = scattering2d(input, self.pad, self.unpad, self.backend, self.J, self.L, self.phi, self.psi,
-                             self.max_order, vectorize=self.vectorize)
+                             self.max_order, self.out_type)
 
-            if self.vectorize:
+            if self.out_type == 'array':
                 scattering_shape = tuple(S.shape[-3:])
                 new_shape = batch_shape + scattering_shape
 

--- a/kymatio/scattering2d/frontend/torch_frontend.py
+++ b/kymatio/scattering2d/frontend/torch_frontend.py
@@ -125,9 +125,14 @@ class ScatteringTorch2D(ScatteringTorch, ScatteringBase2D):
         S = scattering2d(input, self.pad, self.unpad, self.backend, self.J,
                             self.L, phi, psi, self.max_order, vectorize=self.vectorize)
 
-        scattering_shape = S.shape[-3:]
+        if self.vectorize:
+            scattering_shape = S.shape[-3:]
+            S = S.reshape(batch_shape + scattering_shape)
+        else:
+            scattering_shape = S[0].shape[-2:]
+            new_shape = batch_shape + scattering_shape
 
-        S = S.reshape(batch_shape + scattering_shape)
+            S = [x.reshape(new_shape) for x in S]
 
         return S
 

--- a/kymatio/scattering2d/frontend/torch_frontend.py
+++ b/kymatio/scattering2d/frontend/torch_frontend.py
@@ -6,7 +6,8 @@ from ...frontend.torch_frontend import ScatteringTorch
 
 
 class ScatteringTorch2D(ScatteringTorch, ScatteringBase2D):
-    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False, backend='torch', vectorize=True):
+    def __init__(self, J, shape, L=8, max_order=2, pre_pad=False,
+            backend='torch', out_type='array'):
         ScatteringTorch.__init__(self)
         ScatteringBase2D.__init__(**locals())
         ScatteringBase2D._instantiate_backend(self, 'kymatio.scattering2d.backend.')
@@ -115,6 +116,9 @@ class ScatteringTorch2D(ScatteringTorch, ScatteringBase2D):
         if (input.shape[-1] != self.N_padded or input.shape[-2] != self.M_padded) and self.pre_pad:
             raise RuntimeError('Padded tensor must be of spatial size (%i,%i).' % (self.M_padded, self.N_padded))
 
+        if not self.out_type in ('array', 'list'):
+            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
+
         phi, psi = self.load_filters()
 
         batch_shape = input.shape[:-2]
@@ -123,9 +127,9 @@ class ScatteringTorch2D(ScatteringTorch, ScatteringBase2D):
         input = input.reshape((-1,) + signal_shape)
 
         S = scattering2d(input, self.pad, self.unpad, self.backend, self.J,
-                            self.L, phi, psi, self.max_order, vectorize=self.vectorize)
+                            self.L, phi, psi, self.max_order, self.out_type)
 
-        if self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-3:]
             S = S.reshape(batch_shape + scattering_shape)
         else:

--- a/kymatio/scattering2d/frontend/torch_frontend.py
+++ b/kymatio/scattering2d/frontend/torch_frontend.py
@@ -129,10 +129,11 @@ class ScatteringTorch2D(ScatteringTorch, ScatteringBase2D):
             scattering_shape = S.shape[-3:]
             S = S.reshape(batch_shape + scattering_shape)
         else:
-            scattering_shape = S[0].shape[-2:]
+            scattering_shape = S[0]['coef'].shape[-2:]
             new_shape = batch_shape + scattering_shape
 
-            S = [x.reshape(new_shape) for x in S]
+            for x in S:
+                x['coef'] = x['coef'].reshape(new_shape)
 
         return S
 


### PR DESCRIPTION
This is a proposal for dealing with metadata in the 2D code. The idea is to not have a separate `meta` function (or `filters`), but to output the metatdata *along* with the scattering coefficients, if desired. Here, this is achieved using the `out_type` attribute. By default, it is set to `'array'`, which returns the array/tensor we normally get. If it's set to `list`, we get a list of dictionaries. The indexing of the list corresponds to that of the array output (the second dimension if the batch index is one-dimensional). Each element has a key `'coef'`, which contains the actual scattering coefficients, but also `'j'` and `'theta'`. (Probably makes sense to have an `'order'` key, among others, but this is just a proof of concept.)

As an example, we have (in the NP frontend)
```
x = np.random.randn(8, 32, 32)
S = Scattering2D(J=3, shape=(32, 32))

# Get out normal array output. S.out_type is 'array' by default.
Sx_array = S.scattering(x)

# Get our list of dictionaries output
S.out_type = 'list'
Sx_list = S.scattering(x)

# Coefficients are in the 'coef' element.
Sx_array[:, 123, :, :] == Sx_list[123]['coef']

# Get metadata on that scattering coefficient.
j1, j2 = Sx_list[123]['j']
theta1, theta2 = Sx_list[123]['theta']
```
One of the advantages of this approach is that the indexing remains the same, so it's easy to correlate the two outputs (and we can effectively get a `meta` structure for an `'array'` output by setting `out_type = 'list'` and calling `scattering` with an empty input). Another is the flexibility we will have in adding new elements to the dictionary (containing, for example, pointers to the actual filters used). It should also extend well to other modalities (harmonic 3D scattering, joint time–frequency scattering, etc.). Finally, it's not a very *hard* feature, since we can deprecate/disable it in the future if we don't like it by defining new `out_type`s to replace it.

If you think this looks good, I will proceed to make the same additions to the 1D and 3D (deprecating the old `vectorize=False` option in 1D along with the `meta` method).
