### PR TITLE
Deprecate `vectorize`

### DIFF
--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -1,99 +1,4 @@
 import torch
-from torch.autograd import Function
-
-
-class ModulusStable(Function):
-    """Stable complex modulus
-
-    This class implements a modulus transform for complex numbers which is
-    stable with respect to very small inputs (z close to 0), avoiding
-    returning nans in all cases.
-
-    Usage
-    -----
-    modulus = ModulusStable.apply  # apply inherited from Function
-    x_mod = modulus(x)
-
-    Parameters
-    ---------
-    x : tensor
-        The complex tensor (i.e., whose last dimension is two) whose modulus
-        we want to compute.
-
-    Returns
-    -------
-    output : tensor
-        A tensor of same size as the input tensor, except for the last
-        dimension, which is removed. This tensor is differentiable with respect
-        to the input in a stable fashion (so gradent of the modulus at zero is
-        zero).
-    """
-    @staticmethod
-    def forward(ctx, x):
-        """Forward pass of the modulus.
-
-        This is a static method which does not require an instantiation of the
-        class.
-
-        Arguments
-        ---------
-        ctx : context object
-            Collected during the forward pass. These are automatically added
-            by PyTorch and should not be touched. They are then used for the
-            backward pass.
-        x : tensor
-            The complex tensor whose modulus is to be computed.
-
-        Returns
-        -------
-        output : tensor
-            This contains the modulus computed along the last axis, with that
-            axis removed.
-        """
-        ctx.p = 2
-        ctx.dim = -1
-        ctx.keepdim = False
-
-        output = (x[...,0] * x[...,0] + x[...,1] * x[...,1]).sqrt()
-
-        ctx.save_for_backward(x, output)
-
-        return output
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        """Backward pass of the modulus
-
-        This is a static method which does not require an instantiation of the
-        class.
-
-        Arguments
-        ---------
-        ctx : context object
-            Collected during the forward pass. These are automatically added
-            by PyTorch and should not be touched. They are then used for the
-            backward pass.
-        grad_output : tensor
-            The gradient with respect to the output tensor computed at the
-            forward pass.
-
-        Returns
-        -------
-        grad_input : tensor
-            The gradient with respect to the input.
-        """
-        x, output = ctx.saved_tensors
-
-        if ctx.dim is not None and ctx.keepdim is False and x.dim() != 1:
-            grad_output = grad_output.unsqueeze(ctx.dim)
-            output = output.unsqueeze(ctx.dim)
-
-        grad_input = x.mul(grad_output).div(output)
-
-        # Special case at 0 where we return a subgradient containing 0
-        grad_input.masked_fill_(output == 0, 0)
-
-        return grad_input
 
 
 class TorchBackend:
@@ -109,12 +14,12 @@ class TorchBackend:
     @classmethod
     def complex_check(cls, x):
         if not cls._is_complex(x):
-            raise TypeError('The input should be complex (i.e. last dimension is 2).')
+            raise TypeError('The input should be complex (got %s).' % x.dtype)
 
     @classmethod
     def real_check(cls, x):
         if not cls._is_real(x):
-            raise TypeError('The input should be real.')
+            raise TypeError('The input should be real (got %s).' % x.dtype)
 
     @classmethod
     def complex_contiguous_check(cls, x):
@@ -128,21 +33,20 @@ class TorchBackend:
 
     @staticmethod
     def _is_complex(x):
-        return x.shape[-1] == 2
+        return torch.is_complex(x)
 
     @staticmethod
     def _is_real(x):
-        return x.shape[-1] == 1
+        return 'float' in str(x.dtype)
 
     @classmethod
     def modulus(cls, x):
-        cls.complex_contiguous_check(x)
-        norm = ModulusStable.apply(x)[..., None]
-        return norm
+        cls.complex_check(x)
+        return torch.abs(x)
 
     @staticmethod
-    def concatenate(arrays, dim=2):
-        return torch.stack(arrays, dim=dim)
+    def concatenate(arrays, axis=-2):
+        return torch.stack(arrays, dim=axis)
 
     @classmethod
     def cdgmm(cls, A, B):
@@ -185,11 +89,14 @@ class TorchBackend:
 
         cls.complex_contiguous_check(A)
 
-        if A.shape[-len(B.shape):-1] != B.shape[:-1]:
-            raise RuntimeError('The filters are not compatible for multiplication.')
+        if A.shape[-B.ndim:] != B.shape:
+            raise RuntimeError('The filters are not compatible for multiplication '
+                               '(shapes: %s, %s)' % (tuple(A.shape),
+                                                     tuple(B.shape)))
 
-        if A.dtype is not B.dtype:
-            raise TypeError('Input and filter must be of the same dtype.')
+        # if A.dtype is not B.dtype:
+        # TODO does "last dim 2" allow faster multiplication? (real * complex)
+        #     raise TypeError('Input and filter must be of the same dtype.')
 
         if B.device.type == 'cuda':
             if A.device.type == 'cuda':
@@ -202,18 +109,4 @@ class TorchBackend:
             if A.device.type == 'cuda':
                 raise TypeError('Input must be on CPU.')
 
-        if cls._is_real(B):
-            return A * B
-        else:
-            C = A.new(A.shape)
-
-            A_r = A[..., 0].view(-1, B.nelement() // 2)
-            A_i = A[..., 1].view(-1, B.nelement() // 2)
-
-            B_r = B[..., 0].view(-1).unsqueeze(0).expand_as(A_r)
-            B_i = B[..., 1].view(-1).unsqueeze(0).expand_as(A_i)
-
-            C[..., 0].view(-1, B.nelement() // 2)[:] = A_r * B_r - A_i * B_i
-            C[..., 1].view(-1, B.nelement() // 2)[:] = A_r * B_i + A_i * B_r
-
-            return C
+        return A * B

--- a/kymatio/backend/torch_skcuda_backend.py
+++ b/kymatio/backend/torch_skcuda_backend.py
@@ -1,5 +1,4 @@
 import torch
-from skcuda import cublas
 
 
 class TorchSkcudaBackend:
@@ -7,11 +6,11 @@ class TorchSkcudaBackend:
 
     @staticmethod
     def _is_complex(x):
-        return x.shape[-1] == 2
+        return torch.is_complex(x)
 
     @staticmethod
     def _is_real(x):
-        return x.shape[-1] == 1
+        return 'float' in str(x.dtype)
 
     @classmethod
     def cdgmm(cls, A, B):
@@ -50,17 +49,14 @@ class TorchSkcudaBackend:
 
         """
         if not cls._is_complex(A):
-            raise TypeError('The input should be complex (i.e. last dimension is 2).')
+            raise TypeError('The input should be complex (got %s).' % A.dtype)
 
-        if not cls._is_complex(B) and not cls._is_real(B):
+        if not (cls._is_complex(B) or cls._is_real(B)):
             raise TypeError('The filter should be complex or real, indicated by a '
                             'last dimension of size 2 or 1, respectively.')
 
-        if A.shape[-len(B.shape):-1] != B.shape[:-1]:
+        if A.shape[-B.ndim:-1] != B.shape[:-1]:
             raise RuntimeError('The filters are not compatible for multiplication.')
-
-        if A.dtype is not B.dtype:
-            raise TypeError('Input and filter must be of the same dtype.')
 
         if not A.is_cuda or not B.is_cuda:
             raise TypeError('Input and filter must be CUDA tensors.')
@@ -68,19 +64,4 @@ class TorchSkcudaBackend:
         if A.device.index != B.device.index:
             raise TypeError('Input and filter must be on the same GPU.')
 
-        if cls._is_real(B):
-            return A * B
-        else:
-            if not A.is_contiguous() or not B.is_contiguous():
-                raise RuntimeError('Tensors must be contiguous.')
-
-            C = torch.empty_like(A)
-            m, n = B.nelement() // 2, A.nelement() // B.nelement()
-            lda = m
-            ldc = m
-            incx = 1
-            handle = torch.cuda.current_blas_handle()
-            stream = torch.cuda.current_stream()._as_parameter_
-            cublas.cublasSetStream(handle, stream)
-            cublas.cublasCdgmm(handle, 'l', m, n, A.data_ptr(), lda, B.data_ptr(), incx, C.data_ptr(), ldc)
-            return C
+        return A * B

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -30,8 +30,11 @@ class TorchBackend1D(TorchBackend):
             tensor of size x.shape[-2] // k along that dimension.
         """
         cls.complex_check(x)
+        N = x.shape[-1]
 
-        res = x.view(x.shape[:-1] + (k, x.shape[-1] // k)).mean(dim=-2)
+        x = torch.view_as_real(x)
+        res = x.view(x.shape[:-2] + (k, N // k, 2)).mean(dim=-3)
+        res = torch.view_as_complex(res)
 
         return res
 

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -161,14 +161,8 @@ def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
     out_S.extend(out_S_1)
     out_S.extend(out_S_2)
 
-    if out_type == 'array' and vectorize:
+    if out_type == 'array' and average:
         out_S = concatenate([x['coef'] for x in out_S])
-    elif out_type == 'array' and not vectorize:
-        out_S = {x['n']: x['coef'] for x in out_S}
-    elif out_type == 'list':
-        # NOTE: This overrides the vectorize flag.
-        for x in out_S:
-            x.pop('n')
 
     return out_S
 

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,7 +1,7 @@
 def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
         pad_right=0, ind_start=None, ind_end=None, oversampling=0,
         max_order=2, average=True, size_scattering=(0, 0, 0),
-        vectorize=False, out_type='array'):
+        out_type='array'):
     """
     Main function implementing the 1-D scattering transform.
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend=None):
+            oversampling=0, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -19,7 +19,6 @@ class ScatteringBase1D(ScatteringBase):
         self.max_order = max_order
         self.average = average
         self.oversampling = oversampling
-        self.vectorize = vectorize
         self.out_type = out_type
         self.backend = backend
 

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -26,16 +26,9 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         if not self.out_type in ('array', 'list'):
             raise RuntimeError("The out_type must be one of 'array' or 'list'.")
 
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
+        if self.out_type == 'array' and not self.average:
+            raise ValueError("out_type=='array' and average==False are mutually "
+                             "incompatible. Please set out_type='list'.")
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
@@ -58,19 +51,11 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                          size_scattering=size_scattering,
                          out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array' and self.average:
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
 
             S = S.reshape(new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
-            for k, v in S.items():
-                # NOTE: Have to get the shape for each one since we may have
-                # average == False.
-                scattering_shape = v.shape[-2:]
-                new_shape = batch_shape + scattering_shape
-
-                S[k] = v.reshape(new_shape)
         elif self.out_type == 'list':
             for x in S:
                 scattering_shape = x['coef'].shape[-1:]

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -48,12 +48,12 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                          size_scattering=size_scattering,
                          out_type=self.out_type)
 
-        if self.out_type == 'array' and self.average:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
 
             S = S.reshape(new_shape)
-        elif self.out_type == 'list':
+        else:
             for x in S:
                 scattering_shape = x['coef'].shape[-1:]
                 new_shape = batch_shape + scattering_shape

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -1,5 +1,3 @@
-import warnings
-
 from ...frontend.numpy_frontend import ScatteringNumPy
 from ..core.scattering1d import scattering1d
 from ..utils import precompute_size_scattering
@@ -8,10 +6,10 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='numpy'):
+            oversampling=0, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -37,7 +35,7 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
 
         # get the arguments before calling the scattering
         # treat the arguments
-        if self.vectorize:
+        if self.average:
             size_scattering = precompute_size_scattering(
                 self.J, self.Q, max_order=self.max_order, detail=True)
         else:
@@ -47,7 +45,6 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling,
-                         vectorize=self.vectorize,
                          size_scattering=size_scattering,
                          out_type=self.out_type)
 

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -9,11 +9,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='tensorflow',
+            oversampling=0, out_type='array', backend='tensorflow',
                  name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -39,7 +39,7 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
 
         # get the arguments before calling the scattering
         # treat the arguments
-        if self.vectorize:
+        if self.average:
             size_scattering = precompute_size_scattering(
                 self.J, self.Q, max_order=self.max_order, detail=True)
         else:
@@ -49,7 +49,6 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling,
-                         vectorize=self.vectorize,
                          size_scattering=size_scattering,
                          out_type=self.out_type)
 

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -52,12 +52,12 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
                          size_scattering=size_scattering,
                          out_type=self.out_type)
 
-        if self.out_type == 'array' and self.average:
+        if self.out_type == 'array':
             scattering_shape = tf.shape(S)[-2:]
             new_shape = tf.concat((batch_shape, scattering_shape), 0)
 
             S = tf.reshape(S, new_shape)
-        elif self.out_type == 'list':
+        else:
             for x in S:
                 scattering_shape = tf.shape(x['coef'])[-1:]
                 new_shape = tf.concat((batch_shape, scattering_shape), 0)

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -108,12 +108,12 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                        size_scattering=size_scattering,
                        out_type=self.out_type)
 
-        if self.out_type == 'array' and self.average:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
 
             S = S.reshape(new_shape)
-        elif self.out_type == 'list':
+        else:
             for x in S:
                 scattering_shape = x['coef'].shape[-1:]
                 new_shape = batch_shape + scattering_shape

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -28,7 +28,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
             if type(k) != str:
                 # view(-1, 1).repeat(1, 2) because real numbers!
                 self.phi_f[k] = torch.from_numpy(
-                    self.phi_f[k]).float().view(-1, 1)
+                    self.phi_f[k]).float()
                 self.register_buffer('tensor' + str(n), self.phi_f[k])
                 n += 1
         for psi_f in self.psi1_f:
@@ -36,7 +36,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                 if type(sub_k) != str:
                     # view(-1, 1).repeat(1, 2) because real numbers!
                     psi_f[sub_k] = torch.from_numpy(
-                        psi_f[sub_k]).float().view(-1, 1)
+                        psi_f[sub_k]).float()
                     self.register_buffer('tensor' + str(n), psi_f[sub_k])
                     n += 1
         for psi_f in self.psi2_f:
@@ -44,7 +44,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                 if type(sub_k) != str:
                     # view(-1, 1).repeat(1, 2) because real numbers!
                     psi_f[sub_k] = torch.from_numpy(
-                        psi_f[sub_k]).float().view(-1, 1)
+                        psi_f[sub_k]).float()
                     self.register_buffer('tensor' + str(n), psi_f[sub_k])
                     n += 1
 
@@ -80,17 +80,9 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         if not self.out_type in ('array', 'list'):
             raise RuntimeError("The out_type must be one of 'array' or 'list'.")
 
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
+        if self.out_type == 'array' and not self.average:
+            raise ValueError("out_type=='array' and average==False are mutually "
+                             "incompatible. Please set out_type='list'.")
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
@@ -117,19 +109,11 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                        size_scattering=size_scattering,
                        out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array' and self.average:
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
 
             S = S.reshape(new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
-            for k, v in S.items():
-                # NOTE: Have to get the shape for each one since we may have
-                # average == False.
-                scattering_shape = v.shape[-2:]
-                new_shape = batch_shape + scattering_shape
-
-                S[k] = v.reshape(new_shape)
         elif self.out_type == 'list':
             for x in S:
                 scattering_shape = x['coef'].shape[-1:]

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -9,10 +9,10 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='torch'):
+            oversampling=0, out_type='array', backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -93,7 +93,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
 
         # get the arguments before calling the scattering
         # treat the arguments
-        if self.vectorize:
+        if self.average:
             size_scattering = precompute_size_scattering(
                 self.J, self.Q, max_order=self.max_order, detail=True)
         else:
@@ -105,7 +105,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                        pad_left=self.pad_left, pad_right=self.pad_right,
                        ind_start=self.ind_start, ind_end=self.ind_end,
                        oversampling=self.oversampling,
-                       vectorize=self.vectorize,
                        size_scattering=size_scattering,
                        out_type=self.out_type)
 

--- a/tests/scattering1d/test_torch_backend_1d.py
+++ b/tests/scattering1d/test_torch_backend_1d.py
@@ -3,7 +3,7 @@ import torch
 import numpy as np
 
 # set True to execute all test functions without pytest
-run_without_pytest = 1
+run_without_pytest = 0
 
 backends = []
 

--- a/tests/scattering1d/test_torch_backend_1d.py
+++ b/tests/scattering1d/test_torch_backend_1d.py
@@ -2,6 +2,9 @@ import pytest
 import torch
 import numpy as np
 
+# set True to execute all test functions without pytest
+run_without_pytest = 1
+
 backends = []
 
 skcuda_available = False
@@ -19,6 +22,7 @@ if skcuda_available:
 
 from kymatio.scattering1d.backend.torch_backend import backend
 backends.append(backend)
+del backend
 
 if torch.cuda.is_available():
     devices = ['cuda', 'cpu']
@@ -38,15 +42,15 @@ def test_pad_1d(device, backend, random_state=42):
         for pad_right in [pad_left, pad_left + 16]:
             x = torch.randn(2, 4, N, requires_grad=True, device=device)
             x_pad = backend.pad(x, pad_left, pad_right)
-            x_pad = x_pad.reshape(x_pad.shape[:-1])
+            x_pad = x_pad.reshape(x_pad.shape)
             # Check the size
             x2 = x.clone()
             x_pad2 = x_pad.clone()
-            # compare left reflected part of padded array with left side 
+            # compare left reflected part of padded array with left side
             # of original array
             for t in range(1, pad_left + 1):
                 assert torch.allclose(x_pad2[..., pad_left - t], x2[..., t])
-            # compare left part of padded array with left side of 
+            # compare left part of padded array with left side of
             # original array
             for t in range(x.shape[-1]):
                 assert torch.allclose(x_pad2[..., pad_left + t], x2[..., t])
@@ -54,7 +58,7 @@ def test_pad_1d(device, backend, random_state=42):
             # of original array
             for t in range(1, pad_right + 1):
                 assert torch.allclose(x_pad2[..., x_pad.shape[-1] - 1 - pad_right + t], x2[..., x.shape[-1] - 1 - t])
-            # compare right part of padded array with right side of 
+            # compare right part of padded array with right side of
             # original array
             for t in range(1, pad_right + 1):
                 assert torch.allclose(x_pad2[..., x_pad.shape[-1] - 1 - pad_right - t], x2[..., x.shape[-1] - 1 - t])
@@ -81,7 +85,7 @@ def test_pad_1d(device, backend, random_state=42):
     with pytest.raises(ValueError) as ve:
         backend.pad(x, x.shape[-1], 0)
     assert "padding size" in ve.value.args[0]
-    
+
     with pytest.raises(ValueError) as ve:
         backend.pad(x, 0, x.shape[-1])
     assert "padding size" in ve.value.args[0]
@@ -102,15 +106,16 @@ def test_modulus(device, backend, random_state=42):
 
     torch.manual_seed(random_state)
     # Test with a random vector
-    x = torch.randn(2, 4, 128, 2, requires_grad=True, device=device)
+    x = torch.randn(2, 4, 128, 2, requires_grad=True, device=device,
+                    dtype=torch.complex128)
 
-    x_abs = backend.modulus(x).squeeze(-1)
-    assert len(x_abs.shape) == len(x.shape[:-1])
+    x_abs = backend.modulus(x)
+    assert x_abs.ndim == x.ndim
 
     # check the value
     x_abs2 = x_abs.clone()
     x2 = x.clone()
-    assert torch.allclose(x_abs2, torch.sqrt(x2[..., 0] ** 2 + x2[..., 1] ** 2))
+    assert torch.allclose(x_abs2, torch.sqrt(x2.real ** 2 + x2.imag ** 2))
 
     with pytest.raises(TypeError) as te:
         x_bad = torch.randn(4).to(device)
@@ -124,21 +129,22 @@ def test_modulus(device, backend, random_state=42):
     # check the gradient
     loss = torch.sum(x_abs)
     loss.backward()
-    x_grad = x2 / x_abs2[..., None]
+    x_grad = x2 / x_abs2
     assert torch.allclose(x.grad, x_grad)
 
 
     # Test the differentiation with a vector made of zeros
-    x0 = torch.zeros(100, 4, 128, 2, requires_grad=True, device=device)
+    x0 = torch.zeros(100, 4, 128, 2, requires_grad=True, device=device,
+                     dtype=torch.complex128)
     x_abs0 = backend.modulus(x0)
     loss0 = torch.sum(x_abs0)
     loss0.backward()
     assert torch.max(torch.abs(x0.grad)) <= 1e-7
 
 
-@pytest.mark.parametrize("backend", backends)
 @pytest.mark.parametrize("device", devices)
-def test_subsample_fourier(backend, device, random_state=42):
+@pytest.mark.parametrize("backend", backends)
+def test_subsample_fourier(device, backend, random_state=42):
     """
     Tests whether the periodization in Fourier performs a good subsampling
     in time
@@ -152,15 +158,14 @@ def test_subsample_fourier(backend, device, random_state=42):
     rng = np.random.RandomState(random_state)
     J = 10
     x = rng.randn(2, 4, 2**J) + 1j * rng.randn(2, 4, 2**J)
-    x_f = np.fft.fft(x, axis=-1)[..., np.newaxis]
-    x_f.dtype = 'float64'  # make it a vector
+    x_f = np.fft.fft(x, axis=-1)
     x_f_th = torch.from_numpy(x_f).to(device)
 
     for j in range(J + 1):
         x_f_sub_th = backend.subsample_fourier(x_f_th, 2**j).cpu()
         x_f_sub = x_f_sub_th.numpy()
         x_f_sub.dtype = 'complex128'
-        x_sub = np.fft.ifft(x_f_sub[..., 0], axis=-1)
+        x_sub = np.fft.ifft(x_f_sub, axis=-1)
         assert np.allclose(x[:, :, ::2**j], x_sub)
 
     # If we are using a GPU-only backend, make sure it raises the proper
@@ -172,19 +177,19 @@ def test_subsample_fourier(backend, device, random_state=42):
         assert "should be complex" in te.value.args[0]
 
 
-@pytest.mark.parametrize("backend", backends)
 @pytest.mark.parametrize("device", devices)
-def test_unpad(backend, device):
+@pytest.mark.parametrize("backend", backends)
+def test_unpad(device, backend):
     if backend.name == "torch_skcuda" and device == "cpu":
         pytest.skip()
 
     # test unpading of a random tensor
-    x = torch.randn(8, 4, 1).to(device)
+    x = torch.randn(8, 4).to(device)
 
     y = backend.unpad(x, 1, 3)
 
     assert y.shape == (8, 2)
-    assert torch.allclose(y, x[:, 1:3, 0])
+    assert torch.allclose(y, x[:, 1:3])
 
     N = 128
     x = torch.rand(2, 4, N).to(device)
@@ -193,17 +198,17 @@ def test_unpad(backend, device):
     for pad_left in range(0, N - 16, 16):
         pad_right = pad_left + 16
         x_pad = backend.pad(x, pad_left, pad_right)
-        x_unpadded = backend.unpad(x_pad, pad_left, x_pad.shape[-1] - pad_right - 1)
+        x_unpadded = backend.unpad(x_pad, pad_left, x_pad.shape[-1] - pad_right)
         assert torch.allclose(x, x_unpadded)
 
 
-@pytest.mark.parametrize("backend", backends)
 @pytest.mark.parametrize("device", devices)
-def test_fft_type(backend, device):
+@pytest.mark.parametrize("backend", backends)
+def test_fft_type(device, backend):
     if backend.name == "torch_skcuda" and device == "cpu":
         pytest.skip()
 
-    x = torch.randn(8, 4, 2).to(device)
+    x = torch.randn(8, 4, 2, dtype=torch.complex128).to(device)
 
     with pytest.raises(TypeError) as record:
         y = backend.rfft(x)
@@ -220,9 +225,9 @@ def test_fft_type(backend, device):
     assert 'should be complex' in record.value.args[0]
 
 
-@pytest.mark.parametrize("backend", backends)
 @pytest.mark.parametrize("device", devices)
-def test_fft(backend, device):
+@pytest.mark.parametrize("backend", backends)
+def test_fft(device, backend):
     if backend.name == "torch_skcuda" and device == "cpu":
         pytest.skip()
 
@@ -234,18 +239,32 @@ def test_fft(backend, device):
     I, K = np.meshgrid(np.arange(4), np.arange(4), indexing='ij')
 
     coefficents = coefficent(K * I / x_r.shape[0])
-        
+
     y_r = (x_r * coefficents).sum(-1)
 
-    x_r = torch.from_numpy(x_r)[..., None].to(device)
+    x_r = torch.from_numpy(x_r).to(device)
     y_r = torch.from_numpy(np.column_stack((y_r.real, y_r.imag))).to(device)
-    
+
     z = backend.rfft(x_r)
-    assert torch.allclose(y_r, z)
+    assert torch.allclose(y_r[..., 0], z.real)
 
     z_1 = backend.ifft(z)
-    assert torch.allclose(x_r[..., 0], z_1[..., 0])
+    assert torch.allclose(x_r, z_1.real)
 
     z_2 = backend.irfft(z)
-    assert not z_2.shape[-1] == 2
     assert torch.allclose(x_r, z_2)
+
+
+if __name__ == '__main__':
+    if run_without_pytest:
+        for device in devices:
+            for backend in backends:
+                args = (device, backend)
+                test_pad_1d(*args)
+                test_modulus(*args)
+                test_subsample_fourier(*args)
+                test_unpad(*args)
+                test_fft_type(*args)
+                test_fft(*args)
+    else:
+        pytest.main([__file__, "-s"])

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -7,7 +7,7 @@ import io
 import numpy as np
 
 # set True to execute all test functions without pytest
-run_without_pytest = 1
+run_without_pytest = 0
 
 
 backends = []


### PR DESCRIPTION
This fixes dev and passes all 1D tests. But it goes further:

 1. Removed `Modulus` implementations. The cited purpose is "stability" and "not returning NaNs for gradients", but `torch.abs(x)` accomplishes the same AFAIK, and `test_modulus()` passes.
 2. Dropped trailing dim everywhere (i.e. `view_as_real`) except `subsample_fourier` since complex `mean()` isn't implemented in 1.7. I'm not aware of its need beyond modulus; it only complicates code.
 3. Dropped `fft(normalized=False)`. If this was for performance by sparing a division, it makes intuitive sense but I saw no difference in my benchmarks. It makes outputs conflict with numpy's, makes the implementation numerically incorrect, and complicates correctness tests by requiring this difference accounted (and differently for first and second orders).
 4. Dropped `vectorize`, as was planned, and rerouted logic as `True -> out_type=="array" and average`, and `False -> out_type=="list" or not average`.
 5. Improved test debugging and local-friendliness via `run_without_pytest`. 

### Todo

 - [ ] Docs (will change after review)
 - [ ] 2D & 3D (I leave this to devs)