### PR TITLE
Expose `r_psi`

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -435,7 +435,8 @@ def compute_params_filterbank(sigma_low, Q, r_psi=math.sqrt(0.5), alpha=5.):
         number of wavelets per octave.
     r_psi : float, optional
         Should be >0 and <1. Controls the redundancy of the filters
-        (the larger r_psi, the larger the overlap between adjacent wavelets).
+        (the larger r_psi, the larger the overlap between adjacent wavelets),
+        and stability against time-warp deformations (larger r_psi improves it).
         Defaults to sqrt(0.5).
     alpha : float, optional
         tolerance factor for the aliasing after subsampling.
@@ -510,10 +511,12 @@ def calibrate_scattering_filters(J, Q, r_psi=math.sqrt(0.5), sigma0=0.1,
         maximal scale of the scattering (controls the number of wavelets)
     Q : int
         number of wavelets per octave for the first order
-    r_psi : float, optional
+    r_psi : float / tuple[float], optional
         Should be >0 and <1. Controls the redundancy of the filters
-        (the larger r_psi, the larger the overlap between adjacent wavelets).
-        Defaults to sqrt(0.5)
+        (the larger r_psi, the larger the overlap between adjacent wavelets),
+        and stability against time-warp deformations (larger r_psi improves it).
+        Defaults to sqrt(0.5).
+        Tuple sets separately for first- and second-order filters.
     sigma0 : float, optional
         frequential width of the low-pass filter at scale J=0
         (the subsequent widths are defined by sigma_J = sigma0 / 2^J).
@@ -577,10 +580,12 @@ def scattering_filter_factory(J_support, J_scattering, Q, r_psi=math.sqrt(0.5),
     Q : int
         number of wavelets per octave at the first order. For audio signals,
         a value Q >= 12 is recommended in order to separate partials.
-    r_psi : float, optional
+    r_psi : float / tuple[float], optional
         Should be >0 and <1. Controls the redundancy of the filters
-        (the larger r_psi, the larger the overlap between adjacent wavelets).
+        (the larger r_psi, the larger the overlap between adjacent wavelets),
+        and stability against time-warp deformations (larger r_psi improves it).
         Defaults to sqrt(0.5).
+        Tuple sets separately for first- and second-order filters.
     criterion_amplitude : float, optional
         Represents the numerical error which is allowed to be lost after
         convolution and padding. Defaults to 1e-3.

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -22,7 +22,7 @@ class ScatteringBase1D(ScatteringBase):
         self.oversampling = oversampling
         self.vectorize = vectorize
         self.out_type = out_type
-        self.r_psi = r_psi
+        self.r_psi = r_psi if isinstance(r_psi, tuple) else (r_psi, r_psi)
         self.backend = backend
 
     def build(self):
@@ -88,7 +88,8 @@ class ScatteringBase1D(ScatteringBase):
         meta : dictionary
             See the documentation for `compute_meta_scattering()`.
         """
-        return compute_meta_scattering(self.J, self.Q, max_order=self.max_order)
+        return compute_meta_scattering(self.J, self.Q, r_psi=self.r_psi,
+                                       max_order=self.max_order)
 
     def output_size(self, detail=False):
         """Get size of the scattering transform
@@ -195,6 +196,12 @@ class ScatteringBase1D(ScatteringBase):
             output is a list of dictionaries, each containing a scattering
             coefficient along with meta information. For more information, see
             the documentation for `scattering`.
+        r_psi : float / tuple[float], optional
+            Should be >0 and <1. Controls the redundancy of the filters
+            (the larger r_psi, the larger the overlap between adjacent wavelets),
+            and stability against time-warp deformations (larger r_psi improves it).
+            Defaults to sqrt(0.5).
+            Tuple sets separately for first- and second-order filters.
         """
 
     _doc_class = \

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,8 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend=None):
+            oversampling=0, vectorize=True, out_type='array', r_psi=math.sqrt(.5),
+            backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -21,6 +22,7 @@ class ScatteringBase1D(ScatteringBase):
         self.oversampling = oversampling
         self.vectorize = vectorize
         self.out_type = out_type
+        self.r_psi = r_psi
         self.backend = backend
 
     def build(self):
@@ -32,7 +34,6 @@ class ScatteringBase1D(ScatteringBase):
         automatically during object creation and no subsequent calls are
         therefore needed.
         """
-        self.r_psi = math.sqrt(0.5)
         self.sigma0 = 0.1
         self.alpha = 5.
         self.P_max = 5
@@ -183,6 +184,10 @@ class ScatteringBase1D(ScatteringBase):
             Tensor or collected into a dictionary. Deprecated in favor of
             `out_type`. For more details, see the documentation for
             `scattering`.
+        r_psi : float, optional
+            Should be >0 and <1. Controls the redundancy of the filters
+            (the larger r_psi, the larger the overlap between adjacent wavelets).
+            Defaults to sqrt(0.5).
         out_type : str
             Specifices the output format of the transform, which is currently
             one of `'array'` or `'list`'. If `'array'`, the output is a large

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -1,3 +1,4 @@
+import math
 from ...frontend.keras_frontend import ScatteringKeras
 from ...scattering1d.frontend.base_frontend import ScatteringBase1D
 
@@ -7,10 +8,10 @@ from tensorflow.python.framework import tensor_shape
 
 
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
-    def __init__(self, J, Q=1, max_order=2, oversampling=0):
+    def __init__(self, J, Q=1, max_order=2, oversampling=0, r_psi=math.sqrt(.5)):
         ScatteringKeras.__init__(self)
         ScatteringBase1D.__init__(self, J, None, Q, max_order, True,
-                oversampling, True, 'array', None)
+                oversampling, True, 'array', r_psi, None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -1,4 +1,5 @@
 import warnings
+import math
 
 from ...frontend.numpy_frontend import ScatteringNumPy
 from ..core.scattering1d import scattering1d
@@ -8,10 +9,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='numpy'):
+            oversampling=0, vectorize=True, out_type='array', r_psi=math.sqrt(.5),
+            backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, vectorize, out_type, r_psi, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 import warnings
+import math
 
 from ...frontend.tensorflow_frontend import ScatteringTensorFlow
 from ..core.scattering1d import scattering1d
@@ -9,11 +10,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='tensorflow',
-                 name='Scattering1D'):
+            oversampling=0, vectorize=True, out_type='array', r_psi=math.sqrt(.5),
+            backend='tensorflow', name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, vectorize, out_type, r_psi, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -1,5 +1,6 @@
 import torch
 import warnings
+import math
 
 from ...frontend.torch_frontend import ScatteringTorch
 from ..core.scattering1d import scattering1d
@@ -9,10 +10,11 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='torch'):
+            oversampling=0, vectorize=True, out_type='array', r_psi=math.sqrt(.5),
+            backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, vectorize, out_type, r_psi, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -90,11 +90,12 @@ def compute_minimum_support_to_pad(T, J, Q, criterion_amplitude=1e-3,
         convolution and padding.
         The larger criterion_amplitude, the smaller the padding size is.
         Defaults to `1e-3`
-    r_psi : float, optional
-        Should be `>0` and `<1`. Controls the redundancy of the filters
-        (the larger r_psi, the larger the overlap between adjacent
-        wavelets).
-        Defaults to `sqrt(0.5)`.
+    r_psi : float / tuple[float], optional
+        Should be >0 and <1. Controls the redundancy of the filters
+        (the larger r_psi, the larger the overlap between adjacent wavelets),
+        and stability against time-warp deformations (larger r_psi improves it).
+        Defaults to sqrt(0.5).
+        Tuple sets separately for first- and second-order filters.
     sigma0 : float, optional
         parameter controlling the frequential width of the
         low-pass filter at J_scattering=0; at a an absolute J_scattering,
@@ -181,7 +182,7 @@ def precompute_size_scattering(J, Q, max_order=2, detail=False):
             return size_order0 + size_order1
 
 
-def compute_meta_scattering(J, Q, max_order=2):
+def compute_meta_scattering(J, Q, r_psi=math.sqrt(.5), max_order=2):
     """Get metadata on the transform.
 
     This information specifies the content of each scattering coefficient,
@@ -195,6 +196,12 @@ def compute_meta_scattering(J, Q, max_order=2):
     Q : int >= 1
         The number of first-order wavelets per octave.
         Second-order wavelets are fixed to one wavelet per octave.
+    r_psi : float / tuple[float], optional
+        Should be >0 and <1. Controls the redundancy of the filters
+        (the larger r_psi, the larger the overlap between adjacent wavelets),
+        and stability against time-warp deformations (larger r_psi improves it).
+        Defaults to sqrt(0.5).
+        Tuple sets separately for first- and second-order filters.
     max_order : int, optional
         The maximum order of scattering coefficients to compute.
         Must be either equal to `1` or `2`. Defaults to `2`.
@@ -224,7 +231,7 @@ def compute_meta_scattering(J, Q, max_order=2):
             in the non-vectorized output.
     """
     sigma_low, xi1s, sigma1s, j1s, xi2s, sigma2s, j2s = \
-        calibrate_scattering_filters(J, Q)
+        calibrate_scattering_filters(J, Q, r_psi=r_psi)
 
     meta = {}
 


### PR DESCRIPTION
Enables constructing a tight frame; particularly helpful for JTFS where deviations amplify quintically - see [discussion](https://github.com/kymatio/kymatio/discussions/732#discussioncomment-855703).