### PR TITLE
Lower default `alpha`

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -310,7 +310,7 @@ def compute_temporal_support(h_f, criterion_amplitude=1e-3):
     return N
 
 
-def get_max_dyadic_subsampling(xi, sigma, alpha=5.):
+def get_max_dyadic_subsampling(xi, sigma, alpha=4.):
     """
     Computes the maximal dyadic subsampling which is possible for a Gabor
     filter of frequency xi and width sigma
@@ -333,7 +333,7 @@ def get_max_dyadic_subsampling(xi, sigma, alpha=5.):
         frequential width of the filter
     alpha : float, optional
         parameter controlling the error done in the aliasing.
-        The larger alpha, the smaller the error. Defaults to 5.
+        The larger alpha, the smaller the error. Defaults to 4.
 
     Returns
     -------
@@ -347,7 +347,7 @@ def get_max_dyadic_subsampling(xi, sigma, alpha=5.):
     return j
 
 
-def move_one_dyadic_step(cv, Q, alpha=5.):
+def move_one_dyadic_step(cv, Q, alpha=4.):
     """
     Computes the parameters of the next wavelet on the low frequency side,
     based on the parameters of the current wavelet.
@@ -374,7 +374,7 @@ def move_one_dyadic_step(cv, Q, alpha=5.):
         the frequency and width of the current wavelet and the next wavelet.
     alpha : float, optional
         tolerance parameter for the aliasing. The larger alpha,
-        the more conservative the algorithm is. Defaults to 5.
+        the more conservative the algorithm is. Defaults to 4.
 
     Returns
     -------
@@ -409,7 +409,7 @@ def compute_xi_max(Q):
     return xi_max
 
 
-def compute_params_filterbank(sigma_low, Q, r_psi=math.sqrt(0.5), alpha=5.):
+def compute_params_filterbank(sigma_low, Q, r_psi=math.sqrt(0.5), alpha=4.):
     """
     Computes the parameters of a Morlet wavelet filterbank.
 
@@ -440,7 +440,7 @@ def compute_params_filterbank(sigma_low, Q, r_psi=math.sqrt(0.5), alpha=5.):
     alpha : float, optional
         tolerance factor for the aliasing after subsampling.
         The larger alpha, the more conservative the value of maximal
-        subsampling is. Defaults to 5.
+        subsampling is. Defaults to 4.
 
     Returns
     -------
@@ -490,7 +490,7 @@ def compute_params_filterbank(sigma_low, Q, r_psi=math.sqrt(0.5), alpha=5.):
 
 
 def calibrate_scattering_filters(J, Q, r_psi=math.sqrt(0.5), sigma0=0.1,
-                                 alpha=5.):
+                                 alpha=4.):
     """
     Calibrates the parameters of the filters used at the 1st and 2nd orders
     of the scattering transform.
@@ -521,7 +521,7 @@ def calibrate_scattering_filters(J, Q, r_psi=math.sqrt(0.5), sigma0=0.1,
     alpha : float, optional
         tolerance factor for the aliasing after subsampling.
         The larger alpha, the more conservative the value of maximal
-        subsampling is. Defaults to 5.
+        subsampling is. Defaults to 4.
 
     Returns
     -------
@@ -552,7 +552,7 @@ def calibrate_scattering_filters(J, Q, r_psi=math.sqrt(0.5), sigma0=0.1,
 
 def scattering_filter_factory(J_support, J_scattering, Q, r_psi=math.sqrt(0.5),
                               criterion_amplitude=1e-3, normalize='l1',
-                              max_subsampling=None, sigma0=0.1, alpha=5.,
+                              max_subsampling=None, sigma0=0.1, alpha=4.,
                               P_max=5, eps=1e-7, **kwargs):
     """
     Builds in Fourier the Morlet filters used for the scattering transform.
@@ -599,7 +599,7 @@ def scattering_filter_factory(J_support, J_scattering, Q, r_psi=math.sqrt(0.5),
     alpha : float, optional
         tolerance factor for the aliasing after subsampling.
         The larger alpha, the more conservative the value of maximal
-        subsampling is. Defaults to 5.
+        subsampling is. Defaults to 4.
     P_max : int, optional
         maximal number of periods to use to make sure that the Fourier
         transform of the filters is periodic. P_max = 5 is more than enough for

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,8 +11,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', alpha=5.,
-            backend=None):
+            oversampling=0, vectorize=True, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -22,7 +21,6 @@ class ScatteringBase1D(ScatteringBase):
         self.oversampling = oversampling
         self.vectorize = vectorize
         self.out_type = out_type
-        self.alpha = alpha
         self.backend = backend
 
     def build(self):
@@ -36,6 +34,7 @@ class ScatteringBase1D(ScatteringBase):
         """
         self.r_psi = math.sqrt(0.5)
         self.sigma0 = 0.1
+        self.alpha = 4.
         self.P_max = 5
         self.eps = 1e-7
         self.criterion_amplitude = 1e-3
@@ -172,7 +171,7 @@ class ScatteringBase1D(ScatteringBase):
         alpha : float, optional
             tolerance factor for filter aliasing after subsampling.
             The larger alpha, the more conservative the value of maximal
-            subsampling is. Defaults to 5.
+            subsampling is. Defaults to 4.
         out_type : str, optional
             The format of the output of a scattering transform. If set to
             `'list'`, then the output is a list containing each individual

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,8 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend=None):
+            oversampling=0, vectorize=True, out_type='array', alpha=5.,
+            backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -21,6 +22,7 @@ class ScatteringBase1D(ScatteringBase):
         self.oversampling = oversampling
         self.vectorize = vectorize
         self.out_type = out_type
+        self.alpha = alpha
         self.backend = backend
 
     def build(self):
@@ -34,7 +36,6 @@ class ScatteringBase1D(ScatteringBase):
         """
         self.r_psi = math.sqrt(0.5)
         self.sigma0 = 0.1
-        self.alpha = 5.
         self.P_max = 5
         self.eps = 1e-7
         self.criterion_amplitude = 1e-3
@@ -168,6 +169,10 @@ class ScatteringBase1D(ScatteringBase):
             coefficient). This parameter may be modified after object
             creation. Deprecated in favor of `out_type` (see below). Defaults
             to True.
+        alpha : float, optional
+            tolerance factor for filter aliasing after subsampling.
+            The larger alpha, the more conservative the value of maximal
+            subsampling is. Defaults to 5.
         out_type : str, optional
             The format of the output of a scattering transform. If set to
             `'list'`, then the output is a list containing each individual

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -8,10 +8,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='numpy'):
+            oversampling=0, vectorize=True, out_type='array', alpha=5.,
+            backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, vectorize, out_type, alpha, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -8,11 +8,10 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', alpha=5.,
-            backend='numpy'):
+            oversampling=0, vectorize=True, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, alpha, backend)
+                oversampling, vectorize, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -66,7 +66,7 @@ def compute_padding(J_pad, T):
 
 def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
                                        normalize='l1', r_psi=math.sqrt(0.5),
-                                       sigma0=1e-1, alpha=5., P_max=5, eps=1e-7):
+                                       sigma0=1e-1, alpha=4., P_max=5, eps=1e-7):
 
 
     """


### PR DESCRIPTION
Current `alpha` is too conservative, reducing number of second-order coefficients. It should either be exposed, or lowered to `4`.

Example with `Q=1`:

![image](https://user-images.githubusercontent.com/16495490/117577792-5a68d900-b0fc-11eb-8acc-3a54837bd519.png)

At green line (red is current behavior), the ratio of filter's maximum to the point at which it's subsampled is `46909`, which meets `criterion_amplitude` 46-fold. In `scattering.m`, this filter counts toward second order (confirmed by @lostanlen).

Below I show exhaustively that `alpha=4` is a safe value for two combinations of `Q, J` meant to test extremes; colors map subsampling factors. Code shows more plots.

<details>
  <summary><b>code</b></summary>

```python
import numpy as np
from kymatio import Scattering1D
from kymatio.visuals import filterbank_scattering, plot


def viz_bounds(psi_f, idx, sub_up, last_idx=None):
    p = psi_f[idx]
    sub0 = len(p[0]) // 2**(p['j'] + 1)
    sub1 = sub0 // 2 if sub_up else sub0
    pt = p[0][:last_idx]
    
    plot(pt, title="psi_f[%s]" % idx)
    plot([], vlines=(sub0, {'color': 'tab:red'}))
    plot([], vlines=(sub1, {'color': 'tab:green'}), show=1)
    
    add_txt = ("\np.max() / p[sub + 1] = {:.1f}".format(pt.max() / pt[sub1])
               if sub_up else "")
    print(("p=psi1_f[2]; sub = len(p) // 2**(p['j'] + 1)\n"
           "p.max() / p[sub]     = {:.1f}{}").format(pt.max() / pt[sub0], add_txt))

def viz_ratios(psi_f):
    ratios = []
    for p in psi_f:
        pt = p[0]
        sub = len(pt) // 2**(p['j'] + 1)
        ratios.append(pt.max() / pt[sub])
    plot(np.log10(ratios), show=1,
         title="log10(ratio) vs index | (max(psi) / psi[point_of_subsampling])")
    
#%%
N = 4096
for alpha in (5., 4.):
    kw = dict(shape=N, alpha=alpha, frontend='numpy')
    
    scattering = Scattering1D(J=8, Q=1, **kw)
    filterbank_scattering(scattering)
    viz_bounds(scattering.psi1_f, idx=2, sub_up=(alpha == 5))
    viz_ratios(scattering.psi1_f)
    
    scattering = Scattering1D(J=10, Q=16, **kw)
    filterbank_scattering(scattering)
    viz_bounds(scattering.psi1_f, idx=17, sub_up=(alpha == 5))
    viz_ratios(scattering.psi1_f)
    
    if alpha == 4:
        viz_bounds(scattering.psi1_f, idx=-1, sub_up=False, last_idx=32)
```
</details>

![image](https://user-images.githubusercontent.com/16495490/117578074-a9633e00-b0fd-11eb-8f94-a3071113dde5.png)



