### PR TITLE
Update docs (episode II)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Kymatio docs CI
+
+on:
+    - push
+    - pull_request
+
+jobs:
+    docs:
+        if: github.ref == 'refs/head/master'
+        runs-on: ubuntu-20.04
+
+        steps:
+            - uses: actions/checkout@v1
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: 3.7
+            - name: Set up TeX Live
+              run: |
+                  sudo apt update
+                  sudo apt install texlive texlive-latex-extra cm-super-minimal dvipng
+            - name: Install Python dependencies
+              run: |
+                  python3 -m pip install --upgrade pip
+                  python3 -m pip install -r requirements.txt
+                  python3 -m pip install -r requirements_optional.txt
+                  pip install torch==1.8.0+cpu \
+                              torchvision==0.9.0+cpu \
+                              torchaudio==0.8.0 \
+                              -f https://download.pytorch.org/whl/torch_stable.html
+            - name: Set up Kymatio
+              run: python3 setup.py develop
+            - name: Generate documentation
+              run: |
+                  pushd doc
+                  make clean
+                  make html
+                  popd
+            - name: Upload to GitHub pages
+              env:
+                  GITHUB_ACTOR: ${{ github.actor }}
+                  GITHUB_REPOSITORY: ${{ github.repository }}
+                  TOKEN: ${{ secrets.TOKEN }}
+                  DOC_REPO: kymatio/kymatio.github.io
+                  DOC_ROOT: doc/build/html
+              run: "tools/push_doc.sh"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,6 +59,8 @@ extensions = [
     'm2r2'
 ]
 
+bibtex_bibfiles = ["_static/bibtex.bib"]
+
 html_favicon = '_static/kymatio.ico'
 
 # Add path to sphynx gallery

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,9 +19,6 @@ from distutils.version import LooseVersion
 
 
 
-sys.path.insert(0, os.path.abspath('../..'))
-
-
 
 # -- Project information -----------------------------------------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,7 +56,7 @@ extensions = [
     'sphinx_gallery.gen_gallery',
     'sphinx.ext.napoleon',
     'texext',
-    'm2r'
+    'm2r2'
 ]
 
 html_favicon = '_static/kymatio.ico'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,6 +19,7 @@ from distutils.version import LooseVersion
 
 
 
+autodoc_mock_imports = ['torch', 'tensorflow', 'sklearn']
 
 # -- Project information -----------------------------------------------------
 

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -6,4 +6,4 @@ pillow
 matplotlib
 scikit-learn
 texext
-m2r
+m2r2

--- a/tools/push_doc.sh
+++ b/tools/push_doc.sh
@@ -1,47 +1,29 @@
 #!/bin/bash
 
-# This script is adapted from the one in scikit-learn
-
-# This script is meant to be called in the "deploy" step defined in 
-# circle.yml. See https://circleci.com/docs/ for more details.
-# The behavior of the script is controlled by environment variable defined
-# in the circle.yml in the top level folder of the project.
-
 set -ex
 
-if [ -z $CIRCLE_PROJECT_USERNAME ];
-then USERNAME="kymatio-ci";
-else USERNAME=$CIRCLE_PROJECT_USERNAME;
-fi
+git config --global user.name "${GITHUB_ACTOR}"
+git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-DOC_REPO=${2-"kymatio.github.io"}
-GENERATED_DOC_DIR=$1
+repo_root=$(mktemp -d)
+rsync -av "${DOC_ROOT}/" "${repo_root}/"
 
-if [[ -z "$GENERATED_DOC_DIR" ]]; then
-    echo "Need to pass directory of the generated doc as argument"
-    echo "Usage: $0 <generated_doc_dir>"
-    exit 1
-fi
+pushd "${repo_root}"
 
-# Absolute path needed because we use cd further down in this script
-GENERATED_DOC_DIR=$(readlink -f $GENERATED_DOC_DIR)
+git init
+git remote add deploy "https://token:${TOKEN}@github.com/${DOC_REPO}.git"
+git checkout -b gh-pages
 
+touch .nojekyll
 
-dir=dev
+git add .
 
-MSG="Pushing the docs to $dir/ for branch: $CIRCLE_BRANCH, commit $CIRCLE_SHA1"
+msg="Pushing the docs for commit ${GITHUB_SHA} made on from ${GITHUB_REF} by ${GITHUB_ACTOR}"
 
-cd $HOME
-if [ ! -d $DOC_REPO ];
-then git clone --depth 1 "git@github.com:kymatio/"$DOC_REPO".git";
-fi
-cd $DOC_REPO
+git commit -am "${msg}"
 
-cp -R $GENERATED_DOC_DIR/* .
-git config user.email "eugenium+kymatio-ci@gmail.com"
-git config user.name $USERNAME
-git config push.default matching
-git add --all
-git commit -m "$MSG"
-git push
-echo $MSG 
+git push deploy gh-pages --force
+
+popd
+
+exit 0


### PR DESCRIPTION
Add a GitHub Actions workflow for generating the docs and pushing them to GitHub pages. So far only for `master`.

Depends on #687.