### PR TITLE
Fix doc 1 d

### DIFF
--- a/doc/source/userguide.rst
+++ b/doc/source/userguide.rst
@@ -92,7 +92,7 @@ Output size
 1-D
 ---
 
-If the input :math:`x` is a Tensor of size :math:`(B, 1, T)`, the output of the
+If the input :math:`x` is a Tensor of size :math:`(B, T)`, the output of the
 1D scattering transform is of size :math:`(B, P, T/2^J)`, where :math:`P` is
 the number of scattering coefficients and :math:`2^J` is the maximum scale of the
 transform. The value of :math:`P` depends on the maximum order of the scattering

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -260,15 +260,16 @@ class ScatteringBase1D(ScatteringBase):
     """Apply the scattering transform
 
        Given an input `{array}` of size `(B, T)`, where `B` is the batch
-       size and `T` is the length of the individual signals, this function
-       computes its scattering transform. If the `vectorize` flag is set to
-       `True`, the output is in the form of a `{array}` or size `(B, C, T1)`,
-       where `T1` is the signal length after subsampling to the scale :math:`2^J`
-       (with the appropriate oversampling factor to reduce aliasing), and
-       `C` is the number of scattering coefficients.  If `vectorize` is set
-       `False`, however, the output is a dictionary containing `C` keys, each
-       a tuple whose length corresponds to the scattering order and whose
-       elements are the sequence of filter indices used.
+       size (it can be potentially an integer or a shape) and `T` is the length
+       of the individual signals, this function computes its scattering
+       transform. If the `vectorize` flag is set to `True`, the output is in
+       the form of a `{array}` or size `(B, C, T1)`, where `T1` is the signal
+       length after subsampling to the scale :math:`2^J` (with the appropriate
+       oversampling factor to reduce aliasing), and `C` is the number of
+       scattering coefficients.  If `vectorize` is set `False`, however, the
+       output is a dictionary containing `C` keys, each a tuple whose length
+       corresponds to the scattering order and whose elements are the sequence
+       of filter indices used.
 
        Furthermore, if the `average` flag is set to `False`, these outputs
        are not averaged, but are simply the wavelet modulus coefficients of


### PR DESCRIPTION
Closes #411 

This fix an issue concerning the documentaiton of intput/output shape for 1D which was reported in #411 