### PR TITLE
[WIP] Introduce `xi_min`

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -87,7 +87,8 @@ class ScatteringBase1D(ScatteringBase):
         meta : dictionary
             See the documentation for `compute_meta_scattering()`.
         """
-        return compute_meta_scattering(self.J, self.Q, max_order=self.max_order)
+        return compute_meta_scattering(self.J, self.Q, self.N,
+                                       max_order=self.max_order)
 
     def output_size(self, detail=False):
         """Get size of the scattering transform

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -87,7 +87,7 @@ class ScatteringBase1D(ScatteringBase):
         meta : dictionary
             See the documentation for `compute_meta_scattering()`.
         """
-        return compute_meta_scattering(self.J, self.Q, self.N,
+        return compute_meta_scattering(self.J, self.Q, self.J_pad,
                                        max_order=self.max_order)
 
     def output_size(self, detail=False):

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -181,7 +181,7 @@ def precompute_size_scattering(J, Q, max_order=2, detail=False):
             return size_order0 + size_order1
 
 
-def compute_meta_scattering(J, Q, N, max_order=2):
+def compute_meta_scattering(J, Q, J_pad, max_order=2):
     """Get metadata on the transform.
 
     This information specifies the content of each scattering coefficient,
@@ -195,8 +195,8 @@ def compute_meta_scattering(J, Q, N, max_order=2):
     Q : int >= 1
         The number of first-order wavelets per octave.
         Second-order wavelets are fixed to one wavelet per octave.
-    N : int
-        original signal support size
+    J_pad : int
+        2**J_pad == amount of temporal padding
     max_order : int, optional
         The maximum order of scattering coefficients to compute.
         Must be either equal to `1` or `2`. Defaults to `2`.
@@ -225,7 +225,7 @@ def compute_meta_scattering(J, Q, N, max_order=2):
             The tuples indexing the corresponding scattering coefficient
             in the non-vectorized output.
     """
-    xi_min = (2 / N)  # leftmost peak at bin 2
+    xi_min = (2 / 2**J_pad)  # leftmost peak at bin 2
     sigma_low, xi1s, sigma1s, j1s, xi2s, sigma2s, j2s = \
         calibrate_scattering_filters(J, Q, xi_min=xi_min)
 

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -181,7 +181,7 @@ def precompute_size_scattering(J, Q, max_order=2, detail=False):
             return size_order0 + size_order1
 
 
-def compute_meta_scattering(J, Q, max_order=2):
+def compute_meta_scattering(J, Q, N, max_order=2):
     """Get metadata on the transform.
 
     This information specifies the content of each scattering coefficient,
@@ -195,6 +195,8 @@ def compute_meta_scattering(J, Q, max_order=2):
     Q : int >= 1
         The number of first-order wavelets per octave.
         Second-order wavelets are fixed to one wavelet per octave.
+    N : int
+        original signal support size
     max_order : int, optional
         The maximum order of scattering coefficients to compute.
         Must be either equal to `1` or `2`. Defaults to `2`.
@@ -223,8 +225,9 @@ def compute_meta_scattering(J, Q, max_order=2):
             The tuples indexing the corresponding scattering coefficient
             in the non-vectorized output.
     """
+    xi_min = (2 / N)  # leftmost peak at bin 2
     sigma_low, xi1s, sigma1s, j1s, xi2s, sigma2s, j2s = \
-        calibrate_scattering_filters(J, Q)
+        calibrate_scattering_filters(J, Q, xi_min=xi_min)
 
     meta = {}
 


### PR DESCRIPTION
Introduces explicit guard against bandpasses ending up as pure sines.

See images. Attaining a proper wavelet can be very costly on padding, but at the same time we want to tile the entire frequency axis; I thus introduced `max_pad_factor` in latest JTFS, so user can choose faster compute at expense of boundary effects in small fraction of coefficients.

Rationale for `xi_min = 2/N` is, minimal possible wavelet is made with 3 samples in frequency domain (arguably 2), so peak cannot lie on bin 1, thus we put it at bin 2. As shown in "this PR only", this alone doesn't guarantee a good wavelet - it does, however, spare much padding that'd be required to make `psi1_f[-1]` a proper wavelet.

Note that other PRs in progress will allow a bandpass to become exactly a pure sine, exacerbating the problem.

### Current behavior

![image](https://user-images.githubusercontent.com/16495490/116840226-1cdceb00-abe6-11eb-967b-1b7f429dffb7.png)

### After this PR + others

![image](https://user-images.githubusercontent.com/16495490/116840186-fcad2c00-abe5-11eb-99e6-78b939c41c80.png)

### After this PR only

![image](https://user-images.githubusercontent.com/16495490/116840236-2403f900-abe6-11eb-92aa-ad68a0bedd2a.png)

### Plots code


<details>
  <summary><b>show</b></summary>

```python
# run from different branches
import numpy as np
from kymatio.numpy import Scattering1D
from ssqueezepy import ifft
from ssqueezepy.visuals import plot, scat

N = 2048 * 4
J = int(np.log2(N) - 1)
Q = 16
scattering = Scattering1D(J, N, Q, max_pad_factor=None)

p_fr = scattering.psi1_f[-1][0]
p_t = ifft(p_fr)

scat(p_fr[:30], show=1, title="psi1_f[-1][:30]")
plot(p_t, complex=1)
plot(p_t, abs=1, linestyle='--', color='k', title="ifft(psi1_f[-1])")
```
</details>