### PR TITLE
Error upon no second-order coeffs w/ `max_order=2`

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -51,6 +51,11 @@ class ScatteringBase1D(ScatteringBase):
         else:
             raise ValueError("shape must be an integer or a 1-tuple")
 
+        # check that we get any second-order coefficients if max_order==2
+        if self.max_order == 2 and np.isnan(self.meta()['n'][-1][1]):
+            raise ValueError("configuration yields no second-order coefficients; "
+                             "try increasing `J`, or set `max_order=1`.")
+
         # Compute the minimum support to pad (ideally)
         min_to_pad = compute_minimum_support_to_pad(
             self.N, self.J, self.Q, r_psi=self.r_psi, sigma0=self.sigma0,

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -55,7 +55,8 @@ class ScatteringBase1D(ScatteringBase):
         meta = ScatteringBase1D.meta(self)
         if self.max_order == 2 and np.isnan(meta['n'][-1][1]):
             raise ValueError("configuration yields no second-order coefficients; "
-                             "try increasing `J`, or set `max_order=1`.")
+                             "try increasing `J`, or (`Scattering1D` only) "
+                             "set `max_order=1`.")
 
         # Compute the minimum support to pad (ideally)
         min_to_pad = compute_minimum_support_to_pad(

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -52,7 +52,8 @@ class ScatteringBase1D(ScatteringBase):
             raise ValueError("shape must be an integer or a 1-tuple")
 
         # check that we get any second-order coefficients if max_order==2
-        if self.max_order == 2 and np.isnan(self.meta()['n'][-1][1]):
+        meta = ScatteringBase1D.meta(self)
+        if self.max_order == 2 and np.isnan(meta['n'][-1][1]):
             raise ValueError("configuration yields no second-order coefficients; "
                              "try increasing `J`, or set `max_order=1`.")
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -51,13 +51,6 @@ class ScatteringBase1D(ScatteringBase):
         else:
             raise ValueError("shape must be an integer or a 1-tuple")
 
-        # check that we get any second-order coefficients if max_order==2
-        meta = ScatteringBase1D.meta(self)
-        if self.max_order == 2 and np.isnan(meta['n'][-1][1]):
-            raise ValueError("configuration yields no second-order coefficients; "
-                             "try increasing `J`, or (`Scattering1D` only) "
-                             "set `max_order=1`.")
-
         # Compute the minimum support to pad (ideally)
         min_to_pad = compute_minimum_support_to_pad(
             self.N, self.J, self.Q, r_psi=self.r_psi, sigma0=self.sigma0,
@@ -74,6 +67,11 @@ class ScatteringBase1D(ScatteringBase):
         # compute start and end indices
         self.ind_start, self.ind_end = compute_border_indices(
             self.J, self.pad_left, self.pad_left + self.N)
+
+        # record whether configuration yields second order filters
+        meta = ScatteringBase1D.meta(self)
+        self._no_second_order_filters = (self.max_order < 2 or
+                                         bool(np.isnan(meta['n'][-1][1])))
 
     def create_filters(self):
         # Create the filters

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -33,3 +33,8 @@ class TestScattering1DNumpy:
 
         Sx = scattering(x)
         assert np.allclose(Sx, Sx0)
+
+        with pytest.raises(ValueError) as record:
+            sc = Scattering1D(
+                shape=(512,), J=2, max_order=2, backend=backend, frontend='numpy')
+        assert "max_order=1" in record.value.args[0]

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -34,7 +34,6 @@ class TestScattering1DNumpy:
         Sx = scattering(x)
         assert np.allclose(Sx, Sx0)
 
-        with pytest.raises(ValueError) as record:
-            sc = Scattering1D(
-                shape=(512,), J=2, max_order=2, backend=backend, frontend='numpy')
-        assert "max_order=1" in record.value.args[0]
+        sc = Scattering1D(shape=(512,), J=2, max_order=2, backend=backend,
+                          frontend='numpy')
+        assert sc._no_second_order_filters


### PR DESCRIPTION
Users shouldn't think they're getting any second-order when they aren't. Likewise for joint coefficients in JTFS (which instead breaks internally rather than silently).