### PR TITLE
Removed redundant default value for alpha

### DIFF
--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -171,7 +171,7 @@ def precompute_size_scattering(J, Q, T, max_order=2, detail=False):
         the number of coefficients in each order.
     """
     sigma_low, xi1, sigma1, j1, xi2, sigma2, j2 = \
-        calibrate_scattering_filters(J, Q, T)
+        calibrate_scattering_filters(J, Q, T, alpha=5.)
 
     size_order0 = 1
     size_order1 = len(xi1)
@@ -239,7 +239,7 @@ def compute_meta_scattering(J, Q, T, max_order=2):
             in the non-vectorized output.
     """
     sigma_low, xi1s, sigma1s, j1s, xi2s, sigma2s, j2s = \
-        calibrate_scattering_filters(J, Q, T)
+        calibrate_scattering_filters(J, Q, T, alpha=5.)
 
     meta = {}
 

--- a/tests/scattering1d/test_filters_scattering1d.py
+++ b/tests/scattering1d/test_filters_scattering1d.py
@@ -168,7 +168,7 @@ def test_calibrate_scattering_filters():
     for J in J_range:
         for Q in Q_range:
             sigma_low, xi1, sigma1, j1, xi2, sigma2, j2 = \
-                calibrate_scattering_filters( J, Q, 2**J)
+                calibrate_scattering_filters(J, Q, 2 ** J, alpha=5.)
             # Check that all sigmas are > 0
             assert sigma_low > 0
             for sig in sigma1:
@@ -182,7 +182,7 @@ def test_calibrate_scattering_filters():
                 assert sig >= sigma_low
 
     with pytest.raises(ValueError) as ve:
-        calibrate_scattering_filters(J_range[0], 0.9, 2**J_range[0])
+        calibrate_scattering_filters(J_range[0], 0.9, 2 ** J_range[0], alpha=5.)
     assert "should always be >= 1" in ve.value.args[0]
 
 
@@ -211,7 +211,7 @@ def test_get_max_dyadic_subsampling():
         xi_range = xi_max * np.power(0.5, np.arange(J * Q) / float(Q))
         for xi in xi_range:
             sigma = compute_sigma_psi(xi, Q)
-            j = get_max_dyadic_subsampling(xi, sigma)
+            j = get_max_dyadic_subsampling(xi, sigma, alpha=5.)
             # Check for subsampling. If there is no subsampling, the filters
             # cannot be aliased, so no need to check them.
             if j > 0:


### PR DESCRIPTION
Backwards compatible
No new functionality
Note! Test function was modified to use a value of alpha=5.

Removed default value for alpha parameter everywhere in filter_bank.py except factory function (scattering_filter_factory). This way the value of alpha is set once, avoiding a possible override of this value by the default.
