### PR TITLE
TST Set max-parallel to one for self-hosted

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -12,6 +12,7 @@ jobs:
             matrix:
                 python-version: [3.6, 3.7]
                 pytorch-version: [1.7, 1.8]
+            max-parallel: 1
 
         env:
             CONDA_ENV: test-env-py${{ matrix.python-version }}-torch${{ matrix.pytorch-version }}


### PR DESCRIPTION
These tests always seem to run out of memory, so it's probably safer to
run them one at a time to reduce flakiness.