### PR TITLE
TST Try GH actions for pip tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,0 +1,43 @@
+name: Kymatio Conda CI
+
+on:
+    - push
+    - pull_request
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                python-version: [3.5, 3.6, 3.7]
+
+        steps:
+            - uses: actions/checkout@v1
+            - name: Add Conda to path
+              run: echo $CONDA >> $GITHUB_PATH
+            - name: Set up Conda
+              run: |
+                  conda config --set always_yes yes --set changeps1 no
+
+                  conda update -q conda
+
+                  conda info -a
+
+                  conda create -q -n test-env python=${{ matrix.python-version }}
+            - name: Install dependencies
+              run: |
+                  conda install -n test-env numpy scipy pytest pytest-cov
+                  conda install -n test-env pytorch torchvision cpuonly -c pytorch
+
+                  conda run -n test-env python3 -m pip install --upgrade pip
+
+                  conda run -n test-env python3 -m pip install "tensorflow>=2.0.0a"
+                  conda run -n test-env python3 -m pip install scikit-learn
+
+                  conda run -n test-env python3 -m pip install -r requirements.txt
+                  conda run -n test-env python3 -m pip install -r requirements_optional.txt
+            - name: Set up Kymatio
+              run: conda run -n test-env python3 setup.py develop
+            - name: Test
+              run: conda run -n test-env pytest --cov=kymatio

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         strategy:
             matrix:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -1,0 +1,34 @@
+name: Kymatio Pip CI
+
+on:
+    - push
+    - pull_request
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                python-version: [3.5, 3.6, 3.7]
+
+        steps:
+            - uses: actions/checkout@v1
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install dependencies
+              run: |
+                  python3 -m pip install --upgrade pip
+                  python3 -m pip install pytest pytest-cov
+                  python3 -m pip install torch==1.3.0+cpu torchvision==0.4.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+                  python3 -m pip install "tensorflow>=2.0.0a"
+                  python3 -m pip install scikit-learn
+
+                  python3 -m pip install -r requirements.txt
+                  python3 -m pip install -r requirements_optional.txt
+            - name: Set up Kymatio
+              run: python3 setup.py develop
+            - name: Test
+              run: pytest --cov=kymatio

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         strategy:
             matrix:


### PR DESCRIPTION
Adds configuration files for two workflows: one for pip install and one for conda install. Ideally, it should just pop up as a check in the PR, but we'll see.