### PR TITLE
DOC Downgrade Sphinx version

### DIFF
--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,5 +1,5 @@
 pytest
-sphinx
+sphinx<3.0
 sphinxcontrib-bibtex
 sphinx-gallery
 pillow


### PR DESCRIPTION
Right now, m2r is not compatible with Sphinx v3.

See https://github.com/miyakogi/m2r/issues/51.