### PR TITLE
[WIP] Allow non-CQT filter failure

### DIFF
--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -159,7 +159,7 @@ def precompute_size_scattering(J, Q, max_order=2, detail=False):
         integer. If `True`, returns a tuple of size `max_order` containing
         the number of coefficients in each order.
     """
-    sigma_low, xi1, sigma1, j1, xi2, sigma2, j2 = \
+    sigma_low, xi1, sigma1, j1, is_cqt1, xi2, sigma2, j2, is_cqt2 = \
         calibrate_scattering_filters(J, Q)
 
     size_order0 = 1
@@ -223,7 +223,8 @@ def compute_meta_scattering(J, Q, max_order=2):
             The tuples indexing the corresponding scattering coefficient
             in the non-vectorized output.
     """
-    sigma_low, xi1s, sigma1s, j1s, xi2s, sigma2s, j2s = \
+    # TODO meta won't match output if non-CQT are dropped
+    sigma_low, xi1s, sigma1s, j1s, _, xi2s, sigma2s, j2s, _ = \
         calibrate_scattering_filters(J, Q)
 
     meta = {}


### PR DESCRIPTION
Current behavior is to error if `get_normalizing_factor` is too small (i.e. wavelet is actually a pure tone) on _any wavelet_. Since ideally we work with CQT-only anyway, this is unnecessarily strict - and problematic in JTFS where `2**J_support` is typically small (~256, 128), limiting flexibility with `Q_fr`.

PR allows filterbanks whose _intermediate_, or non-CQT, filters fail: `for q in range(1, num_intermediate + 1)`.

### Todo
 1. `meta` will no longer map to output coefficients in all cases, nor will an accurate mapping be possible without explicitly checking for non-CQT failure (by computing them). Options:
      - A. Compute said filters
      - B. Get info from already-computed filters (makes method no longer standalone)
 2. Docs