### PR TITLE
Revamp `xi_max`

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -405,7 +405,7 @@ def compute_xi_max(Q):
     xi_max : float
         largest frequency of the wavelet frame.
     """
-    xi_max = max(1. / (1. + math.pow(2., 3. / Q)), 0.35)
+    xi_max = max(1. / (1. + math.pow(2., 1. / Q)), 0.4)
     return xi_max
 
 


### PR DESCRIPTION
It's too low. Analyticity is worse with greater, but poor coverage beats no coverage.

![image](https://user-images.githubusercontent.com/16495490/126914345-3e67e4ed-e8c4-48ac-99ef-1b2f7193e7c1.png)

<img src="https://user-images.githubusercontent.com/16495490/126914459-2660aa6f-e25b-4fcb-94b1-b8b226b20237.png" width="450">

(Note: LP sum images assume #765 merged)