### PR TITLE
Fix dev

### DIFF
--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -1,99 +1,4 @@
 import torch
-from torch.autograd import Function
-
-
-class ModulusStable(Function):
-    """Stable complex modulus
-
-    This class implements a modulus transform for complex numbers which is
-    stable with respect to very small inputs (z close to 0), avoiding
-    returning nans in all cases.
-
-    Usage
-    -----
-    modulus = ModulusStable.apply  # apply inherited from Function
-    x_mod = modulus(x)
-
-    Parameters
-    ---------
-    x : tensor
-        The complex tensor (i.e., whose last dimension is two) whose modulus
-        we want to compute.
-
-    Returns
-    -------
-    output : tensor
-        A tensor of same size as the input tensor, except for the last
-        dimension, which is removed. This tensor is differentiable with respect
-        to the input in a stable fashion (so gradent of the modulus at zero is
-        zero).
-    """
-    @staticmethod
-    def forward(ctx, x):
-        """Forward pass of the modulus.
-
-        This is a static method which does not require an instantiation of the
-        class.
-
-        Arguments
-        ---------
-        ctx : context object
-            Collected during the forward pass. These are automatically added
-            by PyTorch and should not be touched. They are then used for the
-            backward pass.
-        x : tensor
-            The complex tensor whose modulus is to be computed.
-
-        Returns
-        -------
-        output : tensor
-            This contains the modulus computed along the last axis, with that
-            axis removed.
-        """
-        ctx.p = 2
-        ctx.dim = -1
-        ctx.keepdim = False
-
-        output = (x[...,0] * x[...,0] + x[...,1] * x[...,1]).sqrt()
-
-        ctx.save_for_backward(x, output)
-
-        return output
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        """Backward pass of the modulus
-
-        This is a static method which does not require an instantiation of the
-        class.
-
-        Arguments
-        ---------
-        ctx : context object
-            Collected during the forward pass. These are automatically added
-            by PyTorch and should not be touched. They are then used for the
-            backward pass.
-        grad_output : tensor
-            The gradient with respect to the output tensor computed at the
-            forward pass.
-
-        Returns
-        -------
-        grad_input : tensor
-            The gradient with respect to the input.
-        """
-        x, output = ctx.saved_tensors
-
-        if ctx.dim is not None and ctx.keepdim is False and x.dim() != 1:
-            grad_output = grad_output.unsqueeze(ctx.dim)
-            output = output.unsqueeze(ctx.dim)
-
-        grad_input = x.mul(grad_output).div(output)
-
-        # Special case at 0 where we return a subgradient containing 0
-        grad_input.masked_fill_(output == 0, 0)
-
-        return grad_input
 
 
 class TorchBackend:
@@ -109,12 +14,12 @@ class TorchBackend:
     @classmethod
     def complex_check(cls, x):
         if not cls._is_complex(x):
-            raise TypeError('The input should be complex (i.e. last dimension is 2).')
+            raise TypeError('The input should be complex (got %s).' % x.dtype)
 
     @classmethod
     def real_check(cls, x):
         if not cls._is_real(x):
-            raise TypeError('The input should be real.')
+            raise TypeError('The input should be real (got %s).' % x.dtype)
 
     @classmethod
     def complex_contiguous_check(cls, x):
@@ -128,21 +33,20 @@ class TorchBackend:
 
     @staticmethod
     def _is_complex(x):
-        return x.shape[-1] == 2
+        return torch.is_complex(x)
 
     @staticmethod
     def _is_real(x):
-        return x.shape[-1] == 1
+        return 'float' in str(x.dtype)
 
     @classmethod
     def modulus(cls, x):
-        cls.complex_contiguous_check(x)
-        norm = ModulusStable.apply(x)[..., None]
-        return norm
+        cls.complex_check(x)
+        return torch.abs(x)
 
     @staticmethod
-    def concatenate(arrays, dim=2):
-        return torch.stack(arrays, dim=dim)
+    def concatenate(arrays, axis=-2):
+        return torch.stack(arrays, dim=axis)
 
     @classmethod
     def cdgmm(cls, A, B):
@@ -185,11 +89,14 @@ class TorchBackend:
 
         cls.complex_contiguous_check(A)
 
-        if A.shape[-len(B.shape):-1] != B.shape[:-1]:
-            raise RuntimeError('The filters are not compatible for multiplication.')
+        if A.shape[-B.ndim:] != B.shape:
+            raise RuntimeError('The filters are not compatible for multiplication '
+                               '(shapes: %s, %s)' % (tuple(A.shape),
+                                                     tuple(B.shape)))
 
-        if A.dtype is not B.dtype:
-            raise TypeError('Input and filter must be of the same dtype.')
+        # if A.dtype is not B.dtype:
+        # TODO does "last dim 2" allow faster multiplication? (real * complex)
+        #     raise TypeError('Input and filter must be of the same dtype.')
 
         if B.device.type == 'cuda':
             if A.device.type == 'cuda':
@@ -202,18 +109,4 @@ class TorchBackend:
             if A.device.type == 'cuda':
                 raise TypeError('Input must be on CPU.')
 
-        if cls._is_real(B):
-            return A * B
-        else:
-            C = A.new(A.shape)
-
-            A_r = A[..., 0].view(-1, B.nelement() // 2)
-            A_i = A[..., 1].view(-1, B.nelement() // 2)
-
-            B_r = B[..., 0].view(-1).unsqueeze(0).expand_as(A_r)
-            B_i = B[..., 1].view(-1).unsqueeze(0).expand_as(A_i)
-
-            C[..., 0].view(-1, B.nelement() // 2)[:] = A_r * B_r - A_i * B_i
-            C[..., 1].view(-1, B.nelement() // 2)[:] = A_r * B_i + A_i * B_r
-
-            return C
+        return A * B

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -94,9 +94,8 @@ class TorchBackend:
                                '(shapes: %s, %s)' % (tuple(A.shape),
                                                      tuple(B.shape)))
 
-        # if A.dtype is not B.dtype:
-        # TODO does "last dim 2" allow faster multiplication? (real * complex)
-        #     raise TypeError('Input and filter must be of the same dtype.')
+        if A.dtype is not B.dtype:
+            raise TypeError('Input and filter must be of the same dtype.')
 
         if B.device.type == 'cuda':
             if A.device.type == 'cuda':

--- a/kymatio/backend/torch_skcuda_backend.py
+++ b/kymatio/backend/torch_skcuda_backend.py
@@ -1,5 +1,4 @@
 import torch
-from skcuda import cublas
 
 
 class TorchSkcudaBackend:
@@ -7,11 +6,11 @@ class TorchSkcudaBackend:
 
     @staticmethod
     def _is_complex(x):
-        return x.shape[-1] == 2
+        return torch.is_complex(x)
 
     @staticmethod
     def _is_real(x):
-        return x.shape[-1] == 1
+        return 'float' in str(x.dtype)
 
     @classmethod
     def cdgmm(cls, A, B):
@@ -50,17 +49,14 @@ class TorchSkcudaBackend:
 
         """
         if not cls._is_complex(A):
-            raise TypeError('The input should be complex (i.e. last dimension is 2).')
+            raise TypeError('The input should be complex (got %s).' % A.dtype)
 
-        if not cls._is_complex(B) and not cls._is_real(B):
+        if not (cls._is_complex(B) or cls._is_real(B)):
             raise TypeError('The filter should be complex or real, indicated by a '
                             'last dimension of size 2 or 1, respectively.')
 
-        if A.shape[-len(B.shape):-1] != B.shape[:-1]:
+        if A.shape[-B.ndim:-1] != B.shape[:-1]:
             raise RuntimeError('The filters are not compatible for multiplication.')
-
-        if A.dtype is not B.dtype:
-            raise TypeError('Input and filter must be of the same dtype.')
 
         if not A.is_cuda or not B.is_cuda:
             raise TypeError('Input and filter must be CUDA tensors.')
@@ -68,19 +64,4 @@ class TorchSkcudaBackend:
         if A.device.index != B.device.index:
             raise TypeError('Input and filter must be on the same GPU.')
 
-        if cls._is_real(B):
-            return A * B
-        else:
-            if not A.is_contiguous() or not B.is_contiguous():
-                raise RuntimeError('Tensors must be contiguous.')
-
-            C = torch.empty_like(A)
-            m, n = B.nelement() // 2, A.nelement() // B.nelement()
-            lda = m
-            ldc = m
-            incx = 1
-            handle = torch.cuda.current_blas_handle()
-            stream = torch.cuda.current_stream()._as_parameter_
-            cublas.cublasSetStream(handle, stream)
-            cublas.cublasCdgmm(handle, 'l', m, n, A.data_ptr(), lda, B.data_ptr(), incx, C.data_ptr(), ldc)
-            return C
+        return A * B

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -28,7 +28,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
             if type(k) != str:
                 # view(-1, 1).repeat(1, 2) because real numbers!
                 self.phi_f[k] = torch.from_numpy(
-                    self.phi_f[k]).float().view(-1, 1)
+                    self.phi_f[k]).float()
                 self.register_buffer('tensor' + str(n), self.phi_f[k])
                 n += 1
         for psi_f in self.psi1_f:
@@ -36,7 +36,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                 if type(sub_k) != str:
                     # view(-1, 1).repeat(1, 2) because real numbers!
                     psi_f[sub_k] = torch.from_numpy(
-                        psi_f[sub_k]).float().view(-1, 1)
+                        psi_f[sub_k]).float()
                     self.register_buffer('tensor' + str(n), psi_f[sub_k])
                     n += 1
         for psi_f in self.psi2_f:
@@ -44,7 +44,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                 if type(sub_k) != str:
                     # view(-1, 1).repeat(1, 2) because real numbers!
                     psi_f[sub_k] = torch.from_numpy(
-                        psi_f[sub_k]).float().view(-1, 1)
+                        psi_f[sub_k]).float()
                     self.register_buffer('tensor' + str(n), psi_f[sub_k])
                     n += 1
 

--- a/tests/scattering1d/test_torch_backend_1d.py
+++ b/tests/scattering1d/test_torch_backend_1d.py
@@ -38,15 +38,15 @@ def test_pad_1d(device, backend, random_state=42):
         for pad_right in [pad_left, pad_left + 16]:
             x = torch.randn(2, 4, N, requires_grad=True, device=device)
             x_pad = backend.pad(x, pad_left, pad_right)
-            x_pad = x_pad.reshape(x_pad.shape[:-1])
+            x_pad = x_pad.reshape(x_pad.shape)
             # Check the size
             x2 = x.clone()
             x_pad2 = x_pad.clone()
-            # compare left reflected part of padded array with left side 
+            # compare left reflected part of padded array with left side
             # of original array
             for t in range(1, pad_left + 1):
                 assert torch.allclose(x_pad2[..., pad_left - t], x2[..., t])
-            # compare left part of padded array with left side of 
+            # compare left part of padded array with left side of
             # original array
             for t in range(x.shape[-1]):
                 assert torch.allclose(x_pad2[..., pad_left + t], x2[..., t])
@@ -54,7 +54,7 @@ def test_pad_1d(device, backend, random_state=42):
             # of original array
             for t in range(1, pad_right + 1):
                 assert torch.allclose(x_pad2[..., x_pad.shape[-1] - 1 - pad_right + t], x2[..., x.shape[-1] - 1 - t])
-            # compare right part of padded array with right side of 
+            # compare right part of padded array with right side of
             # original array
             for t in range(1, pad_right + 1):
                 assert torch.allclose(x_pad2[..., x_pad.shape[-1] - 1 - pad_right - t], x2[..., x.shape[-1] - 1 - t])
@@ -81,7 +81,7 @@ def test_pad_1d(device, backend, random_state=42):
     with pytest.raises(ValueError) as ve:
         backend.pad(x, x.shape[-1], 0)
     assert "padding size" in ve.value.args[0]
-    
+
     with pytest.raises(ValueError) as ve:
         backend.pad(x, 0, x.shape[-1])
     assert "padding size" in ve.value.args[0]
@@ -93,7 +93,7 @@ def test_modulus(device, backend, random_state=42):
     """
     Tests the stability and differentiability of modulus
     """
-    if backend.name.endswith('_skcuda') and device == "cpu":
+    if backend.name == "torch_skcuda" and device == "cpu":
         with pytest.raises(TypeError) as re:
             x_bad = torch.randn((4, 2)).cpu()
             backend.modulus(x_bad)
@@ -102,34 +102,36 @@ def test_modulus(device, backend, random_state=42):
 
     torch.manual_seed(random_state)
     # Test with a random vector
-    x = torch.randn(2, 4, 128, 2, requires_grad=True, device=device)
+    x = torch.randn(2, 4, 128, 2, requires_grad=True, device=device,
+                    dtype=torch.complex128)
 
-    x_abs = backend.modulus(x).squeeze(-1)
-    assert len(x_abs.shape) == len(x.shape[:-1])
+    x_abs = backend.modulus(x)
+    assert x_abs.ndim == x.ndim
 
     # check the value
     x_abs2 = x_abs.clone()
     x2 = x.clone()
-    assert torch.allclose(x_abs2, torch.sqrt(x2[..., 0] ** 2 + x2[..., 1] ** 2))
+    assert torch.allclose(x_abs2, torch.sqrt(x2.real ** 2 + x2.imag ** 2))
 
     with pytest.raises(TypeError) as te:
         x_bad = torch.randn(4).to(device)
         backend.modulus(x_bad)
     assert "should be complex" in te.value.args[0]
 
-    if backend.name.endswith('_skcuda'):
+    if backend.name == "torch_skcuda":
         pytest.skip("The skcuda backend does not pass differentiability"
             "tests, but that's ok (for now).")
 
     # check the gradient
     loss = torch.sum(x_abs)
     loss.backward()
-    x_grad = x2 / x_abs2[..., None]
+    x_grad = x2 / x_abs2
     assert torch.allclose(x.grad, x_grad)
 
 
     # Test the differentiation with a vector made of zeros
-    x0 = torch.zeros(100, 4, 128, 2, requires_grad=True, device=device)
+    x0 = torch.zeros(100, 4, 128, 2, requires_grad=True, device=device,
+                     dtype=torch.complex128)
     x_abs0 = backend.modulus(x0)
     loss0 = torch.sum(x_abs0)
     loss0.backward()
@@ -143,7 +145,7 @@ def test_subsample_fourier(backend, device, random_state=42):
     Tests whether the periodization in Fourier performs a good subsampling
     in time
     """
-    if backend.name.endswith('_skcuda') and device == 'cpu':
+    if backend.name == 'torch_skcuda' and device == 'cpu':
         with pytest.raises(TypeError) as re:
             x_bad = torch.randn((4, 2)).cpu()
             backend.subsample_fourier(x_bad, 1)
@@ -152,15 +154,14 @@ def test_subsample_fourier(backend, device, random_state=42):
     rng = np.random.RandomState(random_state)
     J = 10
     x = rng.randn(2, 4, 2**J) + 1j * rng.randn(2, 4, 2**J)
-    x_f = np.fft.fft(x, axis=-1)[..., np.newaxis]
-    x_f.dtype = 'float64'  # make it a vector
+    x_f = np.fft.fft(x, axis=-1)
     x_f_th = torch.from_numpy(x_f).to(device)
 
     for j in range(J + 1):
         x_f_sub_th = backend.subsample_fourier(x_f_th, 2**j).cpu()
         x_f_sub = x_f_sub_th.numpy()
         x_f_sub.dtype = 'complex128'
-        x_sub = np.fft.ifft(x_f_sub[..., 0], axis=-1)
+        x_sub = np.fft.ifft(x_f_sub, axis=-1)
         assert np.allclose(x[:, :, ::2**j], x_sub)
 
     # If we are using a GPU-only backend, make sure it raises the proper
@@ -179,12 +180,12 @@ def test_unpad(backend, device):
         pytest.skip()
 
     # test unpading of a random tensor
-    x = torch.randn(8, 4, 1).to(device)
+    x = torch.randn(8, 4).to(device)
 
     y = backend.unpad(x, 1, 3)
 
     assert y.shape == (8, 2)
-    assert torch.allclose(y, x[:, 1:3, 0])
+    assert torch.allclose(y, x[:, 1:3])
 
     N = 128
     x = torch.rand(2, 4, N).to(device)
@@ -193,7 +194,7 @@ def test_unpad(backend, device):
     for pad_left in range(0, N - 16, 16):
         pad_right = pad_left + 16
         x_pad = backend.pad(x, pad_left, pad_right)
-        x_unpadded = backend.unpad(x_pad, pad_left, x_pad.shape[-1] - pad_right - 1)
+        x_unpadded = backend.unpad(x_pad, pad_left, x_pad.shape[-1] - pad_right)
         assert torch.allclose(x, x_unpadded)
 
 
@@ -203,7 +204,7 @@ def test_fft_type(backend, device):
     if backend.name == "torch_skcuda" and device == "cpu":
         pytest.skip()
 
-    x = torch.randn(8, 4, 2).to(device)
+    x = torch.randn(8, 4, 2, dtype=torch.complex128).to(device)
 
     with pytest.raises(TypeError) as record:
         y = backend.rfft(x)
@@ -234,21 +235,17 @@ def test_fft(backend, device):
     I, K = np.meshgrid(np.arange(4), np.arange(4), indexing='ij')
 
     coefficents = coefficent(K * I / x_r.shape[0])
-        
+
     y_r = (x_r * coefficents).sum(-1)
 
-    x_r = torch.from_numpy(x_r)[..., None].to(device)
+    x_r = torch.from_numpy(x_r).to(device)
     y_r = torch.from_numpy(np.column_stack((y_r.real, y_r.imag))).to(device)
-    
+
     z = backend.rfft(x_r)
-    assert torch.allclose(y_r, z)
+    assert torch.allclose(y_r[..., 0], z.real)
 
     z_1 = backend.ifft(z)
-    assert torch.allclose(x_r[..., 0], z_1[..., 0])
-
-    print(z.shape)
+    assert torch.allclose(x_r, z_1.real)
 
     z_2 = backend.irfft(z)
-    print(z_2.shape)
-    assert not z_2.shape[-1] == 2
     assert torch.allclose(x_r, z_2)

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -368,7 +368,7 @@ def test_batch_shape_agnostic(device, backend):
     for test_shape in test_shapes:
         x = torch.zeros(test_shape).to(device)
 
-        S.vectorize = True
+        S.out_type = 'array'
         Sx = S(x)
 
         assert Sx.dim() == len(test_shape)+1
@@ -376,11 +376,10 @@ def test_batch_shape_agnostic(device, backend):
         assert Sx.shape[-2] == n_coeffs
         assert Sx.shape[:-2] == test_shape[:-1]
 
-        S.vectorize = False
+        S.out_type = 'list'
         Sx = S(x)
 
         assert len(Sx) == n_coeffs
-        for k, v in Sx.items():
-            assert v.shape[-1] == length_ds
-            assert v.shape[-2] == 1
-            assert v.shape[:-2] == test_shape[:-1]
+        for c in Sx:
+            assert c['coef'].shape[-1] == length_ds
+            assert c['coef'].shape[:-1] == test_shape[:-1]


### PR DESCRIPTION
This fixes dev and passes all 1D tests. But it goes further:

 1. Removed `Modulus` implementations. The cited purpose is "stability" and "not returning NaNs for gradients", but `torch.abs(x)` accomplishes the same AFAIK, and `test_modulus()` passes.
 2. Dropped trailing dim everywhere (i.e. `view_as_real`) except `subsample_fourier` since complex `mean()` isn't implemented in 1.7. I'm not aware of its need beyond modulus; it only complicates code.

### Todo

 - [ ] Docs (will change after review)
 - [ ] 2D & 3D (I leave this to devs)