### PR TITLE
Faster `compute_minimum_support_to_pad`

### DIFF
--- a/examples/1d/plot_filters.py
+++ b/examples/1d/plot_filters.py
@@ -60,12 +60,12 @@ Q = 8
 # first-order wavelet filters (`psi1_f`), and the second-order filters
 # (`psi2_f`).
 
-phi_f, psi1_f, psi2_f, _ = scattering_filter_factory(np.log2(T), J, Q)
+phi_f, psi1_f, psi2_f = scattering_filter_factory(np.log2(T), J, Q)
 
 ###############################################################################
 # The `phi_f` output is a dictionary where each integer key corresponds points
 # to the instantiation of the filter at a certain resolution. In other words,
-# `phi_f[0]` corresponds to the lowpass filter at resolution `T`, while 
+# `phi_f[0]` corresponds to the lowpass filter at resolution `T`, while
 # `phi_f[1]` corresponds to the filter at resolution `T/2`, and so on.
 #
 # While `phi_f` only contains a single filter (at different resolutions),

--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -551,9 +551,8 @@ def calibrate_scattering_filters(J, Q, r_psi=math.sqrt(0.5), sigma0=0.1,
 
 
 def scattering_filter_factory(J_support, J_scattering, Q, r_psi=math.sqrt(0.5),
-                              criterion_amplitude=1e-3, normalize='l1',
-                              max_subsampling=None, sigma0=0.1, alpha=5.,
-                              P_max=5, eps=1e-7, **kwargs):
+                              normalize='l1', max_subsampling=None, sigma0=0.1,
+                              alpha=5., P_max=5, eps=1e-7, **kwargs):
     """
     Builds in Fourier the Morlet filters used for the scattering transform.
 
@@ -581,9 +580,6 @@ def scattering_filter_factory(J_support, J_scattering, Q, r_psi=math.sqrt(0.5),
         Should be >0 and <1. Controls the redundancy of the filters
         (the larger r_psi, the larger the overlap between adjacent wavelets).
         Defaults to sqrt(0.5).
-    criterion_amplitude : float, optional
-        Represents the numerical error which is allowed to be lost after
-        convolution and padding. Defaults to 1e-3.
     normalize : string, optional
         Normalization convention for the filters (in the
         temporal domain). Supported values include 'l1' and 'l2'; a ValueError
@@ -635,10 +631,6 @@ def scattering_filter_factory(J_support, J_scattering, Q, r_psi=math.sqrt(0.5),
         The keys of this dictionary are of th etype (j, n) where n is an
         integer counting the filters and j is the maximal dyadic subsampling
         which can be performed on top of this filter without aliasing.
-    t_max_phi : int
-        temporal size to use to pad the signal on the right and on the
-        left by making at most criterion_amplitude error. Assumes that the
-        temporal support of the low-pass filter is larger than all filters.
 
     Refs
     ----
@@ -724,10 +716,5 @@ def scattering_filter_factory(J_support, J_scattering, Q, r_psi=math.sqrt(0.5),
     phi_f['sigma'] = sigma_low
     phi_f['j'] = 0
 
-    # compute the support size allowing to pad without boundary errors
-    # at the finest resolution
-    t_max_phi = compute_temporal_support(
-        phi_f[0].reshape(1, -1), criterion_amplitude=criterion_amplitude)
-
     # return results
-    return phi_f, psi1_f, psi2_f, t_max_phi
+    return phi_f, psi1_f, psi2_f

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -70,9 +70,8 @@ class ScatteringBase1D(ScatteringBase):
 
     def create_filters(self):
         # Create the filters
-        self.phi_f, self.psi1_f, self.psi2_f, _ = scattering_filter_factory(
+        self.phi_f, self.psi1_f, self.psi2_f = scattering_filter_factory(
             self.J_pad, self.J, self.Q, normalize=self.normalize,
-            criterion_amplitude=self.criterion_amplitude,
             r_psi=self.r_psi, sigma0=self.sigma0, alpha=self.alpha,
             P_max=self.P_max, eps=self.eps)
 

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -128,12 +128,12 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
     sigma_low, *_ = calibrate_scattering_filters(J_scattering, Q, r_psi=r_psi,
                                                  sigma0=sigma0, alpha=alpha)
 
-    # compute the filters at all possible subsamplings
+    # compute lowpass
     N = 2 ** J_support
     phi_f = gauss_1d(N, sigma_low, P_max=P_max, eps=eps)
 
     # compute the support size allowing to pad without boundary errors
-    # at the finest resolution
+    # at the coarsest resolution
     t_max_phi = compute_temporal_support(phi_f.reshape(1, -1),
                                          criterion_amplitude=criterion_amplitude)
     min_to_pad = 3 * t_max_phi

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import math
-from .filter_bank import scattering_filter_factory, calibrate_scattering_filters
+from .filter_bank import (calibrate_scattering_filters, compute_temporal_support,
+                          gauss_1d)
 
 def compute_border_indices(J, i0, i1):
     """
@@ -122,10 +123,19 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
         boundary error.
     """
     J_tentative = int(np.ceil(np.log2(T)))
-    _, _, _, t_max_phi = scattering_filter_factory(
-        J_tentative, J, Q, normalize=normalize, to_torch=False,
-        max_subsampling=0, criterion_amplitude=criterion_amplitude,
-        r_psi=r_psi, sigma0=sigma0, alpha=alpha, P_max=P_max, eps=eps)
+    J_support = J_tentative
+    J_scattering = J
+    sigma_low, *_ = calibrate_scattering_filters(J_scattering, Q, r_psi=r_psi,
+                                                 sigma0=sigma0, alpha=alpha)
+
+    # compute the filters at all possible subsamplings
+    N = 2 ** J_support
+    phi_f = gauss_1d(N, sigma_low, P_max=P_max, eps=eps)
+
+    # compute the support size allowing to pad without boundary errors
+    # at the finest resolution
+    t_max_phi = compute_temporal_support(phi_f.reshape(1, -1),
+                                         criterion_amplitude=criterion_amplitude)
     min_to_pad = 3 * t_max_phi
     return min_to_pad
 


### PR DESCRIPTION
Entire filter bank is rebuilt just for `gauss_1d(N)`, this is especially problematic in JTFS where it's called multiple times