### PR TITLE
set version to 0.3.dev0 in dev branch

### DIFF
--- a/kymatio/version.py
+++ b/kymatio/version.py
@@ -1,2 +1,2 @@
-short_version = '0.3s'
+short_version = '0.3'
 version = '0.3.dev0'

--- a/kymatio/version.py
+++ b/kymatio/version.py
@@ -1,3 +1,2 @@
-short_version = '0.2'
-version = '0.2.a0'
-
+short_version = '0.3s'
+version = '0.3.dev0'


### PR DESCRIPTION
PEP440 compliant
follows sklearn convention https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/__init__.py#L26