### PR TITLE
Correct filter scaling in subsampling

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -48,7 +48,7 @@ def adaptive_choice_P(sigma, eps=1e-7):
     return P
 
 
-def periodize_filter_fourier(h_f, nperiods=1, upscale=True):
+def periodize_filter_fourier(h_f, nperiods=1, aggregation_method='sum'):
     """
     Computes a periodization of a filter provided in the Fourier domain.
 
@@ -56,11 +56,12 @@ def periodize_filter_fourier(h_f, nperiods=1, upscale=True):
     ----------
     h_f : array_like
         complex numpy array of shape (N*n_periods,)
-    n_periods: int, optional
+    n_periods : int, optional
         Number of periods which should be used to periodize
-    upscale: bool (default True)
-        Whether to multiply time-domain signal by subsampling factor
-        to conserve energy.
+    aggregation_method : str['sum', 'mean']
+        'mean' will only subsample. 'sum' will multiply subsampled time-domain
+        signal by subsampling factor to conserve energy in strided convolution
+        (otherwise subsampling is "double-accounted").
 
     Returns
     -------
@@ -71,7 +72,7 @@ def periodize_filter_fourier(h_f, nperiods=1, upscale=True):
     """
     N = h_f.shape[0] // nperiods
     h_f_re = h_f.reshape(nperiods, N)
-    v_f = (h_f_re.sum(axis=0) if upscale else
+    v_f = (h_f_re.sum(axis=0) if aggregation_method == 'sum' else
            h_f_re.mean(axis=0))
     return v_f
 

--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -48,7 +48,7 @@ def adaptive_choice_P(sigma, eps=1e-7):
     return P
 
 
-def periodize_filter_fourier(h_f, nperiods=1):
+def periodize_filter_fourier(h_f, nperiods=1, upscale=True):
     """
     Computes a periodization of a filter provided in the Fourier domain.
 
@@ -58,6 +58,9 @@ def periodize_filter_fourier(h_f, nperiods=1):
         complex numpy array of shape (N*n_periods,)
     n_periods: int, optional
         Number of periods which should be used to periodize
+    upscale: bool (default True)
+        Whether to multiply time-domain signal by subsampling factor
+        to conserve energy.
 
     Returns
     -------
@@ -67,7 +70,9 @@ def periodize_filter_fourier(h_f, nperiods=1):
         v_f[k] = sum_{i=0}^{n_periods - 1} h_f[i * N + k]
     """
     N = h_f.shape[0] // nperiods
-    v_f = h_f.reshape(nperiods, N).mean(axis=0)
+    h_f_re = h_f.reshape(nperiods, N)
+    v_f = (h_f_re.sum(axis=0) if upscale else
+           h_f_re.mean(axis=0))
     return v_f
 
 

--- a/tests/scattering1d/test_correctness.py
+++ b/tests/scattering1d/test_correctness.py
@@ -1,0 +1,26 @@
+import numpy as np
+from kymatio.numpy import Scattering1D
+
+
+def test_energy_dirac():
+    """Test that zeroth + first-order coeffs' L1 norm sums to 1 for Dirac input.
+    """
+    N = 2048
+    J = 8
+    Q = 1
+    x = np.zeros(N)
+    x[N//2] = 1
+
+    ts = Scattering1D(shape=N, J=J, Q=Q, average=True)
+    ts_x = ts(x)
+
+    # compute L1 norm
+    ts_x_L1 = np.abs(ts_x).sum(axis=1)
+    ts_x_L1 *= 2**J  # account for subsampling
+
+    n_zeroth = 1
+    n_first  = J + 1
+    n_total  = n_zeroth + n_first
+    th = 1e-1  # can do better with greater N
+    max_adiff = np.max(np.abs(ts_x_L1[:n_total] - 1))
+    assert max_adiff < th, "max_adiff > th ({} > {})".format(max_adiff, th)


### PR DESCRIPTION
Current behavior effectively normalizes _twice_ for subsampling, which falsely discards energy and creates relative scaling disparities between coefficients. On a Dirac input, first-order coeffs L1 norm must be 1, but isn't. PR fixes this.

Suppose `k1, k1_J = 1, 2`. We have: (note, halving in energy due to subsampling by 2 is appropriate, but not quartering)

```python
U_1_c   = cdgmm(U_0_hat, psi1[n1][0])
U_1_hat = subsample_fourier(U_1_c, 2**k1)
U_1_c   = ifft(U_1_hat)

U_1_m   = modulus(U_1_c)
U_1_hat = rfft(U_1_m)

S_1_c   = cdgmm(U_1_hat, phi[k1])
S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
S_1_r   = irfft(S_1_hat)
```

  - **Old behavior**: `U_1_m`'s L1 norm is half of `U_0`'s (good). Since we subsampled `phi[k1]` by 2, its L1 norm is now `0.5`, and so `ifft(S_1_c)`'s L1 norm is `0.5`. Subsampling by `k1_J` we further slash by `1/2**k1_J`. Total: `1 / 2**(k1 + k1 + k1_J)`
  - **New behavior**: no loss to `phi[k1]`; total `1 / 2**(k1 + k1_J)`, as expected.

Note, if we instead convolve with `phi[0]` and then subsample `S_1_c` by `2**(k1 + k1_J)`, the total is `1 / 2**(k1 + k1_J)` - so currently _subsamplings don't commutate_ (when they _should_).

This adds up: convolving with longer input _then_ subsampling more will produce greater values than convolving with shorter input subsampled less, as conv kernel draws from more neighbors. Thus we must upscale the filters.