### PR TITLE
MathJax

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,7 +49,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.coverage',
-    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinxcontrib.bibtex',


### PR DESCRIPTION
SVG rendering and extended math syntax; done via CDN, no install (unless offline), and works on Windows (unlike `imgmath`).

<img src="https://user-images.githubusercontent.com/16495490/117810235-2dd5ce00-b270-11eb-8963-e1f1cdaa48e0.png" width="600">
