### PR TITLE
Improve padding & support computation

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -294,7 +294,7 @@ def compute_temporal_support(h_f, criterion_amplitude=1e-3):
     h = ifft(h_f, axis=1)
     half_support = h.shape[1] // 2
     # check if any value in half of worst case of abs(h) is below criterion
-    hhalf = np.max(np.abs(h[:, :half_support]), axis=0)[::-1]
+    hhalf = np.max(np.abs(h[:, :half_support]), axis=0)
     max_amplitude = hhalf.max()
     meets_criterion_idxs = np.where(hhalf <= criterion_amplitude * max_amplitude
                                     )[0]

--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -293,17 +293,16 @@ def compute_temporal_support(h_f, criterion_amplitude=1e-3):
     """
     h = ifft(h_f, axis=1)
     half_support = h.shape[1] // 2
-    # compute ||h - h_[-N, N]||_1
-    l1_residual = np.fliplr(
-        np.cumsum(np.fliplr(np.abs(h)[:, :half_support]), axis=1))
-    # find the first point above criterion_amplitude
-    if np.any(np.max(l1_residual, axis=0) <= criterion_amplitude):
+    # check if any value in half of worst case of abs(h) is below criterion
+    hhalf = np.max(np.abs(h[:, :half_support]), axis=0)[::-1]
+    max_amplitude = hhalf.max()
+    meets_criterion_idxs = np.where(hhalf <= criterion_amplitude * max_amplitude
+                                    )[0]
+    if len(meets_criterion_idxs) != 0:
         # if it is possible
-        N = np.min(
-            np.where(np.max(l1_residual, axis=0) <= criterion_amplitude)[0])\
-            + 1
+        N = meets_criterion_idxs.min() + 1
     else:
-        # if there is none:
+        # if there are none
         N = half_support
         # Raise a warning to say that there will be border effects
         warnings.warn('Signal support is too small to avoid border effects')

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -129,9 +129,9 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
         J_tentative, J, Q, normalize=normalize, to_torch=False,
         max_subsampling=0, criterion_amplitude=criterion_amplitude,
         r_psi=r_psi, sigma0=sigma0, alpha=alpha, P_max=P_max, eps=eps)
-    min_to_pad = 1.2 * t_max_phi
+    min_to_pad = int(1.2 * t_max_phi)
     if pad_mode == 'zero':
-        min_to_pad /= 2
+        min_to_pad //= 2
     return min_to_pad
 
 

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -66,7 +66,8 @@ def compute_padding(J_pad, T):
 
 def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
                                        normalize='l1', r_psi=math.sqrt(0.5),
-                                       sigma0=1e-1, alpha=5., P_max=5, eps=1e-7):
+                                       sigma0=1e-1, alpha=5., P_max=5, eps=1e-7,
+                                       pad_mode='reflect'):
 
 
     """
@@ -126,7 +127,9 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
         J_tentative, J, Q, normalize=normalize, to_torch=False,
         max_subsampling=0, criterion_amplitude=criterion_amplitude,
         r_psi=r_psi, sigma0=sigma0, alpha=alpha, P_max=P_max, eps=eps)
-    min_to_pad = 3 * t_max_phi
+    min_to_pad = 1.2 * t_max_phi
+    if pad_mode == 'zero':
+        min_to_pad /= 2
     return min_to_pad
 
 

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -115,6 +115,8 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
         required machine precision for the periodization (single
         floating point is enough for deep learning applications).
         Defaults to `1e-7`.
+    pad_mode : str
+        Name of padding used. If 'zero', will halve `min_to_pad`, else no effect.
 
     Returns
     -------


### PR DESCRIPTION
PR remedies:

 1. **Excessive padding**: padding by triple the filter's halfwidth on each side is overkill. Padding amount can also be halved for zero-padding.
 2. **Failure to detect boundary effects**: `compute_temporal_support`'s heuristic aims to find where the filter's envelope decays to some negligible threshold relative to its other values - but this fails where it's most needed: very high support `phi`. For example, it gives a green light on global averaging (`phi[0] = 1; phi[1:] = 0`). PR's scheme is to directly check whether it decays to some fraction of own maximum; this solves all edge cases (afaik) and is more honest to intent.

<hr>

### Excessive padding clarification

The goal of padding is, simply, "left shall not draw from right, and vice versa" - i.e. accounting for circular conv. This is perfectly accomplished with padding by half `phi_t`'s support on each side. If more padding is needed, it's because we're unhappy with `criterion_amplitude`; then either decrease it, or pad a little more - I've done latter. 

Zero padding enables halving whatever amount we chose for `reflect` (or any other scheme), since its left pad is identical to its right.

### Visuals

![image](https://user-images.githubusercontent.com/16495490/116124741-c0556980-a6d5-11eb-8051-5160f8cc82ee.png)

 - Boxcar for `phi_t` and zero padding in both for clarity
 - Red lines are unpad indices; nothing beyond them gets included in final output

### Code proof

```python
import numpy as np
from numpy.fft import fft, ifft

# define signal & padded
N = 2048
x = np.random.randn(N)
xp0 = np.pad(x, N//2)
xp1 = np.pad(x, N//4)

# define arbitrary window
phi_t0 = np.zeros(len(xp0))
phi_t0[:N//2] = np.random.randn(N//2)
phi_t1 = phi_t0[:len(xp1)]
# center both about n=0
phi_t0 = np.roll(phi_t0, -N//4)
phi_t1 = np.roll(phi_t1, -N//4)

# convolve & unpad
out0 = ifft(fft(phi_t0) * fft(xp0))[N//2:-N//2]
out1 = ifft(fft(phi_t1) * fft(xp1))[N//4:-N//4]

# assert equal
assert np.allclose(out0, out1)
```
