### PR TITLE
Remove custom tensorflow build

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -2,10 +2,6 @@ FROM nvidia/cuda:11.2.2-devel-ubuntu20.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      cmake \
-      gfortran \
-      git \
-      intel-mkl \
       python3-appdirs \
       python3-mako \
       python3-numpy \
@@ -21,23 +17,10 @@ RUN apt-get update && \
     apt-get autoclean -y && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-ADD http://icl.utk.edu/projectsfiles/magma/downloads/magma-2.5.4.tar.gz /tmp/
-RUN cd /tmp && \
-    tar xzf magma-*.tar.gz && \
-    rm magma-*.tar.gz && \
-    mkdir magma && cd magma && \
-    CFLAGS=-I/usr/include/mkl CXXFLAGS=-I/usr/include/mkl cmake ../magma-* -DMKLROOT=/usr -DGPU_TARGET=sm_35 && \
-    make -j4 && make install && \
-    git clone --recursive --depth 1 -b v1.7.1 https://github.com/pytorch/pytorch /tmp/pytorch && \
-    cd /tmp/pytorch && \
-    CMAKE_INCLUDE_PATH=/usr/include/mkl TORCH_CUDA_ARCH_LIST=3.5 PYTORCH_BUILD_VERSION=1.7.1 PYTORCH_BUILD_NUMBER=1 python3 setup.py install && \
-    cd /tmp && \
-    rm -rf magma pytorch
-
 RUN pip3 install \
       scipy \
       configparser \
-      'torchvision==0.8.2' \
+      torchvision \
       scikit-cuda \
       cupy \
       'tensorflow-gpu>=2.0.0a0' \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -2,6 +2,7 @@ FROM nvidia/cuda:11.2.2-devel-ubuntu20.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      libcudnn8 \
       python3-appdirs \
       python3-mako \
       python3-numpy \


### PR DESCRIPTION
We've now added v100 GPUs to jenkins, so the custom tensorflow build is no longer necessary.  (Alternatively we could keep it and add support for the new GPUs so we can run on both, but probably there's not much point.)