### PR TITLE
TST Fix Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,8 @@ pipeline {
 	HOME = "$WORKSPACE/build"
       }
       steps {
+	sh 'python3 -m pip --version'
+	sh 'python3 -m pip freeze'
 	sh 'python3 -c "import torch; torch.cuda.current_device()"'
 	sh 'python3 -c "import tensorflow as tf; tf.test.is_gpu_available()"'
 	sh 'python3 -m venv --system-site-packages --without-pip $HOME'

--- a/kymatio/scattering1d/backend/torch_skcuda_backend.py
+++ b/kymatio/scattering1d/backend/torch_skcuda_backend.py
@@ -6,7 +6,13 @@ from ...backend.torch_backend import contiguous_check, complex_check
 
 BACKEND_NAME = 'torch_skcuda'
 
-@cupy.util.memoize(for_each_device=True)
+# As of v8, cupy.util has been renamed cupy._util.
+if hasattr(cupy, '_util'):
+    memoize = cupy._util.memoize
+else:
+    memoize = cupy.util.memoize
+
+@memoize(for_each_device=True)
 def load_kernel(kernel_name, code, **kwargs):
     code = Template(code).substitute(**kwargs)
     kernel_code = cupy.cuda.compile_with_cache(code)

--- a/kymatio/scattering2d/backend/torch_skcuda_backend.py
+++ b/kymatio/scattering2d/backend/torch_skcuda_backend.py
@@ -9,7 +9,13 @@ BACKEND_NAME = 'torch_skcuda'
 from ...backend.torch_backend import contiguous_check, complex_check
 from ...backend.torch_skcuda_backend import cdgmm
 
-@cupy.util.memoize(for_each_device=True)
+# As of v8, cupy.util has been renamed cupy._util.
+if hasattr(cupy, '_util'):
+    memoize = cupy._util.memoize
+else:
+    memoize = cupy.util.memoize
+
+@memoize(for_each_device=True)
 def _load_kernel(kernel_name, code, **kwargs):
     code = Template(code).substitute(**kwargs)
     kernel_code = cupy.cuda.compile_with_cache(code)

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update && \
     apt-get autoclean -y && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip
+RUN python3 -m pip install --upgrade pip
 
-RUN pip3 install \
+RUN python3 -m pip install \
       'numpy>=1.16' \
       scipy \
       configparser \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && \
     apt-get autoclean -y && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 RUN pip3 install \
       'numpy>=1.16' \
       scipy \


### PR DESCRIPTION
This PR gets Jenkins up and running again. There are four main contributions:
- Upgrade `pip` before calling `pip install`. This ensures that we can take advantage of the newer `manylinux2010` and `manylinux2014` wheels. The default version (v9) only installs `manylinux1` wheels and when it can't find them, tries to compile from source, which is a bad idea.
- Invoke `pip` using `python3 -m pip` instead of `pip3` since this is a more robust approach.
- Output version information for `pip` and the installed packages. This should help debugging in the future.
- Fixes usage of internal `cupy` components, which have moved from `cupy.utils` to `cupy._utils` in v8.