### PR TITLE
Agnostic padding

### DIFF
--- a/kymatio/scattering1d/backend/agnostic_backend.py
+++ b/kymatio/scattering1d/backend/agnostic_backend.py
@@ -1,6 +1,5 @@
 
-def pad(x, pad_left, pad_right, pad_mode='reflect', axis=-1,
-        backend_name='numpy'):
+def pad(x, pad_left, pad_right, pad_mode='reflect', axis=-1, out=None):
     """Backend-agnostic padding.
 
     Parameters
@@ -17,47 +16,46 @@ def pad(x, pad_left, pad_right, pad_mode='reflect', axis=-1,
             - reflect: [3,4,3,2, 1,2,3,4, 3,2,1]
     axis : int
         Axis to pad.
-    backend_name : str
-        One of: numpy, torch, tensorflow
 
     Returns
     -------
     out : type(x)
         Padded tensor.
     """
-    if backend_name == 'numpy':
-        import numpy as np
-        backend = np
-        kw = dict(dtype=x.dtype)
-    elif backend_name == 'torch':
-        import torch
-        backend = torch
-        kw = dict(dtype=x.dtype, layout=x.layout, device=x.device)
-    elif backend_name == 'tensorflow':
-        import tensorflow as tf
-        backend = tf
-        kw = dict(dtype=x.dtype)
+    # handle backend
+    backend, backend_name = _infer_backend(x, get_name=True)
+    kw = {'dtype': x.dtype}
+    if backend_name == 'torch':
+        kw.update({'layout': x.layout, 'device': x.device})
 
+    # extract shape info
     N = x.shape[axis]
     axis_idx = axis if axis >= 0 else (x.ndim + axis)
     padded_shape = (x.shape[:axis_idx] + (N + pad_left + pad_right,) +
                     x.shape[axis_idx + 1:])
-    out = backend.zeros(padded_shape, **kw)
-    if backend_name == 'tensorflow':  # TODO
-        out = out.numpy()
+    # make `out` if not provided / run assert
+    if out is None:
+        out = backend.zeros(padded_shape, **kw)
+    else:
+        assert out.shape == padded_shape, (out.shape, padded_shape)
 
-    pad_right_idx = (out.shape[axis] -
-                     (pad_right if pad_right != 0 else None))
-    out[index_axis(pad_left, pad_right_idx, axis, x.ndim)] = x
+    # fill initial `x`
+    pad_right_idx = ((out.shape[axis] - pad_right) if pad_right != 0 else
+                     None)
+    ix = index_axis(pad_left, pad_right_idx, axis, x.ndim)
+    if backend_name != 'tensorflow':
+        out[ix] = x
+    else:
+        from kymatio.backend.tensorflow_backend import TensorFlowBackend as B
+        out = B.assign_slice(out, x, ix)
 
+    # do padding
     if pad_mode == 'zero':
         pass  # already done
     elif pad_mode == 'reflect':
         xflip = _flip(x, backend, axis, backend_name)
-        out = _pad_reflect(x, xflip, out, pad_left, pad_right, N, axis)
-
-    if backend_name == 'tensorflow':  # TODO
-        out = tf.constant(out)
+        out = _pad_reflect(x, xflip, out, pad_left, pad_right, N, axis,
+                           backend_name)
     return out
 
 
@@ -69,21 +67,36 @@ def _flip(x, backend, axis, backend_name='numpy'):
         return backend.flip(x, (axis,))
 
 
-def _pad_reflect(x, xflip, out, pad_left, pad_right, N, axis):
+def _pad_reflect(x, xflip, out, pad_left, pad_right, N, axis, backend_name):
     # fill maximum needed number of reflections
     # pad left ###############################################################
     def idx(i0, i1):
         return index_axis(i0, i1, axis, x.ndim)
+
+    def assign(out, ix0, ix1):
+        # handle separately for performance
+        if backend_name != 'tensorflow':
+            if step % 2 == 0:
+                out[ix0] = xflip[ix1]
+            else:
+                out[ix0] = x[ix1]
+        else:
+            if step % 2 == 0:
+                out = B.assign_slice(out, xflip[ix1], ix0)
+            else:
+                out = B.assign_slice(out, x[ix1], ix0)
+        return out
+
+    if backend_name == 'tensorflow':
+        from kymatio.backend.tensorflow_backend import TensorFlowBackend as B
 
     step, already_stepped  = 0, 0
     while already_stepped < pad_left:
         max_step = min(N - 1, pad_left - already_stepped)
         end = pad_left - already_stepped
         start = end - max_step
-        if step % 2 == 0:
-            out[idx(start, end)] = xflip[idx(-(max_step + 1), -1)]
-        else:
-            out[idx(start, end)] = x[idx(-(max_step + 1), -1)]
+        ix0, ix1 = idx(start, end), idx(-(max_step + 1), -1)
+        out = assign(out, ix0, ix1)
         step += 1
         already_stepped += max_step
 
@@ -93,15 +106,13 @@ def _pad_reflect(x, xflip, out, pad_left, pad_right, N, axis):
         max_step = min(N - 1, pad_right - already_stepped)
         start = N + pad_left + already_stepped
         end = start + max_step
-        if step % 2 == 0:
-            out[idx(start, end)] = xflip[idx(1, max_step + 1)]
-        else:
-            out[idx(start, end)] = x[idx(1, max_step + 1)]
+        ix0, ix1 = idx(start, end), idx(1, max_step + 1)
+        out = assign(out, ix0, ix1)
         step += 1
         already_stepped += max_step
     return out
 
-
+## helpers ###################################################################
 def index_axis(i0, i1, axis, ndim, step=1):
     if axis < 0:
         slc = (slice(None),) * (ndim + axis) + (slice(i0, i1, step),)
@@ -112,3 +123,36 @@ def index_axis(i0, i1, axis, ndim, step=1):
 
 def flip_axis(axis, ndim, step=1):
     return index_axis(-1, None, axis, ndim, -step)
+
+
+def _infer_backend(x, get_name=False):
+    # this belongs in `kymatio\toolkit.py`
+    import numpy as np
+
+    while isinstance(x, (dict, list)):
+        if isinstance(x, dict):
+            if 'coef' in x:
+                x = x['coef']
+            else:
+                x = list(x.values())[0]
+        else:
+            x = x[0]
+
+    module = type(x).__module__.split('.')[0]
+
+    if module == 'numpy':
+        backend = np
+    elif module == 'torch':
+        import torch
+        backend = torch
+    elif module == 'tensorflow':
+        import tensorflow
+        backend = tensorflow
+    elif isinstance(x, (int, float)):
+        # list of lists, fallback to numpy
+        module = 'numpy'
+        backend = np
+    else:
+        raise ValueError("could not infer backend from %s" % type(x))
+    return (backend if not get_name else
+            (backend, module))

--- a/kymatio/scattering1d/backend/agnostic_backend.py
+++ b/kymatio/scattering1d/backend/agnostic_backend.py
@@ -1,0 +1,64 @@
+import numpy as np
+import torch
+
+
+def pad(x, pad_left, pad_right, pad_mode='reflect', backend_name='numpy'):
+    """
+       - zero:    [0,0,0,0, 1,2,3,4, 0,0,0]
+       - reflect: [3,4,3,2, 1,2,3,4, 3,2,1]
+    """
+    if backend_name == 'numpy':
+        backend = np
+        kw = dict(dtype=x.dtype)
+    elif backend_name == 'torch':
+        backend = torch
+        kw = dict(dtype=x.dtype, device=x.device)
+
+    N = x.shape[-1]
+    out = backend.zeros(x.shape[:-1] + (N + pad_left + pad_right,), **kw)
+    out[..., pad_left:-pad_right] = x
+
+    if pad_mode == 'zero':
+        out[..., :pad_left] = 0
+        out[..., -pad_right:] = 0
+    elif pad_mode == 'reflect':
+        xflip = _flip(x, backend_name)
+        out = _pad_reflect(x, xflip, out, pad_left, pad_right, N)
+    return out
+
+
+def _flip(x, backend_name='numpy'):
+    if backend_name == 'numpy':
+        return x[..., ::-1]
+    elif backend_name == 'torch':
+        return torch.flip(x, (x.ndim - 1,))
+
+
+def _pad_reflect(x, xflip, out, pad_left, pad_right, N):
+    # fill maximum needed number of reflections
+    # pad left ###############################################################
+    step, already_stepped  = 0, 0
+    while already_stepped < pad_left:
+        max_step = min(N - 1, pad_left - already_stepped)
+        end = pad_left - already_stepped
+        start = end - max_step
+        if step % 2 == 0:
+            out[..., start:end] = xflip[..., -(max_step + 1):-1]
+        else:
+            out[..., start:end] = x[..., -(max_step + 1):-1]
+        step += 1
+        already_stepped += max_step
+
+    # pad right ##############################################################
+    step, already_stepped  = 0, 0
+    while already_stepped < pad_right:
+        max_step = min(N - 1, pad_right - already_stepped)
+        start = N + pad_left + already_stepped
+        end = start + max_step
+        if step % 2 == 0:
+            out[..., start:end] = xflip[..., 1:(max_step + 1)]
+        else:
+            out[..., start:end] = x[..., 1:(max_step + 1)]
+        step += 1
+        already_stepped += max_step
+    return out

--- a/kymatio/scattering1d/backend/agnostic_backend.py
+++ b/kymatio/scattering1d/backend/agnostic_backend.py
@@ -1,10 +1,6 @@
-import numpy as np
-import torch
-
 
 def pad(x, pad_left, pad_right, pad_mode='reflect', backend_name='numpy'):
     """Backend-agnostic padding.
-
     Parameters
     ----------
     x : input tensor
@@ -19,37 +15,49 @@ def pad(x, pad_left, pad_right, pad_mode='reflect', backend_name='numpy'):
             - reflect: [3,4,3,2, 1,2,3,4, 3,2,1]
     backend_name : str
         One of: numpy, torch, tensorflow
-
     Returns
     -------
     out : type(x)
         Padded tensor.
     """
     if backend_name == 'numpy':
+        import numpy as np
         backend = np
         kw = dict(dtype=x.dtype)
     elif backend_name == 'torch':
+        import torch
         backend = torch
-        kw = dict(dtype=x.dtype, device=x.device)
+        kw = dict(dtype=x.dtype, layout=x.layout, device=x.device)
+    elif backend_name == 'tensorflow':
+        import tensorflow as tf
+        backend = tf
+        kw = dict(dtype=x.dtype)
 
     N = x.shape[-1]
     out = backend.zeros(x.shape[:-1] + (N + pad_left + pad_right,), **kw)
+    if backend_name == 'tensorflow':  # TODO
+        out = out.numpy()
     out[..., pad_left:-pad_right] = x
 
     if pad_mode == 'zero':
         out[..., :pad_left] = 0
         out[..., -pad_right:] = 0
     elif pad_mode == 'reflect':
-        xflip = _flip(x, backend_name)
+        xflip = _flip(x, backend, backend_name)
         out = _pad_reflect(x, xflip, out, pad_left, pad_right, N)
+
+    if backend_name == 'tensorflow':  # TODO
+        out = tf.constant(out)
     return out
 
 
-def _flip(x, backend_name='numpy'):
+def _flip(x, backend, backend_name='numpy'):
     if backend_name == 'numpy':
         return x[..., ::-1]
     elif backend_name == 'torch':
-        return torch.flip(x, (x.ndim - 1,))
+        return backend.flip(x, (x.ndim - 1,))
+    elif backend_name == 'tensorflow':
+        return x[..., ::-1]
 
 
 def _pad_reflect(x, xflip, out, pad_left, pad_right, N):

--- a/kymatio/scattering1d/backend/agnostic_backend.py
+++ b/kymatio/scattering1d/backend/agnostic_backend.py
@@ -3,9 +3,27 @@ import torch
 
 
 def pad(x, pad_left, pad_right, pad_mode='reflect', backend_name='numpy'):
-    """
-       - zero:    [0,0,0,0, 1,2,3,4, 0,0,0]
-       - reflect: [3,4,3,2, 1,2,3,4, 3,2,1]
+    """Backend-agnostic padding.
+
+    Parameters
+    ----------
+    x : input tensor
+        Input tensor.
+    pad_left : int >= 0
+        Amount to pad on left.
+    pad_right : int >= 0
+        Amount to pad on right.
+    pad_mode : str
+        One of supported padding modes:
+            - zero:    [0,0,0,0, 1,2,3,4, 0,0,0]
+            - reflect: [3,4,3,2, 1,2,3,4, 3,2,1]
+    backend_name : str
+        One of: numpy, torch, tensorflow
+
+    Returns
+    -------
+    out : type(x)
+        Padded tensor.
     """
     if backend_name == 'numpy':
         backend = np

--- a/kymatio/scattering1d/backend/agnostic_backend.py
+++ b/kymatio/scattering1d/backend/agnostic_backend.py
@@ -1,6 +1,8 @@
 
-def pad(x, pad_left, pad_right, pad_mode='reflect', backend_name='numpy'):
+def pad(x, pad_left, pad_right, pad_mode='reflect', axis=-1,
+        backend_name='numpy'):
     """Backend-agnostic padding.
+
     Parameters
     ----------
     x : input tensor
@@ -13,8 +15,11 @@ def pad(x, pad_left, pad_right, pad_mode='reflect', backend_name='numpy'):
         One of supported padding modes:
             - zero:    [0,0,0,0, 1,2,3,4, 0,0,0]
             - reflect: [3,4,3,2, 1,2,3,4, 3,2,1]
+    axis : int
+        Axis to pad.
     backend_name : str
         One of: numpy, torch, tensorflow
+
     Returns
     -------
     out : type(x)
@@ -33,45 +38,52 @@ def pad(x, pad_left, pad_right, pad_mode='reflect', backend_name='numpy'):
         backend = tf
         kw = dict(dtype=x.dtype)
 
-    N = x.shape[-1]
-    out = backend.zeros(x.shape[:-1] + (N + pad_left + pad_right,), **kw)
+    N = x.shape[axis]
+    axis_idx = axis if axis >= 0 else (x.ndim + axis)
+    padded_shape = (x.shape[:axis_idx] + (N + pad_left + pad_right,) +
+                    x.shape[axis_idx + 1:])
+    out = backend.zeros(padded_shape, **kw)
     if backend_name == 'tensorflow':  # TODO
         out = out.numpy()
-    out[..., pad_left:-pad_right] = x
+
+    pad_right_idx = (out.shape[axis] -
+                     (pad_right if pad_right != 0 else None))
+    out[index_axis(pad_left, pad_right_idx, axis, x.ndim)] = x
 
     if pad_mode == 'zero':
-        out[..., :pad_left] = 0
-        out[..., -pad_right:] = 0
+        pass  # already done
     elif pad_mode == 'reflect':
-        xflip = _flip(x, backend, backend_name)
-        out = _pad_reflect(x, xflip, out, pad_left, pad_right, N)
+        xflip = _flip(x, backend, axis, backend_name)
+        out = _pad_reflect(x, xflip, out, pad_left, pad_right, N, axis)
 
     if backend_name == 'tensorflow':  # TODO
         out = tf.constant(out)
     return out
 
 
-def _flip(x, backend, backend_name='numpy'):
-    if backend_name == 'numpy':
-        return x[..., ::-1]
+def _flip(x, backend, axis, backend_name='numpy'):
+    if backend_name in ('numpy', 'tensorflow'):
+        return x[flip_axis(axis, x.ndim)]
     elif backend_name == 'torch':
-        return backend.flip(x, (x.ndim - 1,))
-    elif backend_name == 'tensorflow':
-        return x[..., ::-1]
+        axis = axis if axis >= 0 else (x.ndim + axis)
+        return backend.flip(x, (axis,))
 
 
-def _pad_reflect(x, xflip, out, pad_left, pad_right, N):
+def _pad_reflect(x, xflip, out, pad_left, pad_right, N, axis):
     # fill maximum needed number of reflections
     # pad left ###############################################################
+    def idx(i0, i1):
+        return index_axis(i0, i1, axis, x.ndim)
+
     step, already_stepped  = 0, 0
     while already_stepped < pad_left:
         max_step = min(N - 1, pad_left - already_stepped)
         end = pad_left - already_stepped
         start = end - max_step
         if step % 2 == 0:
-            out[..., start:end] = xflip[..., -(max_step + 1):-1]
+            out[idx(start, end)] = xflip[idx(-(max_step + 1), -1)]
         else:
-            out[..., start:end] = x[..., -(max_step + 1):-1]
+            out[idx(start, end)] = x[idx(-(max_step + 1), -1)]
         step += 1
         already_stepped += max_step
 
@@ -82,9 +94,21 @@ def _pad_reflect(x, xflip, out, pad_left, pad_right, N):
         start = N + pad_left + already_stepped
         end = start + max_step
         if step % 2 == 0:
-            out[..., start:end] = xflip[..., 1:(max_step + 1)]
+            out[idx(start, end)] = xflip[idx(1, max_step + 1)]
         else:
-            out[..., start:end] = x[..., 1:(max_step + 1)]
+            out[idx(start, end)] = x[idx(1, max_step + 1)]
         step += 1
         already_stepped += max_step
     return out
+
+
+def index_axis(i0, i1, axis, ndim, step=1):
+    if axis < 0:
+        slc = (slice(None),) * (ndim + axis) + (slice(i0, i1, step),)
+    else:
+        slc = (slice(None),) * axis + (slice(i0, i1, step),)
+    return slc
+
+
+def flip_axis(axis, ndim, step=1):
+    return index_axis(-1, None, axis, ndim, -step)

--- a/tests/scattering1d/test_correctness.py
+++ b/tests/scattering1d/test_correctness.py
@@ -1,0 +1,48 @@
+import pytest
+import numpy as np
+import torch
+from kymatio.scattering1d.backend.agnostic_backend import pad
+
+run_without_pytest = 1
+
+
+def _test_padding(backend_name):
+    if backend_name == 'numpy':
+        backend = np
+    elif backend_name == 'torch':
+        backend = torch
+
+    for N in (128, 129):  # even, odd
+        x = backend.arange(6 * N).reshape(2, 3, N)
+        for pad_factor in (1, 2, 3, 4):
+            pad_left = (N // 2) * pad_factor
+            pad_right = int(np.ceil(N / 4) * pad_factor)
+
+            for pad_mode in ('zero', 'reflect'):
+                out0 = pad(x, pad_left, pad_right, pad_mode=pad_mode,
+                           backend_name=backend_name)
+                out1 = np.pad(x,
+                              [[0, 0]] * (x.ndim - 1) + [[pad_left, pad_right]],
+                              mode=pad_mode if pad_mode != 'zero' else 'constant')
+
+                if backend_name == 'torch':
+                    out1 = torch.from_numpy(out1)
+                assert backend.allclose(out0, out1), (
+                    "{} | (N, pad_mode, pad_left, pad_right) = ({}, {}, {}, {})"
+                    ).format(backend_name, N, pad_mode, pad_left, pad_right)
+
+
+def test_numpy():
+    _test_padding('numpy')
+
+
+def test_torch():
+    _test_padding('torch')
+
+
+if __name__ == '__main__':
+    if run_without_pytest:
+        test_numpy()
+        test_torch()
+    else:
+        pytest.main([__file__, "-s"])

--- a/tests/scattering1d/test_correctness.py
+++ b/tests/scattering1d/test_correctness.py
@@ -7,19 +7,13 @@ run_without_pytest = 0
 
 
 def _test_padding(backend_name):
+    """Test that agnostic implementation matches numpy's."""
     def _arange(N):
         if backend_name == 'tensorflow':
             return backend.range(N)
         return backend.arange(N)
 
-    if backend_name == 'numpy':
-        backend = np
-    elif backend_name == 'torch':
-        import torch
-        backend = torch
-    elif backend_name == 'tensorflow':
-        import tensorflow as tf
-        backend = tf
+    backend = _get_backend(backend_name)
 
     for N in (128, 129):  # even, odd
         x = backend.reshape(_arange(6 * N), (2, 3, N))
@@ -40,8 +34,28 @@ def _test_padding(backend_name):
                     ).format(backend_name, N, pad_mode, pad_left, pad_right)
 
 
+def _test_pad_axis(backend_name):
+    """Test that padding any N-dim axis works as expected."""
+    backend = _get_backend(backend_name)
+    x = backend.zeros((5, 6, 7, 8, 9, 10, 11))
+
+    pad_left, pad_right = 4, 5
+    kw = dict(pad_left=pad_left, pad_right=pad_right, pad_mode='reflect',
+              backend_name=backend_name)
+
+    for axis in range(x.ndim):
+        shape0 = list(x.shape)
+        shape0[axis] += (pad_left + pad_right)
+        shape1 = pad(x, axis=axis, **kw).shape
+        shape2 = pad(x, axis=axis - x.ndim, **kw).shape  # negative axis version
+
+        assert np.allclose(shape0, shape1)
+        assert np.allclose(shape0, shape2)
+
+
 def test_pad_numpy():
     _test_padding('numpy')
+    _test_pad_axis('numpy')
 
 
 def test_pad_torch():
@@ -51,6 +65,7 @@ def test_pad_torch():
         warnings.warn("Failed to import torch")
         return
     _test_padding('torch')
+    _test_pad_axis('torch')
 
 
 def test_pad_tensorflow():
@@ -60,6 +75,19 @@ def test_pad_tensorflow():
         warnings.warn("Failed to import tensorflow")
         return
     _test_padding('tensorflow')
+    _test_pad_axis('tensorflow')
+
+
+def _get_backend(backend_name):
+    if backend_name == 'numpy':
+        backend = np
+    elif backend_name == 'torch':
+        import torch
+        backend = torch
+    elif backend_name == 'tensorflow':
+        import tensorflow as tf
+        backend = tf
+    return backend
 
 
 if __name__ == '__main__':

--- a/tests/scattering1d/test_correctness.py
+++ b/tests/scattering1d/test_correctness.py
@@ -1,19 +1,28 @@
 import pytest
 import numpy as np
-import torch
+import warnings
 from kymatio.scattering1d.backend.agnostic_backend import pad
 
 run_without_pytest = 0
 
 
 def _test_padding(backend_name):
+    def _arange(N):
+        if backend_name == 'tensorflow':
+            return backend.range(N)
+        return backend.arange(N)
+
     if backend_name == 'numpy':
         backend = np
     elif backend_name == 'torch':
+        import torch
         backend = torch
+    elif backend_name == 'tensorflow':
+        import tensorflow as tf
+        backend = tf
 
     for N in (128, 129):  # even, odd
-        x = backend.arange(6 * N).reshape(2, 3, N)
+        x = backend.reshape(_arange(6 * N), (2, 3, N))
         for pad_factor in (1, 2, 3, 4):
             pad_left = (N // 2) * pad_factor
             pad_right = int(np.ceil(N / 4) * pad_factor)
@@ -25,24 +34,38 @@ def _test_padding(backend_name):
                               [[0, 0]] * (x.ndim - 1) + [[pad_left, pad_right]],
                               mode=pad_mode if pad_mode != 'zero' else 'constant')
 
-                if backend_name == 'torch':
-                    out1 = torch.from_numpy(out1)
-                assert backend.allclose(out0, out1), (
+                out0 = out0.numpy() if hasattr(out0, 'numpy') else out0
+                assert np.allclose(out0, out1), (
                     "{} | (N, pad_mode, pad_left, pad_right) = ({}, {}, {}, {})"
                     ).format(backend_name, N, pad_mode, pad_left, pad_right)
 
 
-def test_numpy():
+def test_pad_numpy():
     _test_padding('numpy')
 
 
-def test_torch():
+def test_pad_torch():
+    try:
+        import torch
+    except ImportError:
+        warnings.warn("Failed to import torch")
+        return
     _test_padding('torch')
+
+
+def test_pad_tensorflow():
+    try:
+        import tensorflow
+    except ImportError:
+        warnings.warn("Failed to import tensorflow")
+        return
+    _test_padding('tensorflow')
 
 
 if __name__ == '__main__':
     if run_without_pytest:
-        test_numpy()
-        test_torch()
+        test_pad_numpy()
+        test_pad_torch()
+        test_pad_tensorflow()
     else:
         pytest.main([__file__, "-s"])

--- a/tests/scattering1d/test_correctness.py
+++ b/tests/scattering1d/test_correctness.py
@@ -3,7 +3,7 @@ import numpy as np
 import torch
 from kymatio.scattering1d.backend.agnostic_backend import pad
 
-run_without_pytest = 1
+run_without_pytest = 0
 
 
 def _test_padding(backend_name):


### PR DESCRIPTION
Pad modes implemented in backend-agnostic manner, permitting any pad length.

Currently only torch is tested. Problem is, it [lacks negative stride](https://github.com/pytorch/pytorch/issues/229) and makes a copy (though just once). So it's optimally done via CuPy.

However, padding isn't currently used anywhere except on input (which is very fast relative to transform itself), so there's a workaround: convert to and pad in numpy, revert. This'll support all of numpy's large variety of paddings for any length.

Wasn't sure where to put this so I made an `agnostic_backend.py`. Not deploy-ready, awaiting review.