### PR TITLE
Introduce `pad_mode`

### DIFF
--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -32,7 +32,7 @@ class NumpyBackend1D(NumpyBackend):
         return res
 
     @classmethod
-    def pad(cls, x, pad_left, pad_right, padtype='reflect'):
+    def pad(cls, x, pad_left, pad_right, pad_mode='reflect'):
         """Pad real 1D tensors
         1D implementation of the padding function for real PyTorch tensors.
         Parameters
@@ -46,7 +46,7 @@ class NumpyBackend1D(NumpyBackend):
         pad_right : int
             amount to add on the right of the tensor (at the end of the temporal
             axis).
-        padtype : str
+        pad_mode : str
             name of padding to use.
         Returns
         -------
@@ -55,13 +55,13 @@ class NumpyBackend1D(NumpyBackend):
         """
         if (pad_left >= x.shape[-1]) or (pad_right >= x.shape[-1]):
             raise ValueError('Indefinite padding size (larger than tensor).')
-        if padtype == 'zero':
-            padtype = 'constant'
+        if pad_mode == 'zero':
+            pad_mode = 'constant'
 
         paddings = ((0, 0),) * len(x.shape[:-1])
         paddings += (pad_left, pad_right),
 
-        output = cls._np.pad(x, paddings, mode=padtype)
+        output = cls._np.pad(x, paddings, mode=pad_mode)
 
         return output
 

--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -46,6 +46,8 @@ class NumpyBackend1D(NumpyBackend):
         pad_right : int
             amount to add on the right of the tensor (at the end of the temporal
             axis).
+        padtype : str
+            name of padding to use.
         Returns
         -------
         output : tensor

--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -32,7 +32,7 @@ class NumpyBackend1D(NumpyBackend):
         return res
 
     @classmethod
-    def pad(cls, x, pad_left, pad_right):
+    def pad(cls, x, pad_left, pad_right, padtype='reflect'):
         """Pad real 1D tensors
         1D implementation of the padding function for real PyTorch tensors.
         Parameters
@@ -53,11 +53,13 @@ class NumpyBackend1D(NumpyBackend):
         """
         if (pad_left >= x.shape[-1]) or (pad_right >= x.shape[-1]):
             raise ValueError('Indefinite padding size (larger than tensor).')
+        if padtype == 'zero':
+            padtype = 'constant'
 
         paddings = ((0, 0),) * len(x.shape[:-1])
         paddings += (pad_left, pad_right),
 
-        output = cls._np.pad(x, paddings, mode='reflect')
+        output = cls._np.pad(x, paddings, mode=padtype)
 
         return output
 

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -32,7 +32,7 @@ class TensorFlowBackend1D(TensorFlowBackend):
         return tf.reduce_mean(y, axis=-2)
 
     @staticmethod
-    def pad(x, pad_left, pad_right, padtype='reflect'):
+    def pad(x, pad_left, pad_right, pad_mode='reflect'):
         """Pad real 1D tensors
         1D implementation of the padding function for real PyTorch tensors.
         Parameters
@@ -46,7 +46,7 @@ class TensorFlowBackend1D(TensorFlowBackend):
         pad_right : int
             amount to add on the right of the tensor (at the end of the temporal
             axis).
-        padtype : str
+        pad_mode : str
             name of padding to use.
         Returns
         -------
@@ -55,13 +55,13 @@ class TensorFlowBackend1D(TensorFlowBackend):
         """
         if (pad_left >= x.shape[-1]) or (pad_right >= x.shape[-1]):
             raise ValueError('Indefinite padding size (larger than tensor).')
-        if padtype == 'zero':
-            padtype = 'constant'
+        if pad_mode == 'zero':
+            pad_mode = 'constant'
 
         paddings = [[0, 0]] * len(x.shape[:-1])
         paddings += [[pad_left, pad_right]]
 
-        return tf.pad(x, paddings, mode=padtype)
+        return tf.pad(x, paddings, mode=pad_mode)
 
     @staticmethod
     def unpad(x, i0, i1):

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -32,7 +32,7 @@ class TensorFlowBackend1D(TensorFlowBackend):
         return tf.reduce_mean(y, axis=-2)
 
     @staticmethod
-    def pad(x, pad_left, pad_right):
+    def pad(x, pad_left, pad_right, padtype='reflect'):
         """Pad real 1D tensors
         1D implementation of the padding function for real PyTorch tensors.
         Parameters
@@ -53,11 +53,13 @@ class TensorFlowBackend1D(TensorFlowBackend):
         """
         if (pad_left >= x.shape[-1]) or (pad_right >= x.shape[-1]):
             raise ValueError('Indefinite padding size (larger than tensor).')
+        if padtype == 'zero':
+            padtype = 'constant'
 
         paddings = [[0, 0]] * len(x.shape[:-1])
         paddings += [[pad_left, pad_right]]
 
-        return tf.pad(x, paddings, mode="REFLECT")
+        return tf.pad(x, paddings, mode=padtype)
 
     @staticmethod
     def unpad(x, i0, i1):

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -46,6 +46,8 @@ class TensorFlowBackend1D(TensorFlowBackend):
         pad_right : int
             amount to add on the right of the tensor (at the end of the temporal
             axis).
+        padtype : str
+            name of padding to use.
         Returns
         -------
         res : tensor

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -48,7 +48,7 @@ class TorchBackend1D(TorchBackend):
         return res
 
     @staticmethod
-    def pad(x, pad_left, pad_right, padtype):
+    def pad(x, pad_left, pad_right, pad_mode):
         """Pad real 1D tensors
 
         1D implementation of the padding function for real PyTorch tensors.
@@ -64,7 +64,7 @@ class TorchBackend1D(TorchBackend):
         pad_right : int
             amount to add on the right of the tensor (at the end of the temporal
             axis).
-        padtype : str
+        pad_mode : str
             name of padding to use.
         Returns
         -------
@@ -73,10 +73,10 @@ class TorchBackend1D(TorchBackend):
         """
         if (pad_left >= x.shape[-1]) or (pad_right >= x.shape[-1]):
             raise ValueError('Indefinite padding size (larger than tensor).')
-        if padtype == 'zero':
-            padtype = 'constant'
+        if pad_mode == 'zero':
+            pad_mode = 'constant'
 
-        res = F.pad(x, (pad_left, pad_right), mode=padtype)
+        res = F.pad(x, (pad_left, pad_right), mode=pad_mode)
         res = res[..., None]
 
         return res

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -48,7 +48,7 @@ class TorchBackend1D(TorchBackend):
         return res
 
     @staticmethod
-    def pad(x, pad_left, pad_right, pad_mode):
+    def pad(x, pad_left, pad_right, pad_mode='reflect'):
         """Pad real 1D tensors
 
         1D implementation of the padding function for real PyTorch tensors.

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -48,7 +48,7 @@ class TorchBackend1D(TorchBackend):
         return res
 
     @staticmethod
-    def pad(x, pad_left, pad_right):
+    def pad(x, pad_left, pad_right, padtype):
         """Pad real 1D tensors
 
         1D implementation of the padding function for real PyTorch tensors.
@@ -71,8 +71,10 @@ class TorchBackend1D(TorchBackend):
         """
         if (pad_left >= x.shape[-1]) or (pad_right >= x.shape[-1]):
             raise ValueError('Indefinite padding size (larger than tensor).')
+        if padtype == 'zero':
+            padtype = 'constant'
 
-        res = F.pad(x, (pad_left, pad_right), mode='reflect')
+        res = F.pad(x, (pad_left, pad_right), mode=padtype)
         res = res[..., None]
 
         return res

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -64,6 +64,8 @@ class TorchBackend1D(TorchBackend):
         pad_right : int
             amount to add on the right of the tensor (at the end of the temporal
             axis).
+        padtype : str
+            name of padding to use.
         Returns
         -------
         res : tensor

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,7 +1,7 @@
 def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         pad_right=0, ind_start=None, ind_end=None, oversampling=0,
         max_order=2, average=True, size_scattering=(0, 0, 0),
-        vectorize=False, out_type='array'):
+        vectorize=False, out_type='array', padtype='reflect'):
     """
     Main function implementing the 1-D scattering transform.
 
@@ -51,6 +51,8 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         speed-up. Defaults to `(0, 0, 0)`.
     vectorize : boolean, optional
         whether to return a dictionary or a tensor. Defaults to False.
+    padtype : str
+        name of padding to use.
 
     """
     subsample_fourier = backend.subsample_fourier
@@ -69,7 +71,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     out_S_0, out_S_1, out_S_2 = [], [], []
 
     # pad to a dyadic size and make it complex
-    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right)
+    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right, padtype=padtype)
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,7 +1,7 @@
 def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         pad_right=0, ind_start=None, ind_end=None, oversampling=0,
         max_order=2, average=True, size_scattering=(0, 0, 0),
-        vectorize=False, out_type='array', padtype='reflect'):
+        vectorize=False, out_type='array', pad_mode='reflect'):
     """
     Main function implementing the 1-D scattering transform.
 
@@ -51,7 +51,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         speed-up. Defaults to `(0, 0, 0)`.
     vectorize : boolean, optional
         whether to return a dictionary or a tensor. Defaults to False.
-    padtype : str
+    pad_mode : str
         name of padding to use.
 
     """
@@ -71,7 +71,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     out_S_0, out_S_1, out_S_2 = [], [], []
 
     # pad to a dyadic size and make it complex
-    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right, padtype=padtype)
+    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right, pad_mode=pad_mode)
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -51,6 +51,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         speed-up. Defaults to `(0, 0, 0)`.
     vectorize : boolean, optional
         whether to return a dictionary or a tensor. Defaults to False.
+
     """
     subsample_fourier = backend.subsample_fourier
     modulus = backend.modulus

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,7 +1,7 @@
 def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         pad_right=0, ind_start=None, ind_end=None, oversampling=0,
         max_order=2, average=True, size_scattering=(0, 0, 0),
-        vectorize=False, out_type='array', pad_mode='reflect'):
+        vectorize=False, out_type='array'):
     """
     Main function implementing the 1-D scattering transform.
 
@@ -51,9 +51,6 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         speed-up. Defaults to `(0, 0, 0)`.
     vectorize : boolean, optional
         whether to return a dictionary or a tensor. Defaults to False.
-    pad_mode : str
-        name of padding to use.
-
     """
     subsample_fourier = backend.subsample_fourier
     modulus = backend.modulus
@@ -71,7 +68,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     out_S_0, out_S_1, out_S_2 = [], [], []
 
     # pad to a dyadic size and make it complex
-    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right, pad_mode=pad_mode)
+    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right)
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,5 +1,5 @@
-def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
-        pad_right=0, ind_start=None, ind_end=None, oversampling=0,
+def scattering1d(x, pad_fn, unpad, backend, J, psi1, psi2, phi,
+        ind_start=None, ind_end=None, oversampling=0,
         max_order=2, average=True, size_scattering=(0, 0, 0),
         vectorize=False, out_type='array'):
     """
@@ -69,7 +69,7 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     out_S_0, out_S_1, out_S_2 = [], [], []
 
     # pad to a dyadic size and make it complex
-    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right)
+    U_0 = pad_fn(x)
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', padtype='reflect',
+            oversampling=0, vectorize=True, out_type='array', pad_mode='reflect',
             backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
@@ -22,7 +22,7 @@ class ScatteringBase1D(ScatteringBase):
         self.oversampling = oversampling
         self.vectorize = vectorize
         self.out_type = out_type
-        self.padtype = padtype
+        self.pad_mode = pad_mode
         self.backend = backend
 
     def build(self):
@@ -53,10 +53,10 @@ class ScatteringBase1D(ScatteringBase):
         else:
             raise ValueError("shape must be an integer or a 1-tuple")
 
-        # check padtype
-        if self.padtype not in ('reflect', 'symmetric', 'zero'):
-            raise ValueError("`padtype` must be one of: reflect, symmetric, "
-                             "zero (got %s)" % self.padtype)
+        # check pad_mode
+        if self.pad_mode not in ('reflect', 'symmetric', 'zero'):
+            raise ValueError("`pad_mode` must be one of: reflect, symmetric, "
+                             "zero (got %s)" % self.pad_mode)
 
         # Compute the minimum support to pad (ideally)
         min_to_pad = compute_minimum_support_to_pad(

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -58,6 +58,7 @@ class ScatteringBase1D(ScatteringBase):
         if isinstance(self.pad_mode, FunctionType):
             def pad_fn(x):
                 return self.pad_mode(x, self.pad_left, self.pad_right)
+            self.pad_mode = 'custom'
         elif self.pad_mode not in ('reflect', 'zero'):
             raise ValueError("`pad_mode` must be a function, or string, one of: "
                              "reflect, zero (got %s)" % str(self.pad_mode))
@@ -196,6 +197,8 @@ class ScatteringBase1D(ScatteringBase):
                 - zero:    [0, 0, 1, 2, 3, 0, 0, 0]
                 - reflect: [3, 2, 1, 2, 3, 2, 1, 2]
             Or, pad function with signature `pad_fn(x, pad_left, pad_right)`.
+            This sets `self.pad_mode='custom'` (the name of padding is used
+            for some internal logic).
         """
 
     _doc_attr_vectorize = \

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -56,9 +56,8 @@ class ScatteringBase1D(ScatteringBase):
 
         # check `pad_mode`, set `pad_fn`
         if isinstance(self.pad_mode, FunctionType):
-            fn = self.pad_mode
             def pad_fn(x):
-                return fn(x, self.pad_left, self.pad_right)
+                return self.pad_mode(x, self.pad_left, self.pad_right)
             self.pad_mode = 'custom'
         elif self.pad_mode not in ('reflect', 'zero'):
             raise ValueError(("unsupported `pad_mode` '{}';\nmust be a "
@@ -194,7 +193,7 @@ class ScatteringBase1D(ScatteringBase):
             `'array'`, the output is a large array containing the
             concatenation of all scattering coefficients. Defaults to
             `'array'`.
-        pad_mode : str / function, optional
+        pad_mode : str (default 'reflect') / function, optional
             Name of padding scheme to use, one of (`x = [1, 2, 3]`):
                 - zero:    [0, 0, 1, 2, 3, 0, 0, 0]
                 - reflect: [3, 2, 1, 2, 3, 2, 1, 2]
@@ -216,6 +215,12 @@ class ScatteringBase1D(ScatteringBase):
             output is a list of dictionaries, each containing a scattering
             coefficient along with meta information. For more information, see
             the documentation for `scattering`.
+        pad_mode : str
+            One of supported padding modes: 'reflect', 'zero' - or 'custom'
+            if a function was passed.
+        pad_fn : function
+            A backend padding function, or user function (as passed
+            to `pad_mode`), with signature `pad_fn(x, pad_left, pad_right)`.
         """
 
     _doc_class = \

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -54,16 +54,18 @@ class ScatteringBase1D(ScatteringBase):
         else:
             raise ValueError("shape must be an integer or a 1-tuple")
 
-        # check `pad_mode`, set `_pad_fn`
+        # check `pad_mode`, set `pad_fn`
         if isinstance(self.pad_mode, FunctionType):
-            self._pad_fn = self.pad_mode
+            def pad_fn(x):
+                return self.pad_mode(x, self.pad_left, self.pad_right)
         elif self.pad_mode not in ('reflect', 'zero'):
             raise ValueError("`pad_mode` must be a function, or string, one of: "
                              "reflect, zero (got %s)" % str(self.pad_mode))
         else:
-            def pad_fn(x, pad_left, pad_right):
-                return self.backend.pad(x, pad_left, pad_right, self.pad_mode)
-            self._pad_fn = pad_fn
+            def pad_fn(x):
+                return self.backend.pad(x, self.pad_left, self.pad_right,
+                                        self.pad_mode)
+        self.pad_fn = pad_fn
 
         # Compute the minimum support to pad (ideally)
         min_to_pad = compute_minimum_support_to_pad(
@@ -189,10 +191,11 @@ class ScatteringBase1D(ScatteringBase):
             `'array'`, the output is a large array containing the
             concatenation of all scattering coefficients. Defaults to
             `'array'`.
-        pad_mode : str, optional
+        pad_mode : str / function, optional
             Name of padding scheme to use, one of (`x = [1, 2, 3]`):
                 - zero:    [0, 0, 1, 2, 3, 0, 0, 0]
                 - reflect: [3, 2, 1, 2, 3, 2, 1, 2]
+            Or, pad function with signature `pad_fn(x, pad_left, pad_right)`.
         """
 
     _doc_attr_vectorize = \

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -54,9 +54,9 @@ class ScatteringBase1D(ScatteringBase):
             raise ValueError("shape must be an integer or a 1-tuple")
 
         # check pad_mode
-        if self.pad_mode not in ('reflect', 'symmetric', 'zero'):
-            raise ValueError("`pad_mode` must be one of: reflect, symmetric, "
-                             "zero (got %s)" % self.pad_mode)
+        if self.pad_mode not in ('reflect', 'zero'):
+            raise ValueError("`pad_mode` must be one of: reflect, zero "
+                             "(got %s)" % self.pad_mode)
 
         # Compute the minimum support to pad (ideally)
         min_to_pad = compute_minimum_support_to_pad(
@@ -182,6 +182,10 @@ class ScatteringBase1D(ScatteringBase):
             `'array'`, the output is a large array containing the
             concatenation of all scattering coefficients. Defaults to
             `'array'`.
+        pad_mode : str, optional
+            Name of padding scheme to use, one of (`x = [1, 2, 3]`):
+                - zero:    [0, 0, 1, 2, 3, 0, 0, 0]
+                - reflect: [3, 2, 1, 2, 3, 2, 1, 2]
         """
 
     _doc_attr_vectorize = \

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -60,8 +60,9 @@ class ScatteringBase1D(ScatteringBase):
                 return self.pad_mode(x, self.pad_left, self.pad_right)
             self.pad_mode = 'custom'
         elif self.pad_mode not in ('reflect', 'zero'):
-            raise ValueError("`pad_mode` must be a function, or string, one of: "
-                             "reflect, zero (got %s)" % str(self.pad_mode))
+            raise ValueError(("unsupported `pad_mode` '{}';\nmust be a "
+                              "function, or string, one of: 'zero', 'reflect'."
+                              ).format(str(self.pad_mode)))
         else:
             def pad_fn(x):
                 return self.backend.pad(x, self.pad_left, self.pad_right,

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,8 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend=None):
+            oversampling=0, vectorize=True, out_type='array', padtype='reflect',
+            backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -21,6 +22,7 @@ class ScatteringBase1D(ScatteringBase):
         self.oversampling = oversampling
         self.vectorize = vectorize
         self.out_type = out_type
+        self.padtype = padtype
         self.backend = backend
 
     def build(self):
@@ -50,6 +52,11 @@ class ScatteringBase1D(ScatteringBase):
                                  "have exactly one element")
         else:
             raise ValueError("shape must be an integer or a 1-tuple")
+
+        # check padtype
+        if self.padtype not in ('reflect', 'symmetric', 'zero'):
+            raise ValueError("`padtype` must be one of: reflect, symmetric, "
+                             "zero (got %s)" % self.padtype)
 
         # Compute the minimum support to pad (ideally)
         min_to_pad = compute_minimum_support_to_pad(

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -56,8 +56,9 @@ class ScatteringBase1D(ScatteringBase):
 
         # check `pad_mode`, set `pad_fn`
         if isinstance(self.pad_mode, FunctionType):
+            fn = self.pad_mode
             def pad_fn(x):
-                return self.pad_mode(x, self.pad_left, self.pad_right)
+                return fn(x, self.pad_left, self.pad_right)
             self.pad_mode = 'custom'
         elif self.pad_mode not in ('reflect', 'zero'):
             raise ValueError(("unsupported `pad_mode` '{}';\nmust be a "

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -7,10 +7,10 @@ from tensorflow.python.framework import tensor_shape
 
 
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
-    def __init__(self, J, Q=1, max_order=2, oversampling=0):
+    def __init__(self, J, Q=1, max_order=2, oversampling=0, padtype='reflect'):
         ScatteringKeras.__init__(self)
         ScatteringBase1D.__init__(self, J, None, Q, max_order, True,
-                oversampling, True, 'array', None)
+                oversampling, True, 'array', padtype, None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -7,10 +7,10 @@ from tensorflow.python.framework import tensor_shape
 
 
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
-    def __init__(self, J, Q=1, max_order=2, oversampling=0, padtype='reflect'):
+    def __init__(self, J, Q=1, max_order=2, oversampling=0, pad_mode='reflect'):
         ScatteringKeras.__init__(self)
         ScatteringBase1D.__init__(self, J, None, Q, max_order, True,
-                oversampling, True, 'array', padtype, None)
+                oversampling, True, 'array', pad_mode, None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -8,11 +8,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', padtype='reflect',
+            oversampling=0, vectorize=True, out_type='array', pad_mode='reflect',
             backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, padtype, backend)
+                oversampling, vectorize, out_type, pad_mode, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -58,7 +58,7 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                          vectorize=self.vectorize,
                          size_scattering=size_scattering,
                          out_type=self.out_type,
-                         padtype=self.padtype)
+                         pad_mode=self.pad_mode)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = S.shape[-2:]

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -8,10 +8,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='numpy'):
+            oversampling=0, vectorize=True, out_type='array', padtype='reflect',
+            backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, vectorize, out_type, padtype, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -56,7 +57,8 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                          oversampling=self.oversampling,
                          vectorize=self.vectorize,
                          size_scattering=size_scattering,
-                         out_type=self.out_type)
+                         out_type=self.out_type,
+                         padtype=self.padtype)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = S.shape[-2:]

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -51,14 +51,13 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         else:
             size_scattering = 0
 
-        S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.J, self.psi1_f, self.psi2_f,
+        S = scattering1d(x, self._pad_fn, self.backend.unpad, self.backend, self.J, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling,
                          vectorize=self.vectorize,
                          size_scattering=size_scattering,
-                         out_type=self.out_type,
-                         pad_mode=self.pad_mode)
+                         out_type=self.out_type)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = S.shape[-2:]

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -51,9 +51,9 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         else:
             size_scattering = 0
 
-        S = scattering1d(x, self._pad_fn, self.backend.unpad, self.backend, self.J, self.psi1_f, self.psi2_f,
-                         self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
-                         pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
+        S = scattering1d(x, self.pad_fn, self.backend.unpad, self.backend, self.J, self.psi1_f, self.psi2_f,
+                         self.phi_f, max_order=self.max_order, average=self.average,
+                         ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling,
                          vectorize=self.vectorize,
                          size_scattering=size_scattering,

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -9,11 +9,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', padtype='reflect',
+            oversampling=0, vectorize=True, out_type='array', pad_mode='reflect',
             backend='tensorflow', name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, padtype, backend)
+                oversampling, vectorize, out_type, pad_mode, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -60,7 +60,7 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
                          vectorize=self.vectorize,
                          size_scattering=size_scattering,
                          out_type=self.out_type,
-                         padtype=self.padtype)
+                         pad_mode=self.pad_mode)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = tf.shape(S)[-2:]

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -9,11 +9,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='tensorflow',
-                 name='Scattering1D'):
+            oversampling=0, vectorize=True, out_type='array', padtype='reflect',
+            backend='tensorflow', name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, vectorize, out_type, padtype, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -59,7 +59,8 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
                          oversampling=self.oversampling,
                          vectorize=self.vectorize,
                          size_scattering=size_scattering,
-                         out_type=self.out_type)
+                         out_type=self.out_type,
+                         padtype=self.padtype)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = tf.shape(S)[-2:]

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -59,8 +59,7 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
                          oversampling=self.oversampling,
                          vectorize=self.vectorize,
                          size_scattering=size_scattering,
-                         out_type=self.out_type,
-                         pad_mode=self.pad_mode)
+                         out_type=self.out_type)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = tf.shape(S)[-2:]

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -53,9 +53,9 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         else:
             size_scattering = 0
 
-        S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.J, self.psi1_f, self.psi2_f,
-                         self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
-                         pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
+        S = scattering1d(x, self.pad_fn, self.backend.unpad, self.backend, self.J, self.psi1_f, self.psi2_f,
+                         self.phi_f, max_order=self.max_order, average=self.average,
+                         ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling,
                          vectorize=self.vectorize,
                          size_scattering=size_scattering,

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -9,10 +9,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='torch'):
+            oversampling=0, vectorize=True, out_type='array', padtype='reflect',
+            backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, vectorize, out_type, padtype, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -115,7 +116,8 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                        oversampling=self.oversampling,
                        vectorize=self.vectorize,
                        size_scattering=size_scattering,
-                       out_type=self.out_type)
+                       out_type=self.out_type,
+                       padtype=self.padtype)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = S.shape[-2:]

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -109,9 +109,8 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
             size_scattering = 0
 
 
-        S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.J, self.psi1_f, self.psi2_f, self.phi_f,\
+        S = scattering1d(x, self.pad_fn, self.backend.unpad, self.backend, self.J, self.psi1_f, self.psi2_f, self.phi_f,\
                          max_order=self.max_order, average=self.average,
-                       pad_left=self.pad_left, pad_right=self.pad_right,
                        ind_start=self.ind_start, ind_end=self.ind_end,
                        oversampling=self.oversampling,
                        vectorize=self.vectorize,

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -9,11 +9,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', padtype='reflect',
+            oversampling=0, vectorize=True, out_type='array', pad_mode='reflect',
             backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, padtype, backend)
+                oversampling, vectorize, out_type, pad_mode, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -117,7 +117,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                        vectorize=self.vectorize,
                        size_scattering=size_scattering,
                        out_type=self.out_type,
-                       padtype=self.padtype)
+                       pad_mode=self.pad_mode)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = S.shape[-2:]

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -115,8 +115,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                        oversampling=self.oversampling,
                        vectorize=self.vectorize,
                        size_scattering=size_scattering,
-                       out_type=self.out_type,
-                       pad_mode=self.pad_mode)
+                       out_type=self.out_type)
 
         if self.out_type == 'array' and self.vectorize:
             scattering_shape = S.shape[-2:]

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -33,3 +33,8 @@ class TestScattering1DNumpy:
 
         Sx = scattering(x)
         assert np.allclose(Sx, Sx0)
+
+        with pytest.raises(ValueError) as record:
+            sc = Scattering1D(
+                J, T, Q, backend=backend, frontend='numpy', pad_mode="invalid")
+        assert "pad_mode" in record.value.args[0]


### PR DESCRIPTION
Allow user to choose between `reflect, symmetric, zero` padding.

While a fair default, `reflect` isn't all-purpose best; unless derivatives at boundaries are smooth, it may do more harm than good (I've seen in testing ridge extraction in `ssqueezepy`). Further, it is uniquely detrimental to JTFS, where lowpass captures opposite spin generated by `reflect` (confirmed with @lostanlen).

Current options are bottlenecked by TensorFlow; it can be configured per-backend. Most flexibly, a user can pass a `lambda`. For now I went with barebones that includes the important case of `zero` padding - most primitive, but also least priors, making it arguably general best. (P.S., answer to my 'quiz' at bottom [here](https://github.com/kymatio/kymatio/discussions/710) is boundary effects).
