### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,7 +10,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7]
+                python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,7 +10,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+                python-version: [3.5, 3.6, 3.7, 3.8]
 
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -41,7 +41,10 @@ jobs:
 
                   conda run -n test-env python3 -m pip install --upgrade pip
 
-                  conda run -n test-env python3 -m pip install "tensorflow>=2.0.0a"
+                  if [ "${{ matrix.python-version }}" != "3.9" ]; then
+                      conda run -n test-env python3 -m pip install "tensorflow>=2.0.0a"
+                  fi
+
                   conda run -n test-env python3 -m pip install scikit-learn
 
                   conda run -n test-env python3 -m pip install -r requirements.txt

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -28,7 +28,16 @@ jobs:
             - name: Install dependencies
               run: |
                   conda install -n test-env numpy scipy pytest pytest-cov
-                  conda install -n test-env pytorch torchvision cpuonly -c pytorch
+
+                  if [ "${{ matrix.python-version }}" = "3.9" ]; then
+                      # For py39, we need to override some standard conda
+                      # packages (see https://pytorch.org/get-started/locally/)
+                      channel="-c conda-forge"
+                  else
+                      channel=""
+                  fi
+
+                  conda install -n test-env pytorch torchvision cpuonly -c pytorch ${channel}
 
                   conda run -n test-env python3 -m pip install --upgrade pip
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,7 +5,7 @@ on:
     - pull_request
 
 jobs:
-    build:
+    build-conda:
         runs-on: ubuntu-20.04
 
         strategy:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,7 +10,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8]
+                python-version: [3.6, 3.7, 3.8]
 
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -10,7 +10,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8]
+                python-version: [3.6, 3.7, 3.8]
 
         steps:
             - uses: actions/checkout@v1
@@ -23,13 +23,8 @@ jobs:
                   python3 -m pip install --upgrade pip
                   python3 -m pip install pytest pytest-cov
 
-                  if [ "${{ matrix.python-version }}" = "3.5" ]; then
-                      torch_version="1.5.1+cpu"
-                      torchvision_version="0.6.1+cpu"
-                  else
-                      torch_version="1.7.1+cpu"
-                      torchvision_version="0.8.2+cpu"
-                  fi
+                  torch_version="1.7.1+cpu"
+                  torchvision_version="0.8.2+cpu"
 
                   python3 -m pip install torch==${torch_version} torchvision==${torchvision_version} -f https://download.pytorch.org/whl/torch_stable.html
 

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -10,7 +10,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7]
+                python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -22,7 +22,7 @@ jobs:
               run: |
                   python3 -m pip install --upgrade pip
                   python3 -m pip install pytest pytest-cov
-                  python3 -m pip install torch==1.3.0+cpu torchvision==0.4.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+                  python3 -m pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
                   python3 -m pip install "tensorflow>=2.0.0a"
                   python3 -m pip install scikit-learn
 

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -22,7 +22,16 @@ jobs:
               run: |
                   python3 -m pip install --upgrade pip
                   python3 -m pip install pytest pytest-cov
-                  python3 -m pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
+
+                  if [ "${{ matrix.python-version }}" = "3.5" ]; then
+                      torch_version="1.5.1+cpu"
+                      torchvision_version="0.6.1+cpu"
+                  else
+                      torch_version="1.7.1+cpu"
+                      torchvision_version="0.8.2+cpu"
+                  fi
+
+                  python3 -m pip install torch==${torch_version} torchvision==${torchvision_version} -f https://download.pytorch.org/whl/torch_stable.html
                   python3 -m pip install "tensorflow>=2.0.0a"
                   python3 -m pip install scikit-learn
 

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -10,7 +10,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+                python-version: [3.5, 3.6, 3.7, 3.8]
 
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -32,7 +32,11 @@ jobs:
                   fi
 
                   python3 -m pip install torch==${torch_version} torchvision==${torchvision_version} -f https://download.pytorch.org/whl/torch_stable.html
-                  python3 -m pip install "tensorflow>=2.0.0a"
+
+                  if [ "${{ matrix.python-version }}" != "3.9" ]; then
+                      python3 -m pip install "tensorflow>=2.0.0a"
+                  fi
+
                   python3 -m pip install scikit-learn
 
                   python3 -m pip install -r requirements.txt

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -5,7 +5,7 @@ on:
     - pull_request
 
 jobs:
-    build:
+    build-pip:
         runs-on: ubuntu-20.04
 
         strategy:


### PR DESCRIPTION
Extend support to Python 3.8. Rename the build jobs to distinguish pip and conda (hopefully).

Partially addresses #642.