### PR TITLE
API Refactor code to take advantage of rfft

### DIFF
--- a/kymatio/backend/base_backend.py
+++ b/kymatio/backend/base_backend.py
@@ -1,8 +1,9 @@
 
 
 class FFT:
-    def __init__(self, fft, ifft, irfft, type_checks):
+    def __init__(self, fft, rfft, ifft, irfft, type_checks):
         self.fft = fft
+        self.rfft = rfft
         self.ifft = ifft
         self.irfft = irfft
         self.sanity_checks = type_checks
@@ -42,6 +43,10 @@ class FFT:
             if not inverse:
                 raise RuntimeError('C2R mode can only be done with an inverse FFT.')
 
+        if direction == 'R2C':
+            if inverse:
+                raise RuntimeError('R2C mode can only be done with a FFT.')
+
         self.sanity_checks(x)
 
         if direction == 'C2R':
@@ -51,6 +56,8 @@ class FFT:
                 output = self.ifft(x)
             else:
                 output = self.fft(x)
+        elif direction == 'R2C':
+            output = self.rfft(x)
 
         return output
 

--- a/kymatio/backend/base_backend.py
+++ b/kymatio/backend/base_backend.py
@@ -1,12 +1,14 @@
 
 
 class FFT:
-    def __init__(self, fft, rfft, ifft, irfft, type_checks):
+    def __init__(self, fft, rfft, ifft, irfft, type_checks, real_check, complex_check):
         self.fft = fft
         self.rfft = rfft
         self.ifft = ifft
         self.irfft = irfft
         self.sanity_checks = type_checks
+        self.real_check = real_check
+        self.complex_check = complex_check
 
     def fft_forward(self, x, direction='C2C', inverse=False):
         """Interface with FFT routines for any dimensional signals and any backend signals.
@@ -50,13 +52,16 @@ class FFT:
         self.sanity_checks(x)
 
         if direction == 'C2R':
+            self.complex_check(x)
             output = self.irfft(x)
         elif direction == 'C2C':
+            self.complex_check(x)
             if inverse:
                 output = self.ifft(x)
             else:
                 output = self.fft(x)
         elif direction == 'R2C':
+            self.real_check(x)
             output = self.rfft(x)
 
         return output

--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -68,19 +68,3 @@ def cdgmm(A, B, inplace=False):
         return np.multiply(A, B, out=A)
     else:
         return A * B
-
-
-def real(x):
-    """Real part of complex tensor
-    Takes the real part of a complex tensor, where the last axis corresponds
-    to the real and imaginary parts.
-    Parameters
-    ----------
-    x : tensor
-        A complex tensor (that is, whose last dimension is equal to 2).
-    Returns
-    -------
-    x_real : tensor
-        The tensor x[..., 0] which is interpreted as the real part of x.
-    """
-    return np.real(x)

--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -4,6 +4,14 @@ def input_checks(x):
     if x is None:
         raise TypeError('The input should be not empty.')
 
+def complex_check(x):
+    if not _is_complex(x):
+        raise TypeError('The input should be complex.')
+
+def real_check(x):
+    if not _is_real(x):
+        raise TypeError('The input should be real.')
+
 
 def modulus(x):
     """

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -3,6 +3,15 @@ import numpy as np
 
 
 
+
+def complex_check(x):
+    if not _is_complex(x):
+        raise TypeError('The input should be complex.')
+
+def real_check(x):
+    if not _is_real(x):
+        raise TypeError('The input should be real.')
+
 def _is_complex(x):
     return (x.dtype == np.complex64) or (x.dtype == np.complex128)
 
@@ -67,8 +76,7 @@ def cdgmm(A, B, inplace=False):
 
 
 def sanity_check(x):
-    if not _is_complex(x):
-        raise TypeError('The input should be complex.')
-
+    complex_check(x)    
+    
     if not x.is_contiguous():
         raise RuntimeError('Tensors must be contiguous.')

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -32,22 +32,6 @@ class Modulus():
         return norm
 
 
-def real(x):
-    """Real part of complex tensor
-    Takes the real part of a complex tensor, where the last axis corresponds
-    to the real and imaginary parts.
-    Parameters
-    ----------
-    x : tensor
-        A complex tensor (that is, whose last dimension is equal to 2).
-    Returns
-    -------
-    x_real : tensor
-        The tensor x[..., 0] which is interpreted as the real part of x.
-    """
-    return tf.math.real(x)
-
-
 def concatenate(arrays, dim):
     return tf.stack(arrays, axis=dim)
 

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -29,7 +29,7 @@ class Modulus():
     """
     def __call__(self, x):
         norm = tf.abs(x)
-        return tf.cast(norm, tf.complex64)
+        return norm
 
 
 def real(x):

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -186,7 +186,6 @@ def cdgmm(A, B, inplace=False):
             raise RuntimeError('Tensors must be contiguous.')
 
     type_checks(A)
-
     if A.shape[-len(B.shape):-1] != B.shape[:-1]:
         raise RuntimeError('The filters are not compatible for multiplication.')
 

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -189,7 +189,7 @@ def cdgmm(A, B, inplace=False):
     if A.shape[-len(B.shape):-1] != B.shape[:-1]:
         raise RuntimeError('The filters are not compatible for multiplication.')
 
-    if A.dtype is not B.dtype or type(A) is not type(B):
+    if A.dtype is not B.dtype:
         raise TypeError('Input and filter must be of the same dtype.')
 
     if B.device.type == 'cuda':

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -190,7 +190,7 @@ def cdgmm(A, B, inplace=False):
     if A.shape[-len(B.shape):-1] != B.shape[:-1]:
         raise RuntimeError('The filters are not compatible for multiplication.')
 
-    if A.dtype is not B.dtype:
+    if A.dtype is not B.dtype or type(A) is not type(B):
         raise TypeError('Input and filter must be of the same dtype.')
 
     if B.device.type == 'cuda':

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -131,13 +131,14 @@ class Modulus():
             contains the complex modulus of x, while output[..., 1] = 0.
     """
     def __call__(self, x):
-        type_checks_modulus(x)
+        type_checks_complex(x)
         norm = modulus(x)
         return norm
 
-def type_checks_modulus(x):
+def type_checks_complex(x):
     if not _is_complex(x):
         raise TypeError('The input should be complex (i.e. last dimension is 2).')
+
     if not x.is_contiguous():
         raise RuntimeError('Tensors must be contiguous.')
 
@@ -179,7 +180,7 @@ def cdgmm(A, B, inplace=False):
 
     """
     if not _is_real(B):
-        type_checks(B)
+        type_checks_complex(B)
     else:
         if not B.is_contiguous():
             raise RuntimeError('Tensors must be contiguous.')

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -42,7 +42,6 @@ class ModulusStable(Function):
         to the input in a stable fashion (so gradent of the modulus at zero is
         zero).
     """
-
     @staticmethod
     def forward(ctx, x):
         """Forward pass of the modulus.
@@ -132,16 +131,17 @@ class Modulus():
             contains the complex modulus of x, while output[..., 1] = 0.
     """
     def __call__(self, x):
-        type_checks(x)
-
-        norm = torch.zeros_like(x)
-        norm[..., 0] = modulus(x)
+        type_checks_modulus(x)
+        norm = modulus(x)
         return norm
 
-def type_checks(x):
+def type_checks_modulus(x):
     if not _is_complex(x):
         raise TypeError('The input should be complex (i.e. last dimension is 2).')
+    if not x.is_contiguous():
+        raise RuntimeError('Tensors must be contiguous.')
 
+def type_checks(x):
     if not x.is_contiguous():
         raise RuntimeError('Tensors must be contiguous.')
 
@@ -186,6 +186,7 @@ def cdgmm(A, B, inplace=False):
 
     type_checks(A)
 
+    print(A.shape, B.shape)
     if A.shape[-len(B.shape):-1] != B.shape[:-1]:
         raise RuntimeError('The filters are not compatible for multiplication.')
 

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -139,8 +139,7 @@ def type_checks_complex(x):
     if not _is_complex(x):
         raise TypeError('The input should be complex (i.e. last dimension is 2).')
 
-    if not x.is_contiguous():
-        raise RuntimeError('Tensors must be contiguous.')
+    type_checks(x)
 
 def type_checks(x):
     if not x.is_contiguous():

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -7,8 +7,11 @@ def input_checks(x):
     if x is None:
         raise TypeError('The input should be not empty.')
 
-    if not x.is_contiguous():
-        raise RuntimeError('The input must be contiguous.')
+    type_checks(x)
+
+def complex_check(x):
+    if not _is_complex(x):
+        raise TypeError('The input should be complex (i.e. last dimension is 2).')
 
 def _is_complex(x):
     return x.shape[-1] == 2
@@ -136,9 +139,7 @@ class Modulus():
         return norm
 
 def type_checks_complex(x):
-    if not _is_complex(x):
-        raise TypeError('The input should be complex (i.e. last dimension is 2).')
-
+    complex_check(x)
     type_checks(x)
 
 def type_checks(x):

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -186,7 +186,6 @@ def cdgmm(A, B, inplace=False):
 
     type_checks(A)
 
-    print(A.shape, B.shape)
     if A.shape[-len(B.shape):-1] != B.shape[:-1]:
         raise RuntimeError('The filters are not compatible for multiplication.')
 

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -224,22 +224,3 @@ def cdgmm(A, B, inplace=False):
 
 def concatenate(arrays, dim):
     return torch.stack(arrays, dim=dim)
-
-
-def real(x):
-    """Real part of complex tensor
-
-    Takes the real part of a complex tensor, where the last axis corresponds
-    to the real and imaginary parts.
-
-    Parameters
-    ----------
-    x : tensor
-        A complex tensor (that is, whose last dimension is equal to 2).
-
-    Returns
-    -------
-    x_real : tensor
-        The tensor x[..., 0] which is interpreted as the real part of x.
-    """
-    return x[..., 0]

--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -92,7 +92,7 @@ def concatenate(arrays):
 
 
 backend = namedtuple('backend',
-                     ['name', 'modulus_complex', 'subsample_fourier', 
+                     ['name', 'modulus', 'subsample_fourier', 
                       'unpad', 'fft', 'concatenate', 'cdgmm'])
 backend.name = 'numpy'
 backend.modulus = modulus

--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -5,7 +5,7 @@ import numpy as np
 
 BACKEND_NAME = 'numpy'
 
-from ...backend.numpy_backend import modulus, cdgmm, real
+from ...backend.numpy_backend import modulus, cdgmm
 from ...backend.base_backend import FFT
 
 
@@ -92,12 +92,11 @@ def concatenate(arrays):
 
 
 backend = namedtuple('backend',
-                     ['name', 'modulus_complex', 'subsample_fourier', 'real',
+                     ['name', 'modulus_complex', 'subsample_fourier', 
                       'unpad', 'fft', 'concatenate', 'cdgmm'])
 backend.name = 'numpy'
 backend.modulus = modulus
 backend.subsample_fourier = subsample_fourier
-backend.real = real
 backend.unpad = unpad
 backend.pad = pad
 backend.cdgmm = cdgmm

--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -5,7 +5,7 @@ import numpy as np
 
 BACKEND_NAME = 'numpy'
 
-from ...backend.numpy_backend import modulus, cdgmm
+from ...backend.numpy_backend import modulus, cdgmm, complex_check, real_check
 from ...backend.base_backend import FFT
 
 
@@ -104,5 +104,5 @@ backend.fft = FFT(lambda x:scipy.fft.fft(x),
                   lambda x:scipy.fft.fft(x),
                   lambda x:scipy.fft.ifft(x),
                   lambda x:np.real(scipy.fft.ifft(x)),
-                  lambda x:None)
+                  lambda x:None, real_check, complex_check)
 backend.concatenate = concatenate

--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -35,7 +35,7 @@ def subsample_fourier(x, k):
     return res
 
 
-def pad_1d(x, pad_left, pad_right, mode='constant', value=0.):
+def pad(x, pad_left, pad_right, mode='reflect', value=0.):
     """Pad real 1D tensors
     1D implementation of the padding function for real PyTorch tensors.
     Parameters
@@ -57,38 +57,14 @@ def pad_1d(x, pad_left, pad_right, mode='constant', value=0.):
         0.
     Returns
     -------
-    res : tensor
+    output : tensor
         The tensor passed along the third dimension.
     """
     if (pad_left >= x.shape[-1]) or (pad_right >= x.shape[-1]):
         if mode == 'reflect':
             raise ValueError('Indefinite padding size (larger than tensor).')
 
-    res = np.pad(x, ((0, 0), (0, 0), (pad_left, pad_right),), mode=mode)
-    return res
-
-
-def pad(x, pad_left=0, pad_right=0):
-    """Pad real 1D tensors and map to complex
-    Padding which allows to simultaneously pad in a reflection fashion and map
-    to complex if necessary.
-    Parameters
-    ----------
-    x : tensor
-        Three-dimensional input tensor with the third axis being the one to
-        be padded.
-    pad_left : int
-        Amount to add on the left of the tensor (at the beginning of the
-        temporal axis).
-    pad_right : int
-        amount to add on the right of the tensor (at the end of the temporal
-        axis).
-    Returns
-    -------
-    output : tensor
-        A padded signal.
-    """
-    output = pad_1d(x, pad_left, pad_right, mode='reflect')
+    output = np.pad(x, ((0, 0), (0, 0), (pad_left, pad_right),), mode=mode)
     return output
 
 
@@ -111,8 +87,6 @@ def unpad(x, i0, i1):
     return x[..., i0:i1]
 
 
-
-
 def concatenate(arrays):
     return np.stack(arrays, axis=-2)
 
@@ -121,15 +95,15 @@ backend = namedtuple('backend',
                      ['name', 'modulus_complex', 'subsample_fourier', 'real',
                       'unpad', 'fft', 'concatenate', 'cdgmm'])
 backend.name = 'numpy'
-backend.modulus_complex = modulus
+backend.modulus = modulus
 backend.subsample_fourier = subsample_fourier
 backend.real = real
 backend.unpad = unpad
 backend.pad = pad
-backend.pad_1d = pad_1d
 backend.cdgmm = cdgmm
-backend.fft = FFT(lambda x:scipy.fftpack.fft(x),
-                  lambda x:scipy.fftpack.ifft(x),
-                  lambda x:np.real(scipy.fftpack.ifft(x)),
+backend.fft = FFT(lambda x:scipy.fft.fft(x),
+                  lambda x:scipy.fft.fft(x),
+                  lambda x:scipy.fft.ifft(x),
+                  lambda x:np.real(scipy.fft.ifft(x)),
                   lambda x:None)
 backend.concatenate = concatenate

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 BACKEND_NAME = 'tensorflow'
 
 
-from ...backend.tensorflow_backend import Modulus, real, concatenate, cdgmm
+from ...backend.tensorflow_backend import Modulus, concatenate, cdgmm
 from ...backend.base_backend import FFT
 
 def subsample_fourier(x, k):
@@ -90,11 +90,10 @@ def unpad(x, i0, i1):
 
 
 
-backend = namedtuple('backend', ['name', 'modulus_complex', 'subsample_fourier', 'real', 'unpad', 'fft', 'concatenate'])
+backend = namedtuple('backend', ['name', 'modulus_complex', 'subsample_fourier', 'unpad', 'fft', 'concatenate'])
 backend.name = 'tensorflow'
 backend.modulus = Modulus()
 backend.subsample_fourier = subsample_fourier
-backend.real = real
 backend.unpad = unpad
 backend.cdgmm = cdgmm
 backend.pad = pad

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -90,7 +90,7 @@ def unpad(x, i0, i1):
 
 
 
-backend = namedtuple('backend', ['name', 'modulus_complex', 'subsample_fourier', 'unpad', 'fft', 'concatenate'])
+backend = namedtuple('backend', ['name', 'modulus', 'subsample_fourier', 'unpad', 'fft', 'concatenate'])
 backend.name = 'tensorflow'
 backend.modulus = Modulus()
 backend.subsample_fourier = subsample_fourier

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -36,7 +36,7 @@ def subsample_fourier(x, k):
     return tf.reduce_mean(y, axis=(1,))
 
 
-def pad(x, pad_left=0, pad_right=0, mode='reflect', value=0.):
+def pad(x, pad_left, pad_right, mode='reflect', value=0.):
     """Pad real 1D tensors
     1D implementation of the padding function for real PyTorch tensors.
     Parameters

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 BACKEND_NAME = 'tensorflow'
 
 
-from ...backend.tensorflow_backend import Modulus, concatenate, cdgmm
+from ...backend.tensorflow_backend import Modulus, concatenate, cdgmm, complex_check, real_check
 from ...backend.base_backend import FFT
 
 def subsample_fourier(x, k):
@@ -101,5 +101,5 @@ backend.fft = FFT(lambda x: tf.signal.fft(x, name='fft1d'),
                   lambda x: tf.signal.fft(tf.cast(x, tf.complex64), name='rfft1d'),
                   lambda x: tf.signal.ifft(x, name='ifft1d'),
                   lambda x: tf.math.real(tf.signal.ifft(x, name='irfft1d')),
-                  lambda x: None)
+                  lambda x: None, real_check, complex_check)
 backend.concatenate = lambda x: concatenate(x, -2)

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -36,7 +36,7 @@ def subsample_fourier(x, k):
     return tf.reduce_mean(y, axis=(1,))
 
 
-def pad_1d(x, pad_left, pad_right, mode='constant', value=0.):
+def pad(x, pad_left=0, pad_right=0, mode='reflect', value=0.):
     """Pad real 1D tensors
     1D implementation of the padding function for real PyTorch tensors.
     Parameters
@@ -67,31 +67,7 @@ def pad_1d(x, pad_left, pad_right, mode='constant', value=0.):
 
     paddings = [[0, 0]] * len(x.shape[:-1])
     paddings += [[pad_left, pad_right],]
-    return tf.cast(tf.pad(x, paddings, mode="REFLECT"), tf.complex64)
-
-
-def pad(x, pad_left=0, pad_right=0):
-    """Pad real 1D tensors and map to complex
-    Padding which allows to simultaneously pad in a reflection fashion and map
-    to complex if necessary.
-    Parameters
-    ----------
-    x : tensor
-        Three-dimensional input tensor with the third axis being the one to
-        be padded.
-    pad_left : int
-        Amount to add on the left of the tensor (at the beginning of the
-        temporal axis).
-    pad_right : int
-        amount to add on the right of the tensor (at the end of the temporal
-        axis).
-    Returns
-    -------
-    output : tensor
-        A padded signal
-    """
-    output = pad_1d(x, pad_left, pad_right, mode='reflect')
-    return output
+    return tf.pad(x, paddings, mode="REFLECT")
 
 
 def unpad(x, i0, i1):
@@ -116,14 +92,14 @@ def unpad(x, i0, i1):
 
 backend = namedtuple('backend', ['name', 'modulus_complex', 'subsample_fourier', 'real', 'unpad', 'fft', 'concatenate'])
 backend.name = 'tensorflow'
-backend.modulus_complex = Modulus()
+backend.modulus = Modulus()
 backend.subsample_fourier = subsample_fourier
 backend.real = real
 backend.unpad = unpad
 backend.cdgmm = cdgmm
 backend.pad = pad
-backend.pad_1d = pad_1d
 backend.fft = FFT(lambda x: tf.signal.fft(x, name='fft1d'),
+                  lambda x: tf.signal.fft(tf.cast(x, tf.complex64), name='rfft1d'),
                   lambda x: tf.signal.ifft(x, name='ifft1d'),
                   lambda x: tf.math.real(tf.signal.ifft(x, name='irfft1d')),
                   lambda x: None)

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -10,6 +10,7 @@ BACKEND_NAME = 'torch'
 from ...backend.torch_backend import _is_complex, Modulus, concatenate, type_checks, cdgmm, real
 from ...backend.base_backend import FFT
 
+
 def subsample_fourier(x, k):
     """Subsampling in the Fourier domain
 
@@ -40,7 +41,7 @@ def subsample_fourier(x, k):
     res = x.view(x.shape[:-2] + (k, N // k, 2)).mean(dim=-3)
     return res
 
-def pad_1d(x, pad_left, pad_right, mode='constant', value=0.):
+def pad(x, pad_left, pad_right, mode='reflect', value=0.):
     """Pad real 1D tensors
 
     1D implementation of the padding function for real PyTorch tensors.
@@ -76,39 +77,6 @@ def pad_1d(x, pad_left, pad_right, mode='constant', value=0.):
                 mode=mode, value=value).squeeze(2)
     return res
 
-def pad(x, pad_left=0, pad_right=0, to_complex=True):
-    """Pad real 1D tensors and map to complex
-
-    Padding which allows to simultaneously pad in a reflection fashion and map
-    to complex if necessary.
-
-    Parameters
-    ----------
-    x : tensor
-        Three-dimensional input tensor with the third axis being the one to
-        be padded.
-    pad_left : int
-        Amount to add on the left of the tensor (at the beginning of the
-        temporal axis).
-    pad_right : int
-        amount to add on the right of the tensor (at the end of the temporal
-        axis).
-    to_complex : boolean, optional
-        Whether to map the resulting padded tensor to a complex type (seen
-        as a real number). Defaults to True.
-
-    Returns
-    -------
-    output : tensor
-        A padded signal, possibly transformed into a four-dimensional tensor
-        with the last axis of size 2 if to_complex is True (this axis
-        corresponds to the real and imaginary parts).
-    """
-    output = pad_1d(x, pad_left, pad_right, mode='reflect')
-    if to_complex:
-        output = torch.stack((output, torch.zeros_like(output)), dim=-1)
-    return output
-
 def unpad(x, i0, i1):
     """Unpad real 1D tensor
 
@@ -139,12 +107,11 @@ fft = FFT(lambda x: torch.fft(x, 1, normalized=False),
 
 backend = namedtuple('backend', ['name', 'modulus_complex', 'subsample_fourier', 'real', 'unpad', 'fft', 'concatenate'])
 backend.name = 'torch'
-backend.modulus_complex = Modulus()
+backend.modulus = Modulus()
 backend.subsample_fourier = subsample_fourier
 backend.real = real
 backend.unpad = unpad
 backend.cdgmm = cdgmm
 backend.pad = pad
-backend.pad_1d = pad_1d
 backend.fft = fft
 backend.concatenate = lambda x: concatenate(x, -2)

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 BACKEND_NAME = 'torch'
 
-from ...backend.torch_backend import _is_complex, Modulus, concatenate, type_checks, cdgmm, real
+from ...backend.torch_backend import _is_complex, Modulus, concatenate, type_checks, cdgmm
 from ...backend.base_backend import FFT
 
 
@@ -106,11 +106,10 @@ fft = FFT(lambda x: torch.fft(x, 1, normalized=False),
     type_checks)
 
 
-backend = namedtuple('backend', ['name', 'modulus_complex', 'subsample_fourier', 'real', 'unpad', 'fft', 'concatenate'])
+backend = namedtuple('backend', ['name', 'modulus_complex', 'subsample_fourier', 'unpad', 'fft', 'concatenate'])
 backend.name = 'torch'
 backend.modulus = Modulus()
 backend.subsample_fourier = subsample_fourier
-backend.real = real
 backend.unpad = unpad
 backend.cdgmm = cdgmm
 backend.pad = pad

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -100,6 +100,7 @@ def unpad(x, i0, i1):
 
 
 fft = FFT(lambda x: torch.fft(x, 1, normalized=False),
+    lambda x: torch.rfft(x, 1, normalized=False),
     lambda x: torch.ifft(x, 1, normalized=False),
     lambda x: torch.irfft(x, 1, normalized=False, onesided=False),
     type_checks)

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -106,7 +106,7 @@ fft = FFT(lambda x: torch.fft(x, 1, normalized=False),
     type_checks)
 
 
-backend = namedtuple('backend', ['name', 'modulus_complex', 'subsample_fourier', 'unpad', 'fft', 'concatenate'])
+backend = namedtuple('backend', ['name', 'modulus', 'subsample_fourier', 'unpad', 'fft', 'concatenate'])
 backend.name = 'torch'
 backend.modulus = Modulus()
 backend.subsample_fourier = subsample_fourier

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -100,7 +100,7 @@ def unpad(x, i0, i1):
 
 
 fft = FFT(lambda x: torch.fft(x, 1, normalized=False),
-    lambda x: torch.rfft(x, 1, normalized=False),
+    lambda x: torch.rfft(x, 1, normalized=False, onesided=False),
     lambda x: torch.ifft(x, 1, normalized=False),
     lambda x: torch.irfft(x, 1, normalized=False, onesided=False),
     type_checks)

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 BACKEND_NAME = 'torch'
 
-from ...backend.torch_backend import _is_complex, Modulus, concatenate, type_checks, cdgmm
+from ...backend.torch_backend import _is_complex, Modulus, concatenate, type_checks, cdgmm, complex_check
 from ...backend.base_backend import FFT
 
 
@@ -103,7 +103,7 @@ fft = FFT(lambda x: torch.fft(x, 1, normalized=False),
     lambda x: torch.rfft(x, 1, normalized=False, onesided=False),
     lambda x: torch.ifft(x, 1, normalized=False),
     lambda x: torch.irfft(x, 1, normalized=False, onesided=False),
-    type_checks)
+    type_checks, lambda x: None, complex_check)
 
 
 backend = namedtuple('backend', ['name', 'modulus', 'subsample_fourier', 'unpad', 'fft', 'concatenate'])

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -59,7 +59,6 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     """
     subsample_fourier = backend.subsample_fourier
     modulus = backend.modulus
-    real = backend.real
     fft = backend.fft
     cdgmm = backend.cdgmm
     concatenate = backend.concatenate

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -75,9 +75,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     U_0 = pad(x, pad_left=pad_left, pad_right=pad_right)
 
     # compute the Fourier transform
-    print(U_0.shape)
     U_0_hat = fft(U_0, 'R2C')
-    print(U_0_hat.shape)
 
     # Get S0
     k0 = max(J - oversampling, 0)

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -75,7 +75,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     U_0 = pad(x, pad_left=pad_left, pad_right=pad_right)
 
     # compute the Fourier transform
-    U_0_hat = fft(U_0, 'C2C')
+    U_0_hat = fft(U_0, 'R2C')
 
     # Get S0
     k0 = max(J - oversampling, 0)
@@ -110,7 +110,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         U_1_m = modulus_complex(U_1_c)
 
         if average or max_order > 1:
-            U_1_hat = fft(U_1_m, 'C2C')
+            U_1_hat = fft(U_1_m, 'R2C')
 
         if average:
             # Convolve with phi_J
@@ -122,10 +122,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
 
             S_1 = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
         else:
-            # just take the real value and unpad
-            U_1_r = real(U_1_m)
-
-            S_1 = unpad(U_1_r, ind_start[k1], ind_end[k1])
+            S_1 = unpad(U_1_m, ind_start[k1], ind_end[k1])
 
         out_S_1.append({'coef': S_1,
                         'j': (j1,),
@@ -150,7 +147,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
                     U_2_m = modulus_complex(U_2_c)
 
                     if average:
-                        U_2_hat = fft(U_2_m, 'C2C')
+                        U_2_hat = fft(U_2_m, 'R2C')
 
                         # Convolve with phi_J
                         k2_J = max(J - k2 - k1 - oversampling, 0)
@@ -161,9 +158,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
 
                         S_2 = unpad(S_2_r, ind_start[k1 + k2 + k2_J], ind_end[k1 + k2 + k2_J])
                     else:
-                        # just take the real value and unpad
-                        U_2_r = real(U_2_m)
-                        S_2 = unpad(U_2_r, ind_start[k1 + k2], ind_end[k1 + k2])
+                        S_2 = unpad(U_2_m, ind_start[k1 + k2], ind_end[k1 + k2])
 
                     out_S_2.append({'coef': S_2,
                                     'j': (j1, j2),

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -58,7 +58,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
 
     """
     subsample_fourier = backend.subsample_fourier
-    modulus_complex = backend.modulus_complex
+    modulus = backend.modulus
     real = backend.real
     fft = backend.fft
     cdgmm = backend.cdgmm
@@ -75,7 +75,9 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     U_0 = pad(x, pad_left=pad_left, pad_right=pad_right)
 
     # compute the Fourier transform
+    print(U_0.shape)
     U_0_hat = fft(U_0, 'R2C')
+    print(U_0_hat.shape)
 
     # Get S0
     k0 = max(J - oversampling, 0)
@@ -107,7 +109,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         U_1_c = fft(U_1_hat, 'C2C', inverse=True)
 
         # Take the modulus
-        U_1_m = modulus_complex(U_1_c)
+        U_1_m = modulus(U_1_c)
 
         if average or max_order > 1:
             U_1_hat = fft(U_1_m, 'R2C')
@@ -144,7 +146,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
                     # take the modulus
                     U_2_c = fft(U_2_hat, 'C2C', inverse=True)
 
-                    U_2_m = modulus_complex(U_2_c)
+                    U_2_m = modulus(U_2_c)
 
                     if average:
                         U_2_hat = fft(U_2_m, 'R2C')

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -95,6 +95,7 @@ backend.cdgmm = cdgmm
 backend.modulus = modulus
 backend.subsample_fourier = SubsampleFourier()
 backend.fft = FFT(lambda x:np.fft.fft2(x),
+                  lambda x:np.fft.fft2(x),
                   lambda x:np.fft.ifft2(x),
                   lambda x:np.real(np.fft.ifft2(x)),
                   lambda x:None)

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -7,7 +7,7 @@ import scipy.fft
 BACKEND_NAME = 'numpy'
 
 
-from ...backend.numpy_backend import modulus, cdgmm
+from ...backend.numpy_backend import modulus, cdgmm, complex_check, real_check
 from ...backend.base_backend import FFT
 
 
@@ -99,7 +99,7 @@ backend.fft = FFT(lambda x:scipy.fft.fft2(x),
                   lambda x:scipy.fft.fft2(x),
                   lambda x:scipy.fft.ifft2(x),
                   lambda x:np.real(scipy.fft.ifft2(x)),
-                  lambda x:None)
+                  lambda x:None, real_check, complex_check)
 backend.Pad = Pad
 backend.unpad = unpad
 backend.concatenate = concatenate

--- a/kymatio/scattering2d/backend/numpy_backend.py
+++ b/kymatio/scattering2d/backend/numpy_backend.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from collections import namedtuple
+import scipy.fft
 
 BACKEND_NAME = 'numpy'
 
@@ -94,10 +95,10 @@ backend.name = 'numpy'
 backend.cdgmm = cdgmm
 backend.modulus = modulus
 backend.subsample_fourier = SubsampleFourier()
-backend.fft = FFT(lambda x:np.fft.fft2(x),
-                  lambda x:np.fft.fft2(x),
-                  lambda x:np.fft.ifft2(x),
-                  lambda x:np.real(np.fft.ifft2(x)),
+backend.fft = FFT(lambda x:scipy.fft.fft2(x),
+                  lambda x:scipy.fft.fft2(x),
+                  lambda x:scipy.fft.ifft2(x),
+                  lambda x:np.real(scipy.fft.ifft2(x)),
                   lambda x:None)
 backend.Pad = Pad
 backend.unpad = unpad

--- a/kymatio/scattering2d/backend/tensorflow_backend.py
+++ b/kymatio/scattering2d/backend/tensorflow_backend.py
@@ -32,7 +32,7 @@ class Pad(object):
         else:
             paddings = [[0, 0]] * len(x.shape[:-2])
             paddings += [[self.pad_size[0], self.pad_size[1]], [self.pad_size[2], self.pad_size[3]]]
-            return tf.cast(tf.pad(x, paddings, mode="REFLECT"), tf.complex64)
+            return tf.pad(x, paddings, mode="REFLECT")
 
 def unpad(in_):
     """
@@ -83,6 +83,7 @@ backend.cdgmm = cdgmm
 backend.modulus = Modulus()
 backend.subsample_fourier = SubsampleFourier()
 backend.fft = FFT(lambda x: tf.signal.fft2d(x, name='fft2d'),
+                  lambda x: tf.signal.fft2d(tf.cast(x, tf.complex64), name='rfft2d'),
                   lambda x: tf.signal.ifft2d(x, name='ifft2d'),
                   lambda x: tf.math.real(tf.signal.ifft2d(x, name='irfft2d')),
                   lambda x: None)

--- a/kymatio/scattering2d/backend/tensorflow_backend.py
+++ b/kymatio/scattering2d/backend/tensorflow_backend.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 BACKEND_NAME = 'tensorflow'
 
 
-from ...backend.tensorflow_backend import Modulus, cdgmm, concatenate
+from ...backend.tensorflow_backend import Modulus, cdgmm, concatenate, complex_check, real_check
 from ...backend.base_backend import FFT
 
 class Pad(object):
@@ -86,7 +86,7 @@ backend.fft = FFT(lambda x: tf.signal.fft2d(x, name='fft2d'),
                   lambda x: tf.signal.fft2d(tf.cast(x, tf.complex64), name='rfft2d'),
                   lambda x: tf.signal.ifft2d(x, name='ifft2d'),
                   lambda x: tf.math.real(tf.signal.ifft2d(x, name='irfft2d')),
-                  lambda x: None)
+                  lambda x: None, real_check, complex_check)
 backend.Pad = Pad
 backend.unpad = unpad
 backend.concatenate = lambda x: concatenate(x, -3)

--- a/kymatio/scattering2d/backend/torch_backend.py
+++ b/kymatio/scattering2d/backend/torch_backend.py
@@ -81,9 +81,7 @@ class Pad(object):
             if self.pad_size[2] == self.input_size[1]:
                 x = torch.cat([x[:, :, :, 1].unsqueeze(3), x, x[:, :, :, x.shape[3] - 2].unsqueeze(3)], 3)
 
-        output = x.new_zeros(x.shape + (2,))
-        output[..., 0] = x
-        output = output.reshape(batch_shape + output.shape[-3:])
+        output = x.reshape(batch_shape + x.shape[-2:])
         return output
 
 def unpad(in_):
@@ -146,6 +144,7 @@ class SubsampleFourier(object):
 
 
 fft = FFT(lambda x: torch.fft(x, 2, normalized=False),
+          lambda x: torch.rfft(x, 2, normalized=False, onesided=False),
           lambda x: torch.ifft(x, 2, normalized=False),
           lambda x: torch.irfft(x, 2, normalized=False, onesided=False),
           type_checks)

--- a/kymatio/scattering2d/backend/torch_backend.py
+++ b/kymatio/scattering2d/backend/torch_backend.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 BACKEND_NAME = 'torch'
 
-from ...backend.torch_backend import _is_complex, cdgmm, type_checks, Modulus, concatenate
+from ...backend.torch_backend import _is_complex, cdgmm, type_checks, Modulus, concatenate, complex_check
 from ...backend.base_backend import FFT
 
 
@@ -147,7 +147,7 @@ fft = FFT(lambda x: torch.fft(x, 2, normalized=False),
           lambda x: torch.rfft(x, 2, normalized=False, onesided=False),
           lambda x: torch.ifft(x, 2, normalized=False),
           lambda x: torch.irfft(x, 2, normalized=False, onesided=False),
-          type_checks)
+          type_checks, lambda x: None, complex_check)
 
 
 backend = namedtuple('backend', ['name', 'cdgmm', 'modulus', 'subsample_fourier', 'fft', 'Pad', 'unpad', 'concatenate'])

--- a/kymatio/scattering2d/core/scattering2d.py
+++ b/kymatio/scattering2d/core/scattering2d.py
@@ -14,7 +14,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order,
 
     U_r = pad(x)
 
-    U_0_c = fft(U_r, 'C2C')
+    U_0_c = fft(U_r, 'R2C')
 
     # First low pass filter
     U_1_c = cdgmm(U_0_c, phi[0])
@@ -36,7 +36,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order,
             U_1_c = subsample_fourier(U_1_c, k=2 ** j1)
         U_1_c = fft(U_1_c, 'C2C', inverse=True)
         U_1_c = modulus(U_1_c)
-        U_1_c = fft(U_1_c, 'C2C')
+        U_1_c = fft(U_1_c, 'R2C')
 
         # Second low pass filter
         S_1_c = cdgmm(U_1_c, phi[j1])
@@ -62,7 +62,7 @@ def scattering2d(x, pad, unpad, backend, J, L, phi, psi, max_order,
             U_2_c = subsample_fourier(U_2_c, k=2 ** (j2 - j1))
             U_2_c = fft(U_2_c, 'C2C', inverse=True)
             U_2_c = modulus(U_2_c)
-            U_2_c = fft(U_2_c, 'C2C')
+            U_2_c = fft(U_2_c, 'R2C')
 
             # Third low pass filter
             S_2_c = cdgmm(U_2_c, phi[j2])

--- a/kymatio/scattering2d/utils.py
+++ b/kymatio/scattering2d/utils.py
@@ -22,8 +22,3 @@ def compute_padding(M, N, J):
     N_padded = ((N + 2 ** J) // 2 ** J + 1) * 2 ** J
 
     return M_padded, N_padded
-
-def fft2(x):
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', FutureWarning)
-        return scipy.fftpack.fft2(x)

--- a/kymatio/scattering3d/backend/numpy_backend.py
+++ b/kymatio/scattering3d/backend/numpy_backend.py
@@ -5,27 +5,11 @@ from scipy.fftpack import fftn, ifftn
 
 BACKEND_NAME = 'numpy'
 
+from ...backend.numpy_backend import modulus, cdgmm
+from ...backend.base_backend import FFT
 
 def _iscomplex(x):
     return x.dtype == np.complex64 or x.dtype == np.complex128
-
-
-def complex_modulus(input_array):
-    """Computes complex modulus.
-
-        Parameters
-        ----------
-        input_array : tensor
-            Input tensor whose complex modulus is to be calculated.
-        Returns
-        -------
-        modulus : tensor
-            Tensor the same size as input_array. modulus[..., 0] holds the
-            result of the complex modulus, modulus[..., 1] = 0.
-
-    """
-
-    return np.abs(input_array)
 
 
 def modulus_rotation(x, module=None):
@@ -80,92 +64,6 @@ def compute_integrals(input_array, integral_powers):
     return integrals
 
 
-def fft(x, direction='C2C', inverse=False):
-    """
-        Interface with torch FFT routines for 2D signals.
-
-        Example
-        -------
-        x = torch.randn(128, 32, 32, 2)
-        x_fft = fft(x, inverse=True)
-
-        Parameters
-        ----------
-        input : tensor
-            complex input for the FFT
-        direction : string
-            'C2R' for complex to real, 'C2C' for complex to complex
-        inverse : bool
-            True for computing the inverse FFT.
-            NB : if direction is equal to 'C2R', then an error is raised.
-
-    """
-    if direction == 'C2R':
-        if not inverse:
-            raise RuntimeError('C2R mode can only be done with an inverse FFT.')
-
-    if direction == 'C2R':
-        output = np.real(ifftn(x, axes=(-3, -2, -1)))
-    elif direction == 'C2C':
-        if inverse:
-            output = ifftn(x, axes=(-3, -2, -1))
-        else:
-            output = fftn(x, axes=(-3, -2, -1))
-
-    return output
-
-
-def cdgmm3d(A, B, inplace=False):
-    """Complex pointwise multiplication.
-
-        Complex pointwise multiplication between (batched) tensor A and tensor B.
-
-        Parameters
-        ----------
-        A : torch tensor
-            Complex torch tensor.
-        B : torch tensor
-            Complex of the same size as A.
-        inplace : boolean, optional
-            If set True, all the operations are performed inplace.
-
-        Raises
-        ------
-        RuntimeError
-            In the event that the tensors are not compatibile for multiplication
-            (i.e. the final four dimensions of A do not match with the dimensions
-            of B), or in the event that B is not complex, or in the event that the
-            type of A and B are not the same.
-        TypeError
-            In the event that x is not complex i.e. does not have a final dimension
-            of 2, or in the event that both tensors are not on the same device.
-
-        Returns
-        -------
-        output : torch tensor
-            Torch tensor of the same size as A containing the result of the
-            elementwise complex multiplication of A with B.
-    """
-
-    if A.shape[-3:] != B.shape[-3:]:
-        raise RuntimeError('The tensors are not compatible for multiplication.')
-
-    if not _iscomplex(A) or not _iscomplex(B):
-        raise TypeError('The input, filter and output should be complex.')
-
-    if B.ndim != 3:
-        raise RuntimeError('The second tensor must be simply a complex array.')
-
-    if type(A) is not type(B):
-        raise RuntimeError('A and B should be same type.')
-
-
-    if inplace:
-        return np.multiply(A, B, out=A)
-    else:
-        return A * B
-
-
 def concatenate(arrays, L):
     S = np.stack(arrays, axis=1)
     S = S.reshape((S.shape[0], S.shape[1] // (L + 1), (L + 1)) + S.shape[2:])
@@ -182,9 +80,13 @@ backend = namedtuple('backend',
                       'concatenate'])
 
 backend.name = 'numpy'
-backend.cdgmm3d = cdgmm3d
-backend.fft = fft
+backend.cdgmm3d = cdgmm
+backend.fft = FFT(lambda x:np.fft.fftn(x),
+                  lambda x:np.fft.fftn(x),
+                  lambda x:np.fft.ifftn(x),
+                  lambda x:np.real(np.fft.ifftn(x)),
+                  lambda x:None)
 backend.concatenate = concatenate
-backend.modulus = complex_modulus
+backend.modulus = modulus
 backend.modulus_rotation = modulus_rotation
 backend.compute_integrals = compute_integrals

--- a/kymatio/scattering3d/backend/numpy_backend.py
+++ b/kymatio/scattering3d/backend/numpy_backend.py
@@ -4,7 +4,7 @@ import scipy.fft
 
 BACKEND_NAME = 'numpy'
 
-from ...backend.numpy_backend import modulus, cdgmm
+from ...backend.numpy_backend import modulus, cdgmm, complex_check, real_check
 from ...backend.base_backend import FFT
 
 
@@ -27,7 +27,7 @@ def modulus_rotation(x, module=None):
             which is covariant to 3D translations and rotations.
     """
     if module is None:
-        module = np.zeros_like(x)
+        module = np.zeros_like(x, np.float64)
     else:
         module = module ** 2
     module += np.abs(x) ** 2
@@ -81,7 +81,7 @@ backend.fft = FFT(lambda x:scipy.fft.fftn(x),
                   lambda x:scipy.fft.fftn(x),
                   lambda x:scipy.fft.ifftn(x),
                   lambda x:np.real(scipy.fft.ifftn(x)),
-                  lambda x:None)
+                  lambda x:None, real_check, complex_check)
 backend.concatenate = concatenate
 backend.modulus = modulus
 backend.modulus_rotation = modulus_rotation

--- a/kymatio/scattering3d/backend/numpy_backend.py
+++ b/kymatio/scattering3d/backend/numpy_backend.py
@@ -8,9 +8,6 @@ BACKEND_NAME = 'numpy'
 from ...backend.numpy_backend import modulus, cdgmm
 from ...backend.base_backend import FFT
 
-def _iscomplex(x):
-    return x.dtype == np.complex64 or x.dtype == np.complex128
-
 
 def modulus_rotation(x, module=None):
     """Used for computing rotation invariant scattering transform coefficents.

--- a/kymatio/scattering3d/backend/numpy_backend.py
+++ b/kymatio/scattering3d/backend/numpy_backend.py
@@ -1,7 +1,6 @@
 import numpy as np
 from collections import namedtuple
-from scipy.fftpack import fftn, ifftn
-
+import scipy.fft
 
 BACKEND_NAME = 'numpy'
 
@@ -78,10 +77,10 @@ backend = namedtuple('backend',
 
 backend.name = 'numpy'
 backend.cdgmm3d = cdgmm
-backend.fft = FFT(lambda x:np.fft.fftn(x),
-                  lambda x:np.fft.fftn(x),
-                  lambda x:np.fft.ifftn(x),
-                  lambda x:np.real(np.fft.ifftn(x)),
+backend.fft = FFT(lambda x:scipy.fft.fftn(x),
+                  lambda x:scipy.fft.fftn(x),
+                  lambda x:scipy.fft.ifftn(x),
+                  lambda x:np.real(scipy.fft.ifftn(x)),
                   lambda x:None)
 backend.concatenate = concatenate
 backend.modulus = modulus

--- a/kymatio/scattering3d/backend/tensorflow_backend.py
+++ b/kymatio/scattering3d/backend/tensorflow_backend.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 BACKEND_NAME = 'tensorflow'
 
-from ...backend.tensorflow_backend import Modulus
+from ...backend.tensorflow_backend import Modulus, complex_check, real_check
 from ...backend.base_backend import FFT
 
 
@@ -112,7 +112,7 @@ backend.fft = FFT(lambda x: tf.signal.fft3d(x, name='fft3d'),
                   lambda x: tf.signal.fft3d(tf.cast(x, tf.complex64), name='rfft3d'),
                   lambda x: tf.signal.ifft3d(x, name='ifft3d'),
                   lambda x: tf.math.real(tf.signal.ifft3d(x, name='irfft3d')),
-                  lambda x: None)
+                  lambda x: None, real_check, complex_check)
 backend.modulus = Modulus()
 backend.modulus_rotation = modulus_rotation
 backend.compute_integrals = compute_integrals

--- a/kymatio/scattering3d/backend/torch_backend.py
+++ b/kymatio/scattering3d/backend/torch_backend.py
@@ -8,24 +8,6 @@ from ...backend.torch_backend import _is_complex, cdgmm, type_checks, Modulus, c
 from ...backend.base_backend import FFT
 
 
-def complex_modulus(input_array):
-    """Computes complex modulus.
-
-        Parameters
-        ----------
-        input_array : tensor
-            Input tensor whose complex modulus is to be calculated.
-        Returns
-        -------
-        modulus : tensor
-            Tensor the same size as input_array. modulus[..., 0] holds the
-            result of the complex modulus.
-
-    """
-    modulus = torch.sqrt((input_array ** 2).sum(-1))
-    return modulus
-
-
 def modulus_rotation(x, module=None):
     """Used for computing rotation invariant scattering transform coefficents.
 

--- a/kymatio/scattering3d/backend/torch_backend.py
+++ b/kymatio/scattering3d/backend/torch_backend.py
@@ -4,7 +4,7 @@ import warnings
 BACKEND_NAME = 'torch'
 from collections import namedtuple
 
-from ...backend.torch_backend import _is_complex, cdgmm, type_checks, Modulus, concatenate
+from ...backend.torch_backend import _is_complex, cdgmm, type_checks, Modulus, concatenate, complex_check
 from ...backend.base_backend import FFT
 
 
@@ -71,7 +71,8 @@ fft = FFT(lambda x: torch.fft(x, 3, normalized=False),
           lambda x: torch.rfft(x, 3, normalized=False, onesided=False),
           lambda x: torch.ifft(x, 3, normalized=False),
           lambda x: torch.irfft(x, 3, normalized=False, onesided=False),
-          type_checks)
+          type_checks, lambda x: None, complex_check)
+
 
 backend = namedtuple('backend',
                      ['name',

--- a/kymatio/scattering3d/core/scattering3d.py
+++ b/kymatio/scattering3d/core/scattering3d.py
@@ -23,7 +23,7 @@ def scattering3d(x, filters, rotation_covariant, L, J, max_order, backend, avera
     modulus_rotation = backend.modulus_rotation
     concatenate = backend.concatenate
 
-    U_0_c = fft(x)
+    U_0_c = fft(x, 'R2C')
 
     s_order_1, s_order_2 = [], []
     for l in range(L + 1):
@@ -33,28 +33,28 @@ def scattering3d(x, filters, rotation_covariant, L, J, max_order, backend, avera
             if rotation_covariant:
                 for m in range(len(filters[l][j_1])):
                     U_1_c = cdgmm3d(U_0_c, filters[l][j_1][m])
-                    U_1_c = fft(U_1_c, inverse=True)
+                    U_1_c = fft(U_1_c, 'C2C', inverse=True)
                     U_1_m = modulus_rotation(U_1_c, U_1_m)
             else:
                 U_1_c = cdgmm3d(U_0_c, filters[l][j_1][0])
-                U_1_c = fft(U_1_c , inverse=True)
+                U_1_c = fft(U_1_c, 'C2C', inverse=True)
                 U_1_m = modulus(U_1_c)
 
             S_1_l = averaging(U_1_m)
             s_order_1_l.append(S_1_l)
 
             if max_order > 1:
-                U_1_c = fft(U_1_m)
+                U_1_c = fft(U_1_m, 'R2C')
                 for j_2 in range(j_1 + 1, J + 1):
                     U_2_m = None
                     if rotation_covariant:
                         for m in range(len(filters[l][j_2])):
                             U_2_c = cdgmm3d(U_1_c, filters[l][j_2][m])
-                            U_2_c = fft(U_2_c, inverse=True)
+                            U_2_c = fft(U_2_c, 'C2C', inverse=True)
                             U_2_m = modulus_rotation(U_2_c, U_2_m)
                     else:
                         U_2_c = cdgmm3d(U_1_c, filters[l][j_2][0])
-                        U_2_c = fft(U_2_c, inverse=True)
+                        U_2_c = fft(U_2_c, 'C2C', inverse=True)
                         U_2_m = modulus(U_2_c)
                     S_2_l = averaging(U_2_m)
                     s_order_2_l.append(S_2_l)

--- a/kymatio/scattering3d/frontend/torch_frontend.py
+++ b/kymatio/scattering3d/frontend/torch_frontend.py
@@ -8,6 +8,40 @@ from .base_frontend import ScatteringBase3D
 
 
 class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
+    """3D Solid Harmonic scattering .
+    This class implements solid harmonic scattering on an input 3D image.
+    For details see https://arxiv.org/abs/1805.00571.
+    Instantiates and initializes a 3d solid harmonic scattering object.
+    Parameters
+    ----------
+    J: int
+        number of scales
+    shape: tuple of int
+        shape (M, N, O) of the input signal
+    L: int, optional
+        Number of l values. Defaults to 3.
+    sigma_0: float, optional
+        Bandwidth of mother wavelet. Defaults to 1.
+    max_order: int, optional
+        The maximum order of scattering coefficients to compute. Must be
+        either 1 or 2. Defaults to 2.
+    rotation_covariant: bool, optional
+        if set to True the first order moduli take the form:
+        $\\sqrt{\\sum_m (x \\star \\psi_{j,l,m})^2)}$
+        if set to False the first order moduli take the form:
+        $x \\star \\psi_{j,l,m}$
+        The second order moduli change analogously
+        Defaut: True
+    method: string, optional
+        specifies the method for obtaining scattering coefficients
+        ("standard","local","integral"). Default: "standard"
+    points: array-like, optional
+        List of locations in which to sample wavelet moduli. Used when
+        method == 'local'
+    integral_powers: array-like
+        List of exponents to the power of which moduli are raised before
+        integration. Used with method == 'standard', method == 'integral'
+    """
     def __init__(self, J, shape, L=3, sigma_0=1, max_order=2, rotation_covariant=True, method='integral', points=None,
                  integral_powers=(0.5, 1., 2.), backend='torch'):
         ScatteringTorch.__init__(self)
@@ -39,6 +73,21 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
         self.register_buffer('tensor_gaussian_filter', self.gaussian_filters)
 
     def scattering(self, input_array):
+        """
+            The forward pass of 3D solid harmonic scattering
+            Parameters
+            ----------
+            input_array: torch tensor
+                input of size (batchsize, M, N, O)
+            Returns
+            -------
+            output: tuple | torch tensor
+                if max_order is 1 it returns a torch tensor with the
+                first order scattering coefficients
+                if max_order is 2 it returns a torch tensor with the
+                first and second order scattering coefficients,
+                concatenated along the feature axis
+            """
         if not torch.is_tensor(input_array):
             raise TypeError(
                 'The input should be a torch.cuda.FloatTensor, '
@@ -61,7 +110,21 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
 
         input_array = input_array.reshape((-1,) + signal_shape)
 
-        S = self.scattering(input_array)
+        x = input_array
+
+        buffer_dict = dict(self.named_buffers())
+        for k in range(len(self.filters)):
+            self.filters[k] = buffer_dict['tensor' + str(k)]
+
+        methods = ['integral']
+        if not self.method in methods:
+            raise ValueError('method must be in {}'.format(methods))
+
+        if self.method == 'integral': \
+                self.averaging = lambda x: self.backend.compute_integrals(x, self.integral_powers)
+
+        S = scattering3d(x, filters=self.filters, rotation_covariant=self.rotation_covariant, L=self.L,
+                            J=self.J, max_order=self.max_order, backend=self.backend, averaging=self.averaging)
         scattering_shape = S.shape[1:]
 
         S = S.reshape(batch_shape + scattering_shape)

--- a/kymatio/scattering3d/frontend/torch_frontend.py
+++ b/kymatio/scattering3d/frontend/torch_frontend.py
@@ -61,22 +61,7 @@ class HarmonicScatteringTorch3D(ScatteringTorch, ScatteringBase3D):
 
         input_array = input_array.reshape((-1,) + signal_shape)
 
-        x = input_array.new(input_array.shape + (2,)).fill_(0)
-        x[..., 0] = input_array
-
-        buffer_dict = dict(self.named_buffers())
-        for k in range(len(self.filters)):
-            self.filters[k] = buffer_dict['tensor' + str(k)]
-
-        methods = ['integral']
-        if not self.method in methods:
-            raise ValueError('method must be in {}'.format(methods))
-
-        if self.method == 'integral': \
-                self.averaging = lambda x: self.backend.compute_integrals(x, self.integral_powers)
-
-        S = scattering3d(x, filters=self.filters, rotation_covariant=self.rotation_covariant, L=self.L,
-                            J=self.J, max_order=self.max_order, backend=self.backend, averaging=self.averaging)
+        S = self.scattering(input_array)
         scattering_shape = S.shape[1:]
 
         S = S.reshape(batch_shape + scattering_shape)

--- a/tests/scattering2d/test_torch_scattering2d.py
+++ b/tests/scattering2d/test_torch_scattering2d.py
@@ -53,13 +53,12 @@ class TestPad:
 
         z = pad(x)
 
-        assert z.shape == (1, 8, 8, 2)
-        assert torch.allclose(z[0, 2, 2, 0], x[0, 0, 0])
-        assert torch.allclose(z[0, 1, 0, 0], x[0, 1, 2])
-        assert torch.allclose(z[0, 1, 1, 0], x[0, 1, 1])
-        assert torch.allclose(z[0, 1, 2, 0], x[0, 1, 0])
-        assert torch.allclose(z[0, 1, 3, 0], x[0, 1, 1])
-        assert torch.allclose(z[..., 1], torch.zeros_like(z[..., 1]))
+        assert z.shape == (1, 8, 8)
+        assert torch.allclose(z[0, 2, 2], x[0, 0, 0])
+        assert torch.allclose(z[0, 1, 0], x[0, 1, 2])
+        assert torch.allclose(z[0, 1, 1], x[0, 1, 1])
+        assert torch.allclose(z[0, 1, 2], x[0, 1, 0])
+        assert torch.allclose(z[0, 1, 3], x[0, 1, 1])
 
         pad = backend.Pad((2, 2, 2, 2), (4, 4), pre_pad=True)
 
@@ -68,8 +67,7 @@ class TestPad:
 
         z = pad(x)
 
-        assert torch.allclose(z[..., 0], x)
-        assert torch.allclose(z[..., 1], torch.zeros_like(z[..., 1]))
+        assert torch.allclose(z, x)
 
     @pytest.mark.parametrize('backend_device', backends_devices)
     def test_unpad(self, backend_device):
@@ -96,10 +94,9 @@ class TestModulus:
 
         y = modulus(x)
         u = torch.squeeze(torch.sqrt(torch.sum(x * x, 3)))
-        v = y.narrow(3, 0, 1)
         u = u.squeeze()
-        v = v.squeeze()
-        assert torch.allclose(u, v)
+        y = y.squeeze()
+        assert torch.allclose(u, y)
 
         y = x[..., 0].contiguous()
         with pytest.raises(TypeError) as record:

--- a/tests/scattering2d/test_torch_scattering2d.py
+++ b/tests/scattering2d/test_torch_scattering2d.py
@@ -320,11 +320,10 @@ class TestFFT:
         assert z.shape == x.shape[:-1]
         assert torch.allclose(y[..., 0], z)
 
-        x = x[..., 0].contiguous()
-        y[..., 1] = 0.0
+        x_r = x[..., 0].contiguous()
+        y[..., 1] = 0
 
-        z = backend.fft(x, 'R2C')
-        z = z
+        z = backend.fft(x_r, 'R2C')
 
         assert torch.allclose(y, z)
         

--- a/tests/scattering2d/test_torch_scattering2d.py
+++ b/tests/scattering2d/test_torch_scattering2d.py
@@ -327,8 +327,6 @@ class TestFFT:
         z = z
 
         assert torch.allclose(y, z)
-
-
         
 
     @pytest.mark.parametrize('backend_device', backends_devices)

--- a/tests/scattering2d/test_torch_scattering2d.py
+++ b/tests/scattering2d/test_torch_scattering2d.py
@@ -234,10 +234,6 @@ class TestCDGMM:
         assert 'not compatible' in exc.value.args[0]
 
         with pytest.raises(TypeError) as exc:
-            backend.cdgmm(torch.empty(3, 4, 5, 1), torch.empty(4, 5, 1))
-        assert 'input should be complex' in exc.value.args[0]
-
-        with pytest.raises(TypeError) as exc:
             backend.cdgmm(torch.empty(3, 4, 5, 2), torch.empty(4, 5, 3))
         assert 'should be complex' in exc.value.args[0]
 
@@ -324,6 +320,17 @@ class TestFFT:
         assert z.shape == x.shape[:-1]
         assert torch.allclose(y[..., 0], z)
 
+        x = x[..., 0].contiguous()
+        y[..., 1] = 0.0
+
+        z = backend.fft(x, 'R2C')
+        z = z
+
+        assert torch.allclose(y, z)
+
+
+        
+
     @pytest.mark.parametrize('backend_device', backends_devices)
     def test_fft_exceptions(self, backend_device):
         backend, device = backend_device
@@ -333,11 +340,6 @@ class TestFFT:
                         inverse=False)
         assert 'done with an inverse' in record.value.args[0]
 
-        x = torch.rand(4, 4, 1)
-        x = x.to(device)
-        with pytest.raises(TypeError) as record:
-            backend.fft(x)
-        assert 'complex' in record.value.args[0]
 
         x = torch.randn(4, 4, 2)
         x = x.to(device)

--- a/tests/scattering3d/test_torch_scattering3d.py
+++ b/tests/scattering3d/test_torch_scattering3d.py
@@ -115,13 +115,8 @@ def test_cdgmm3d(device, backend, inplace):
             backend.cdgmm3d(x, y)
         assert "not compatible" in record.value.args[0]
 
-        # Create a tensor that behaves like `torch.Tensor` but is technically a
-        # different type.
-        class FakeTensor(torch.Tensor):
-            pass
-
         with pytest.raises(TypeError) as record:
-            x = FakeTensor(3, 3, 3, 2)
+            x = torch.randn(3, 3, 3, 2).double()
             y = torch.randn(3, 3, 3, 2)
             backend.cdgmm3d(x, y)
         assert " must be of the same dtype" in record.value.args[0]


### PR DESCRIPTION
This pr refactors the padding and modulus classes to not cast to complex. Instead, the complex casting is taken care of by a framework specific rfft function. This PR also refactors the algorithm to take into account the change in real or complex tensors. Closes #462, Closes #598  .