### PR TITLE
Improve `compute_minimum_support_to_pad`

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -332,22 +332,25 @@ def compute_minimum_required_length(fn, N_init, max_N=None,
 
     Returns
     -------
-    N_min : int
+    N: int
         Minimum required number of samples for `fn(N)` to have temporal
-        support less than `N`. If `fn` ends up global averaging, will return -1
-        (no such `N` exists).
+        support less than `N`.
     """
     N = 2**math.ceil(math.log2(N_init))  # ensure pow 2
-    N_min = N
     while True:
-        p_fr = fn(N)
-        N_min = 2 * compute_temporal_support(
+        try:
+            p_fr = fn(N)
+        except ValueError:  # get_normalizing_factor()
+            N *= 2
+            continue
+
+        p_halfwidth = compute_temporal_support(
             p_fr.reshape(1, -1), criterion_amplitude=criterion_amplitude)
 
         if N > 1e9:  # avoid crash
             raise Exception("couldn't satisfy stop criterion before `N > 1e9`; "
                             "check `fn`")
-        if N_min < N or (max_N is not None and N > max_N):
+        if 2 * p_halfwidth < N or (max_N is not None and N > max_N):
             break
         N *= 2
     return N

--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -314,7 +314,6 @@ def compute_minimum_required_length(fn, N_init, max_N=None,
                                     criterion_amplitude=1e-3):
     """Computes minimum required number of samples for `fn(N)` to have temporal
     support less than `N`, as determined by `compute_temporal_support`.
-
     Parameters
     ----------
     fn: FunctionType
@@ -329,7 +328,6 @@ def compute_minimum_required_length(fn, N_init, max_N=None,
         value \\epsilon controlling the numerical
         error. The larger criterion_amplitude, the smaller the temporal
         support and the larger the numerical error. Defaults to 1e-3
-
     Returns
     -------
     N: int

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -52,7 +52,7 @@ class ScatteringBase1D(ScatteringBase):
             raise ValueError("shape must be an integer or a 1-tuple")
 
         # Compute the minimum support to pad (ideally)
-        min_to_pad = compute_minimum_support_to_pad(
+        min_to_pad, N_ref = compute_minimum_support_to_pad(
             self.N, self.J, self.Q, r_psi=self.r_psi, sigma0=self.sigma0,
             alpha=self.alpha, P_max=self.P_max, eps=self.eps,
             criterion_amplitude=self.criterion_amplitude,
@@ -60,7 +60,7 @@ class ScatteringBase1D(ScatteringBase):
         # to avoid padding more than N - 1 on the left and on the right,
         # since otherwise torch sends nans
         J_max_support = int(np.floor(np.log2(3 * self.N - 2)))
-        self.J_pad = min(int(np.ceil(np.log2(self.N + 2 * min_to_pad))),
+        self.J_pad = min(int(np.ceil(np.log2(N_ref + 2 * min_to_pad))),
                          J_max_support)
         # compute the padding quantities:
         self.pad_left, self.pad_right = compute_padding(self.J_pad, self.N)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -52,11 +52,11 @@ class ScatteringBase1D(ScatteringBase):
             raise ValueError("shape must be an integer or a 1-tuple")
 
         # Compute the minimum support to pad (ideally)
-        min_to_pad = compute_minimum_support_to_pad(
-            self.N, self.J, self.Q, r_psi=self.r_psi, sigma0=self.sigma0,
-            alpha=self.alpha, P_max=self.P_max, eps=self.eps,
+        min_to_pad, *_ = compute_minimum_support_to_pad(
+            self.N, self.J, self.Q, self.T, r_psi=self.r_psi,
+            sigma0=self.sigma0, alpha=self.alpha, P_max=self.P_max, eps=self.eps,
             criterion_amplitude=self.criterion_amplitude,
-            normalize=self.normalize)
+            normalize=self.normalize, pad_mode=self.pad_mode)
         # to avoid padding more than N - 1 on the left and on the right,
         # since otherwise torch sends nans
         J_max_support = int(np.floor(np.log2(3 * self.N - 2)))

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -52,7 +52,7 @@ class ScatteringBase1D(ScatteringBase):
             raise ValueError("shape must be an integer or a 1-tuple")
 
         # Compute the minimum support to pad (ideally)
-        min_to_pad, N_ref = compute_minimum_support_to_pad(
+        min_to_pad = compute_minimum_support_to_pad(
             self.N, self.J, self.Q, r_psi=self.r_psi, sigma0=self.sigma0,
             alpha=self.alpha, P_max=self.P_max, eps=self.eps,
             criterion_amplitude=self.criterion_amplitude,
@@ -60,7 +60,7 @@ class ScatteringBase1D(ScatteringBase):
         # to avoid padding more than N - 1 on the left and on the right,
         # since otherwise torch sends nans
         J_max_support = int(np.floor(np.log2(3 * self.N - 2)))
-        self.J_pad = min(int(np.ceil(np.log2(N_ref + 2 * min_to_pad))),
+        self.J_pad = min(int(np.ceil(np.log2(self.N + 2 * min_to_pad))),
                          J_max_support)
         # compute the padding quantities:
         self.pad_left, self.pad_right = compute_padding(self.J_pad, self.N)

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -176,16 +176,19 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
     else:
         psi2_halfwidth = -1
 
-    # take maximum
-    t_max = max(phi_halfwidth, psi1_halfwidth, psi2_halfwidth)
+    # set min to pad based on each; take a little extra on each to be safe
+    pads = [int(1.1 * hw) for hw in
+            (phi_halfwidth, psi1_halfwidth, psi2_halfwidth)]
 
-    # set min to pad based on maximum
-    min_to_pad = int(1.2 * t_max)  # take a little extra to be safe
+    # can pad half as much
     if pad_mode == 'zero':
-        min_to_pad //= 2
+        pads = [p//2 for p in pads]
+    pad_phi, pad_psi1, pad_psi2 = pads
+    # set main quantity as the max of all
+    min_to_pad = max(pads)
 
     # return results
-    return min_to_pad
+    return min_to_pad, pad_phi, pad_psi1, pad_psi2
 
 
 def precompute_size_scattering(J, Q, max_order=2, detail=False):

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -141,9 +141,10 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
     Q1, Q2 = Q if isinstance(Q, tuple) else (Q, 1)
     Q_temp = (max(Q1, 1), max(Q2, 1))  # don't pass in zero
     N = 2 ** J_support
-    xi_min = (2 / N)  # leftmost peak at bin 2
+    # compute without limit, will find necessary pad_psi then check in factories
+    xi_min = -1
 
-    sigma_low, xi1, sigma1, j1s, xi2, sigma2, j2s = \
+    sigma_low, xi1, sigma1, j1s, _, xi2, sigma2, j2s, _ = \
         calibrate_scattering_filters(J_scattering, Q_temp, T, xi_min=xi_min)
 
     # compute psi1_f with greatest time support, if requested
@@ -158,27 +159,25 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
     phi_f_fn = lambda N: gauss_1d(N, sigma_low, P_max=P_max, eps=eps)
 
     # compute for all cases as psi's time support might exceed phi's
-    kw = dict(criterion_amplitude=criterion_amplitude)
-    N_min_phi = compute_minimum_required_length(phi_f_fn, N_init=N, **kw)
-    phi_halfwidth = compute_temporal_support(
-        phi_f_fn(N_min_phi).reshape(1, -1), **kw)
+    ca = dict(criterion_amplitude=criterion_amplitude)
+    N_min_phi = compute_minimum_required_length(phi_f_fn, N_init=N, **ca)
+    phi_halfwidth = compute_temporal_support(phi_f_fn(N_min_phi)[None], **ca)
 
     if Q1 >= 1:
-        N_min_psi1 = compute_minimum_required_length(psi1_f_fn, N_init=N, **kw)
-        psi1_halfwidth = compute_temporal_support(
-            psi1_f_fn(N_min_psi1).reshape(1, -1), **kw)
+        N_min_psi1 = compute_minimum_required_length(psi1_f_fn, N_init=N, **ca)
+        psi1_halfwidth = compute_temporal_support(psi1_f_fn(N_min_psi1)[None],
+                                                  **ca)
     else:
         psi1_halfwidth = -1  # placeholder
     if Q2 >= 1:
-        N_min_psi2 = compute_minimum_required_length(psi2_f_fn, N_init=N, **kw)
-        psi2_halfwidth = compute_temporal_support(
-            psi2_f_fn(N_min_psi2).reshape(1, -1), **kw)
+        N_min_psi2 = compute_minimum_required_length(psi2_f_fn, N_init=N, **ca)
+        psi2_halfwidth = compute_temporal_support(psi2_f_fn(N_min_psi2)[None],
+                                                  **ca)
     else:
         psi2_halfwidth = -1
 
-    # set min to pad based on each; take a little extra on each to be safe
-    pads = [int(1.1 * hw) for hw in
-            (phi_halfwidth, psi1_halfwidth, psi2_halfwidth)]
+    # set min to pad based on each
+    pads = (phi_halfwidth, psi1_halfwidth, psi2_halfwidth)
 
     # can pad half as much
     if pad_mode == 'zero':

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -131,10 +131,6 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
     min_to_pad: int
         minimal value to pad the signal on one size to avoid any
         boundary error.
-    N_ref: int
-        Length of longest filter that decays to have time support less than
-        half own length, which may exceed `N`; this is the `N` to be used
-        for computing final pad length.
     """
     # compute params for calibrating, & calibrate
     J_tentative = int(np.ceil(np.log2(N)))
@@ -200,10 +196,9 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
         N_min_psi2 = -2
 
     # take maximum
-    N_min_max = max(N_min_phi, N_min_psi1, N_min_psi2)
-    if N_min_phi == N_min_max:
+    if N_min_phi == max(N_min_phi, N_min_psi1, N_min_psi2):
         p_fr = phi_f_fn(N_min_phi)
-    elif N_min_psi1 == N_min_max:
+    elif N_min_psi1 == max(N_min_phi, N_min_psi1, N_min_psi2):
         p_fr = psi1_f_fn_widest(N_min_psi1)
     else:
         p_fr = psi2_f_fn_widest(N_min_psi2)
@@ -216,8 +211,7 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
         min_to_pad //= 2
 
     # return results
-    N_ref = N_min_max
-    return min_to_pad, N_ref
+    return min_to_pad
 
 
 def precompute_size_scattering(J, Q, max_order=2, detail=False):

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -1,6 +1,8 @@
 import numpy as np
 import math
-from .filter_bank import scattering_filter_factory, calibrate_scattering_filters
+from .filter_bank import (calibrate_scattering_filters, compute_temporal_support,
+                          compute_minimum_required_length, gauss_1d, morlet_1d)
+
 
 def compute_border_indices(J, i0, i1):
     """
@@ -64,9 +66,10 @@ def compute_padding(J_pad, T):
         raise ValueError('Too large padding value, will lead to NaN errors')
     return pad_left, pad_right
 
-def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
+def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
                                        normalize='l1', r_psi=math.sqrt(0.5),
-                                       sigma0=1e-1, alpha=5., P_max=5, eps=1e-7):
+                                       sigma0=1e-1, alpha=5., P_max=5, eps=1e-7,
+                                       pad_mode='reflect'):
 
 
     """
@@ -75,12 +78,18 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
 
     Parameters
     ----------
-    T : int
+    N : int
         temporal size of the input signal
     J : int
         scale of the scattering
-    Q : int
-        number of wavelets per octave
+    Q : int >= 1
+        The number of first-order wavelets per octave.
+    T : int
+        temporal support of low-pass filter, controlling amount of imposed
+        time-shift invariance and subsampling
+    Q2 : int >= 0  # TODO
+        The number of second-order wavelets per octave.
+        If 0, will exclude `psi2` from computation.
     normalize : string, optional
         normalization type for the wavelets.
         Only `'l2'` or `'l1'` normalizations are supported.
@@ -114,6 +123,8 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
         required machine precision for the periodization (single
         floating point is enough for deep learning applications).
         Defaults to `1e-7`.
+    pad_mode : str
+        Name of padding used. If 'zero', will halve `min_to_pad`, else no effect.
 
     Returns
     -------
@@ -121,12 +132,85 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
         minimal value to pad the signal on one size to avoid any
         boundary error.
     """
-    J_tentative = int(np.ceil(np.log2(T)))
-    _, _, _, t_max_phi = scattering_filter_factory(
-        J_tentative, J, Q, normalize=normalize, to_torch=False,
-        max_subsampling=0, criterion_amplitude=criterion_amplitude,
-        r_psi=r_psi, sigma0=sigma0, alpha=alpha, P_max=P_max, eps=eps)
-    min_to_pad = 3 * t_max_phi
+    # compute params for calibrating, & calibrate
+    J_tentative = int(np.ceil(np.log2(N)))
+    J_support = J_tentative
+    J_scattering = J
+
+    Q1, Q2 = Q if isinstance(Q, tuple) else (Q, 1)
+    Q_temp = (max(Q1, 1), max(Q2, 1))  # don't pass in zero
+    N = 2 ** J_support
+    xi_min = (2 / N)  # leftmost peak at bin 2
+
+    sigma_low, xi1, sigma1, j1s, is_cqt1, xi2, sigma2, j2s, is_cqt2 = \
+        calibrate_scattering_filters(J_scattering, Q_temp, T, xi_min=xi_min)
+
+    def last_cqt(is_cqt):
+        """Begin iterating from last CQT wavelet."""
+        return (is_cqt.index(False) if False in is_cqt else len(is_cqt)) - 1
+
+    # compute psi1_f with greatest time support, if requested
+    if Q1 >= 1:
+        # TODO subsampled variant
+        n1_last_cqt = last_cqt(is_cqt1)
+        for n1 in range(n1_last_cqt, len(j1s)):
+            try:
+                psi1_f_fn = lambda N: morlet_1d(
+                    N, xi1[n1], sigma1[n1], normalize=normalize, P_max=P_max,
+                    eps=eps)
+                _ = psi1_f_fn(N)
+            except ValueError as e:
+                if is_cqt1[n1]:
+                    raise e
+                break
+        psi1_f_fn_widest = psi1_f_fn
+
+    # compute psi2_f with greatest time support, if requested
+    if Q2 >= 1:
+        n2_last_cqt = last_cqt(is_cqt2)
+        for n2 in range(n2_last_cqt, len(j2s)):
+            try:
+                psi2_f_fn = lambda N: morlet_1d(
+                    N, xi2[n2], sigma2[n2], normalize=normalize, P_max=P_max,
+                    eps=eps)
+                _ = psi2_f_fn(N)
+            except ValueError as e:
+                if is_cqt2[n2]:
+                    raise e
+                break
+        psi2_f_fn_widest = psi2_f_fn
+
+    # compute lowpass
+    phi_f_fn = lambda N: gauss_1d(N, sigma_low, P_max=P_max, eps=eps)
+
+    # compute for all cases as psi's time support might exceed phi's
+    kw = dict(N_init=N, criterion_amplitude=criterion_amplitude)
+    N_min_phi = compute_minimum_required_length(phi_f_fn, **kw)
+    if Q1 >= 1:
+        N_min_psi1 = compute_minimum_required_length(psi1_f_fn, **kw)
+    else:
+        N_min_psi1 = -2  # placeholder
+    if Q2 >= 1:
+        N_min_psi2 = compute_minimum_required_length(psi2_f_fn, **kw)
+    else:
+        N_min_psi2 = -2
+
+    # take maximum
+    if N_min_phi == max(N_min_phi, N_min_psi1, N_min_psi2):
+        p_fr = phi_f_fn(N_min_phi)
+    elif N_min_psi1 == max(N_min_phi, N_min_psi1, N_min_psi2):
+        p_fr = psi1_f_fn_widest(N_min_psi1)
+    else:
+        p_fr = psi2_f_fn_widest(N_min_psi2)
+    t_max = compute_temporal_support(p_fr.reshape(1, -1),
+                                     criterion_amplitude=criterion_amplitude)
+
+    # set min to pad based on maximum
+    min_to_pad = int(1.2 * t_max)
+    if pad_mode == 'zero':
+        min_to_pad //= 2
+
+    # return results
     return min_to_pad
 
 

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -131,6 +131,10 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
     min_to_pad: int
         minimal value to pad the signal on one size to avoid any
         boundary error.
+    N_ref: int
+        Length of longest filter that decays to have time support less than
+        half own length, which may exceed `N`; this is the `N` to be used
+        for computing final pad length.
     """
     # compute params for calibrating, & calibrate
     J_tentative = int(np.ceil(np.log2(N)))
@@ -196,9 +200,10 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
         N_min_psi2 = -2
 
     # take maximum
-    if N_min_phi == max(N_min_phi, N_min_psi1, N_min_psi2):
+    N_min_max = max(N_min_phi, N_min_psi1, N_min_psi2)
+    if N_min_phi == N_min_max:
         p_fr = phi_f_fn(N_min_phi)
-    elif N_min_psi1 == max(N_min_phi, N_min_psi1, N_min_psi2):
+    elif N_min_psi1 == N_min_max:
         p_fr = psi1_f_fn_widest(N_min_psi1)
     else:
         p_fr = psi2_f_fn_widest(N_min_psi2)
@@ -211,7 +216,8 @@ def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
         min_to_pad //= 2
 
     # return results
-    return min_to_pad
+    N_ref = N_min_max
+    return min_to_pad, N_ref
 
 
 def precompute_size_scattering(J, Q, max_order=2, detail=False):


### PR DESCRIPTION
Code builds on #673, #727, #728, #734, arguably #738, and a not-made PR on `max_pad_factor`, and cannot run standalone; PR is to isolate code for review. It's fully functional in JTFS.

#673 introduces possibility of `psi` having greater temporal support than `phi`; this PR accounts for it, and for possibility of padding by more than `N`.