### PR TITLE
REF+DOC Make Keras importable from ScatteringEntry

### DIFF
--- a/kymatio/frontend/entry.py
+++ b/kymatio/frontend/entry.py
@@ -11,7 +11,7 @@ class ScatteringEntry(object):
         kwargs.pop('class_name')
 
         frontend_suffixes = {'torch' : 'Torch', 'numpy' : 'NumPy', 'tensorflow'
-                : 'TensorFlow'}
+                : 'TensorFlow', 'keras': 'Keras'}
         if 'frontend' not in kwargs:
             warnings.warn("Torch frontend is currently the default, but NumPy will become the default in the next"
                           " version.", DeprecationWarning)

--- a/kymatio/frontend/keras_frontend.py
+++ b/kymatio/frontend/keras_frontend.py
@@ -1,0 +1,32 @@
+from tensorflow.keras.layers import Layer
+
+
+class ScatteringKeras(Layer):
+    def __init__(self):
+        Layer.__init__(self)
+        self.frontend_name = 'keras'
+
+    def build(self, input_shape):
+        self.shape = input_shape
+        Layer.build(self, input_shape)
+
+    def scattering(self, x):
+        return self.S.scattering(x)
+
+    def call(self, x):
+        return self.scattering(x)
+
+    _doc_array = 'tf.Tensor'
+    _doc_array_n = ''
+
+    _doc_alias_name = 'call'
+
+    _doc_alias_call = ''
+
+    _doc_frontend_paragraph = \
+        """
+        This class inherits from `tf.keras.layers.Layer`. As a result, it has
+        all the same capabilities as a standard Keras `Layer`.
+        """
+
+    _doc_sample = 'np.random.randn({shape})'

--- a/kymatio/frontend/keras_frontend.py
+++ b/kymatio/frontend/keras_frontend.py
@@ -30,3 +30,7 @@ class ScatteringKeras(Layer):
         """
 
     _doc_sample = 'np.random.randn({shape})'
+
+    _doc_has_shape = False
+
+    _doc_has_out_type = False

--- a/kymatio/frontend/numpy_frontend.py
+++ b/kymatio/frontend/numpy_frontend.py
@@ -25,3 +25,7 @@ class ScatteringNumPy:
     _doc_frontend_paragraph = ''
 
     _doc_sample = 'np.random.randn({shape})'
+
+    _doc_has_shape = True
+
+    _doc_has_out_type = True

--- a/kymatio/frontend/tensorflow_frontend.py
+++ b/kymatio/frontend/tensorflow_frontend.py
@@ -30,3 +30,7 @@ class ScatteringTensorFlow(tf.Module):
         """
 
     _doc_sample = 'np.random.randn({shape})'
+
+    _doc_has_shape = True
+
+    _doc_has_out_type = True

--- a/kymatio/frontend/torch_frontend.py
+++ b/kymatio/frontend/torch_frontend.py
@@ -39,3 +39,7 @@ class ScatteringTorch(nn.Module):
         """
 
     _doc_sample = 'torch.randn({shape})'
+
+    _doc_has_shape = True
+
+    _doc_has_out_type = True

--- a/kymatio/keras.py
+++ b/kymatio/keras.py
@@ -1,59 +1,12 @@
-from kymatio.tensorflow import Scattering1D as ScatteringTensorFlow1D
-from kymatio.tensorflow import Scattering2D as ScatteringTensorFlow2D
+from kymatio.scattering1d.frontend.keras_frontend \
+    import ScatteringKeras1D as Scattering1D
+from kymatio.scattering2d.frontend.keras_frontend \
+    import ScatteringKeras2D as Scattering2D
 
-from tensorflow.keras.layers import Layer
-from tensorflow.python.framework import tensor_shape
+Scattering1D.__module__ = 'kymatio.keras'
+Scattering1D.__name__ = 'Scattering1D'
 
+Scattering2D.__module__ = 'kymatio.keras'
+Scattering2D.__name__ = 'Scattering2D'
 
-class Scattering1D(Layer):
-    def __init__(self, J, Q=1, max_order=2, oversampling=0):
-        super(Scattering1D, self).__init__()
-        self.J = J
-        self.Q = Q
-        self.max_order = max_order
-        self.oversampling = oversampling
-
-    def build(self, input_shape):
-        shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
-        self.S = ScatteringTensorFlow1D(J=self.J, shape=shape,
-                                        Q=self.Q, max_order=self.max_order,
-                                        oversampling=self.oversampling)
-        super(Scattering1D, self).build(input_shape)
-
-    def call(self, x):
-        return self.S(x)
-
-    def compute_output_shape(self, input_shape):
-        input_shape = tensor_shape.TensorShape(input_shape).as_list()
-        nc = self.S.output_size()
-        k0 = max(self.J - self.oversampling, 0)
-        ln = self.S.ind_end[k0] - self.S.ind_start[k0]
-        output_shape = [input_shape[0], nc, ln]
-        return tensor_shape.TensorShape(output_shape)
-
-
-class Scattering2D(Layer):
-    def __init__(self, J, L=8, max_order=2, pre_pad=False):
-        super(Scattering2D, self).__init__()
-        self.J = J
-        self.L = L
-        self.max_order = max_order
-        self.pre_pad = pre_pad
-
-    def build(self, input_shape):
-        shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-2:])
-        self.S = ScatteringTensorFlow2D(J=self.J, shape=shape,
-                                        L=self.L, max_order=self.max_order,
-                                        pre_pad=self.pre_pad)
-        super(Scattering2D, self).build(input_shape)
-
-    def call(self, x):
-        return self.S(x)
-
-    def compute_output_shape(self, input_shape):
-        input_shape = tensor_shape.TensorShape(input_shape).as_list()
-        m0 = input_shape[-2] // 2 ** self.J
-        m1 = input_shape[-1] // 2 ** self.J
-        nc = (self.L ** 2) * self.J * (self.J - 1) // 2 + self.L * self.J + 1
-        output_shape = [input_shape[0], nc, m0, m1]
-        return tensor_shape.TensorShape(output_shape)
+__all__ = ['Scattering1D', 'Scattering2D']

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -112,6 +112,69 @@ class ScatteringBase1D(ScatteringBase):
 
     _doc_shape = 'T'
 
+    _doc_instantiation_shape = {True: 'S = Scattering1D(J, T, Q)',
+                                False: 'S = Scattering1D(J, Q)'}
+
+    _doc_param_shape = \
+    r"""shape : int
+            The length of the input signals.
+        """
+
+    _doc_attrs_shape = \
+    r"""J_pad : int
+            The logarithm of the padded length of the signals.
+        pad_left : int
+            The amount of padding to the left of the signal.
+        pad_right : int
+            The amount of padding to the right of the signal.
+        phi_f : dictionary
+            A dictionary containing the lowpass filter at all resolutions. See
+            `filter_bank.scattering_filter_factory` for an exact description.
+        psi1_f : dictionary
+            A dictionary containing all the first-order wavelet filters, each
+            represented as a dictionary containing that filter at all
+            resolutions. See `filter_bank.scattering_filter_factory` for an
+            exact description.
+        psi2_f : dictionary
+            A dictionary containing all the second-order wavelet filters, each
+            represented as a dictionary containing that filter at all
+            resolutions. See `filter_bank.scattering_filter_factory` for an
+            exact description.
+        """
+
+    _doc_param_average = \
+    r"""average : boolean, optional
+            Determines whether the output is averaged in time or not. The
+            averaged output corresponds to the standard scattering transform,
+            while the un-averaged output skips the last convolution by
+            :math:`\phi_J(t)`.  This parameter may be modified after object
+            creation. Defaults to `True`.
+        """
+
+    _doc_attr_average = \
+    r"""average : boolean
+            Controls whether the output should be averaged (the standard
+            scattering transform) or not (resulting in wavelet modulus
+            coefficients). Note that to obtain unaveraged output, the
+            `vectorize` flag must be set to `False`.
+        """
+
+    _doc_param_vectorize = \
+    r"""vectorize : boolean, optional
+            Determines wheter to return a vectorized scattering transform
+            (that is, a large array containing the output) or a dictionary
+            (where each entry corresponds to a separate scattering
+            coefficient). This parameter may be modified after object
+            creation. Defaults to True.
+        """
+
+    _doc_attr_vectorize = \
+    r"""vectorize : boolean
+            Controls whether the output should be vectorized into a single
+            Tensor or collected into a dictionary. For more details, see the
+            documentation for `scattering`.
+        """
+
     _doc_class = \
     r"""The 1D scattering transform
 
@@ -161,7 +224,7 @@ class ScatteringBase1D(ScatteringBase):
             x = {sample}
 
             # Define a Scattering1D object.
-            S = Scattering1D(J, T, Q)
+            {instantiation}
 
             # Calculate the scattering transform.
             Sx = S.scattering(x)
@@ -181,21 +244,13 @@ class ScatteringBase1D(ScatteringBase):
         J : int
             The maximum log-scale of the scattering transform. In other words,
             the maximum scale is given by :math:`2^J`.
-        T : int
-            The length of the input signals.
-        Q : int >= 1
+        {param_shape}Q : int >= 1
             The number of first-order wavelets per octave (second-order
             wavelets are fixed to one wavelet per octave). Defaults to `1`.
         max_order : int, optional
             The maximum order of scattering coefficients to compute. Must be
             either `1` or `2`. Defaults to `2`.
-        average : boolean, optional
-            Determines whether the output is averaged in time or not. The
-            averaged output corresponds to the standard scattering transform,
-            while the un-averaged output skips the last convolution by
-            :math:`\phi_J(t)`.  This parameter may be modified after object
-            creation. Defaults to `True`.
-        oversampling : integer >= 0, optional
+        {param_average}oversampling : integer >= 0, optional
             Controls the oversampling factor relative to the default as a
             power of two. Since the convolving by wavelets (or lowpass
             filters) and taking the modulus reduces the high-frequency content
@@ -204,57 +259,21 @@ class ScatteringBase1D(ScatteringBase):
             calculation. If this is not desirable, `oversampling` can be set
             to a large value to prevent too much subsampling. This parameter
             may be modified after object creation. Defaults to `0`.
-        vectorize : boolean, optional
-            Determines wheter to return a vectorized scattering transform
-            (that is, a large array containing the output) or a dictionary
-            (where each entry corresponds to a separate scattering
-            coefficient). This parameter may be modified after object
-            creation. Defaults to True.
-
+        {param_vectorize}
         Attributes
         ----------
         J : int
             The maximum log-scale of the scattering transform. In other words,
             the maximum scale is given by `2 ** J`.
-        shape : int
-            The length of the input signals.
-        Q : int
+        {param_shape}Q : int
             The number of first-order wavelets per octave (second-order
             wavelets are fixed to one wavelet per octave).
-        J_pad : int
-            The logarithm of the padded length of the signals.
-        pad_left : int
-            The amount of padding to the left of the signal.
-        pad_right : int
-            The amount of padding to the right of the signal.
-        phi_f : dictionary
-            A dictionary containing the lowpass filter at all resolutions. See
-            `filter_bank.scattering_filter_factory` for an exact description.
-        psi1_f : dictionary
-            A dictionary containing all the first-order wavelet filters, each
-            represented as a dictionary containing that filter at all
-            resolutions. See `filter_bank.scattering_filter_factory` for an
-            exact description.
-        psi2_f : dictionary
-            A dictionary containing all the second-order wavelet filters, each
-            represented as a dictionary containing that filter at all
-            resolutions. See `filter_bank.scattering_filter_factory` for an
-            exact description.
-        max_order : int
+        {attrs_shape}max_order : int
             The maximum scattering order of the transform.
-        average : boolean
-            Controls whether the output should be averaged (the standard
-            scattering transform) or not (resulting in wavelet modulus
-            coefficients). Note that to obtain unaveraged output, the
-            `vectorize` flag must be set to `False`.
-        oversampling : int
+        {attr_average}oversampling : int
             The number of powers of two to oversample the output compared to
             the default subsampling rate determined from the filters.
-        vectorize : boolean
-            Controls whether the output should be vectorized into a single
-            Tensor or collected into a dictionary. For more details, see the
-            documentation for `scattering`.
-        """
+        {attr_vectorize}"""
 
     _doc_scattering = \
     """Apply the scattering transform
@@ -290,11 +309,27 @@ class ScatteringBase1D(ScatteringBase):
 
     @classmethod
     def _document(cls):
+        instantiation = cls._doc_instantiation_shape[cls._doc_has_shape]
+        param_shape = cls._doc_param_shape if cls._doc_has_shape else ''
+        attrs_shape = cls._doc_attrs_shape if cls._doc_has_shape else ''
+
+        param_average = cls._doc_param_average if cls._doc_has_out_type else ''
+        attr_average = cls._doc_attr_average if cls._doc_has_out_type else ''
+        param_vectorize = cls._doc_param_vectorize if cls._doc_has_out_type else ''
+        attr_vectorize = cls._doc_attr_vectorize if cls._doc_has_out_type else ''
+
         cls.__doc__ = ScatteringBase1D._doc_class.format(
             array=cls._doc_array,
             frontend_paragraph=cls._doc_frontend_paragraph,
             alias_name=cls._doc_alias_name,
             alias_call=cls._doc_alias_call,
+            instantiation=instantiation,
+            param_shape=param_shape,
+            attrs_shape=attrs_shape,
+            param_average=param_average,
+            attr_average=attr_average,
+            param_vectorize=param_vectorize,
+            attr_vectorize=attr_vectorize,
             sample=cls._doc_sample.format(shape=cls._doc_shape))
 
         cls.scattering.__doc__ = ScatteringBase1D._doc_scattering.format(

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -1,26 +1,23 @@
+from kymatio.frontend.keras_frontend import ScatteringKeras
+from kymatio.scattering1d.frontend.base_frontend import ScatteringBase1D
+
 from kymatio.tensorflow import Scattering1D as ScatteringTensorFlow1D
 
-from tensorflow.keras.layers import Layer
 from tensorflow.python.framework import tensor_shape
 
 
-class ScatteringKeras1D(Layer):
+class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, max_order=2, oversampling=0):
-        super(ScatteringKeras1D, self).__init__()
-        self.J = J
-        self.Q = Q
-        self.max_order = max_order
-        self.oversampling = oversampling
+        ScatteringKeras.__init__(self)
+        ScatteringBase1D.__init__(self, J, None, Q, max_order, True,
+                oversampling, True, 'array', None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
         self.S = ScatteringTensorFlow1D(J=self.J, shape=shape,
                                         Q=self.Q, max_order=self.max_order,
                                         oversampling=self.oversampling)
-        super(ScatteringKeras1D, self).build(input_shape)
-
-    def call(self, x):
-        return self.S(x)
+        ScatteringKeras.build(self, input_shape)
 
     def compute_output_shape(self, input_shape):
         input_shape = tensor_shape.TensorShape(input_shape).as_list()
@@ -29,3 +26,6 @@ class ScatteringKeras1D(Layer):
         ln = self.S.ind_end[k0] - self.S.ind_start[k0]
         output_shape = [input_shape[0], nc, ln]
         return tensor_shape.TensorShape(output_shape)
+
+
+ScatteringKeras1D._document()

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -1,0 +1,31 @@
+from kymatio.tensorflow import Scattering1D as ScatteringTensorFlow1D
+
+from tensorflow.keras.layers import Layer
+from tensorflow.python.framework import tensor_shape
+
+
+class ScatteringKeras1D(Layer):
+    def __init__(self, J, Q=1, max_order=2, oversampling=0):
+        super(ScatteringKeras1D, self).__init__()
+        self.J = J
+        self.Q = Q
+        self.max_order = max_order
+        self.oversampling = oversampling
+
+    def build(self, input_shape):
+        shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
+        self.S = ScatteringTensorFlow1D(J=self.J, shape=shape,
+                                        Q=self.Q, max_order=self.max_order,
+                                        oversampling=self.oversampling)
+        super(ScatteringKeras1D, self).build(input_shape)
+
+    def call(self, x):
+        return self.S(x)
+
+    def compute_output_shape(self, input_shape):
+        input_shape = tensor_shape.TensorShape(input_shape).as_list()
+        nc = self.S.output_size()
+        k0 = max(self.J - self.oversampling, 0)
+        ln = self.S.ind_end[k0] - self.S.ind_start[k0]
+        output_shape = [input_shape[0], nc, ln]
+        return tensor_shape.TensorShape(output_shape)

--- a/kymatio/scattering2d/frontend/base_frontend.py
+++ b/kymatio/scattering2d/frontend/base_frontend.py
@@ -33,6 +33,25 @@ class ScatteringBase2D(ScatteringBase):
 
     _doc_shape = 'M, N'
 
+    _doc_instantiation_shape = {True: 'S = Scattering2D(J, (M, N))',
+                                False: 'S = Scattering2D(J)'}
+
+    _doc_param_shape = \
+    r"""shape : tuple of ints
+            Spatial support (M, N) of the input
+        """
+
+    _doc_attrs_shape = \
+    r"""Psi : dictionary
+            Contains the wavelets filters at all resolutions. See
+            `filter_bank.filter_bank` for an exact description.
+        Phi : dictionary
+            Contains the low-pass filters at all resolutions. See
+            `filter_bank.filter_bank` for an exact description.
+        M_padded, N_padded : int
+             Spatial support of the padded input.
+        """
+
     _doc_class = \
     r"""The 2D scattering transform
 
@@ -70,7 +89,7 @@ class ScatteringBase2D(ScatteringBase):
             x = {sample}
 
             # Define a Scattering2D object.
-            S = Scattering2D(J, (M, N))
+            {instantiation}
 
             # Calculate the scattering transform.
             Sx = S.scattering(x)
@@ -82,9 +101,7 @@ class ScatteringBase2D(ScatteringBase):
         ----------
         J : int
             Log-2 of the scattering scale.
-        shape : tuple of ints
-            Spatial support (M, N) of the input.
-        L : int, optional
+        {param_shape}L : int, optional
             Number of angles used for the wavelet transform. Defaults to `8`.
         max_order : int, optional
             The maximum order of scattering coefficients to compute. Must be
@@ -100,9 +117,7 @@ class ScatteringBase2D(ScatteringBase):
         ----------
         J : int
             Log-2 of the scattering scale.
-        shape : tuple of int
-            Spatial support (M, N) of the input.
-        L : int, optional
+        {param_shape}L : int, optional
             Number of angles used for the wavelet transform.
         max_order : int, optional
             The maximum order of scattering coefficients to compute.
@@ -111,15 +126,7 @@ class ScatteringBase2D(ScatteringBase):
             Controls the padding: if set to False, a symmetric padding is
             applied on the signal. If set to True, the software will assume
             the signal was padded externally.
-        Psi : dictionary
-            Contains the wavelets filters at all resolutions. See
-            `filter_bank.filter_bank` for an exact description.
-        Phi : dictionary
-            Contains the low-pass filters at all resolutions. See
-            `filter_bank.filter_bank` for an exact description.
-        M_padded, N_padded : int
-             Spatial support of the padded input.
-
+        {attrs_shape}
         Notes
         -----
         The design of the filters is optimized for the value `L = 8`.
@@ -156,11 +163,18 @@ class ScatteringBase2D(ScatteringBase):
 
     @classmethod
     def _document(cls):
+        instantiation = cls._doc_instantiation_shape[cls._doc_has_shape]
+        param_shape = cls._doc_param_shape if cls._doc_has_shape else ''
+        attrs_shape = cls._doc_attrs_shape if cls._doc_has_shape else ''
+
         cls.__doc__ = ScatteringBase2D._doc_class.format(
             array=cls._doc_array,
             frontend_paragraph=cls._doc_frontend_paragraph,
             alias_name=cls._doc_alias_name,
             alias_call=cls._doc_alias_call,
+            instantiation=instantiation,
+            param_shape=param_shape,
+            attrs_shape=attrs_shape,
             sample=cls._doc_sample.format(shape=cls._doc_shape))
 
         cls.scattering.__doc__ = ScatteringBase2D._doc_scattering.format(

--- a/kymatio/scattering2d/frontend/base_frontend.py
+++ b/kymatio/scattering2d/frontend/base_frontend.py
@@ -74,9 +74,7 @@ class ScatteringBase2D(ScatteringBase):
         and $\psi^{{(2)}}_\mu$ is another family of bandpass filters. Only
         Morlet filters are used in this implementation. Convolutions are
         efficiently performed in the Fourier domain.
-
         {frontend_paragraph}
-
         Example
         -------
         ::

--- a/kymatio/scattering2d/frontend/keras_frontend.py
+++ b/kymatio/scattering2d/frontend/keras_frontend.py
@@ -1,0 +1,31 @@
+from kymatio.tensorflow import Scattering2D as ScatteringTensorFlow2D
+
+from tensorflow.keras.layers import Layer
+from tensorflow.python.framework import tensor_shape
+
+
+class ScatteringKeras2D(Layer):
+    def __init__(self, J, L=8, max_order=2, pre_pad=False):
+        super(ScatteringKeras2D, self).__init__()
+        self.J = J
+        self.L = L
+        self.max_order = max_order
+        self.pre_pad = pre_pad
+
+    def build(self, input_shape):
+        shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-2:])
+        self.S = ScatteringTensorFlow2D(J=self.J, shape=shape,
+                                        L=self.L, max_order=self.max_order,
+                                        pre_pad=self.pre_pad)
+        super(ScatteringKeras2D, self).build(input_shape)
+
+    def call(self, x):
+        return self.S(x)
+
+    def compute_output_shape(self, input_shape):
+        input_shape = tensor_shape.TensorShape(input_shape).as_list()
+        m0 = input_shape[-2] // 2 ** self.J
+        m1 = input_shape[-1] // 2 ** self.J
+        nc = (self.L ** 2) * self.J * (self.J - 1) // 2 + self.L * self.J + 1
+        output_shape = [input_shape[0], nc, m0, m1]
+        return tensor_shape.TensorShape(output_shape)

--- a/kymatio/scattering2d/frontend/keras_frontend.py
+++ b/kymatio/scattering2d/frontend/keras_frontend.py
@@ -1,26 +1,25 @@
+from kymatio.frontend.keras_frontend import ScatteringKeras
+from kymatio.scattering2d.frontend.base_frontend import ScatteringBase2D
+
 from kymatio.tensorflow import Scattering2D as ScatteringTensorFlow2D
 
-from tensorflow.keras.layers import Layer
 from tensorflow.python.framework import tensor_shape
 
 
-class ScatteringKeras2D(Layer):
+class ScatteringKeras2D(ScatteringKeras, ScatteringBase2D):
     def __init__(self, J, L=8, max_order=2, pre_pad=False):
-        super(ScatteringKeras2D, self).__init__()
-        self.J = J
-        self.L = L
-        self.max_order = max_order
-        self.pre_pad = pre_pad
+        ScatteringKeras.__init__(self)
+        ScatteringBase2D.__init__(self, J, None, L, max_order, pre_pad,
+                                  'array')
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-2:])
         self.S = ScatteringTensorFlow2D(J=self.J, shape=shape,
                                         L=self.L, max_order=self.max_order,
                                         pre_pad=self.pre_pad)
-        super(ScatteringKeras2D, self).build(input_shape)
-
-    def call(self, x):
-        return self.S(x)
+        ScatteringKeras.build(self, input_shape)
+        # NOTE: Do not call ScatteringBase2D.build here since that will
+        # recreate the filters already in self.S
 
     def compute_output_shape(self, input_shape):
         input_shape = tensor_shape.TensorShape(input_shape).as_list()
@@ -29,3 +28,6 @@ class ScatteringKeras2D(Layer):
         nc = (self.L ** 2) * self.J * (self.J - 1) // 2 + self.L * self.J + 1
         output_shape = [input_shape[0], nc, m0, m1]
         return tensor_shape.TensorShape(output_shape)
+
+
+ScatteringKeras2D._document()


### PR DESCRIPTION
This way, we can run
```
from kymatio import Scattering2D
S = Scattering2D(J=3, frontend='keras')
``
and have things work as expected. This PR also hooks the Keras frontend into the documentation template so docstrings should now be there. This last part required reworking some of the templates since the Keras frontend is a little different than the others (it doesn't have a `shape` attribute and it doesn't support non-vectorized outputs).