### PR TITLE
DOC correction

### DIFF
--- a/kymatio/frontend/keras_frontend.py
+++ b/kymatio/frontend/keras_frontend.py
@@ -21,7 +21,7 @@ class ScatteringKeras(Layer):
 
     _doc_alias_name = 'call'
 
-    _doc_alias_call = ''
+    _doc_alias_call = '({x})'
 
     _doc_frontend_paragraph = \
         """

--- a/kymatio/frontend/numpy_frontend.py
+++ b/kymatio/frontend/numpy_frontend.py
@@ -14,7 +14,7 @@ class ScatteringNumPy:
 
     _doc_alias_name = '__call__'
 
-    _doc_alias_call = ''
+    _doc_alias_call = '({x})'
 
     _doc_frontend_paragraph = ''
 

--- a/kymatio/frontend/sklearn_frontend.py
+++ b/kymatio/frontend/sklearn_frontend.py
@@ -21,7 +21,7 @@ class ScatteringTransformerMixin(BaseEstimator, TransformerMixin):
 
     _doc_alias_name = 'predict'
 
-    _doc_alias_call = '.predict'
+    _doc_alias_call = '.predict({x}.flatten())'
 
     _doc_frontend_paragraph = \
         """
@@ -31,7 +31,7 @@ class ScatteringTransformerMixin(BaseEstimator, TransformerMixin):
         extension, it can be included as part of a scikit-learn `Pipeline`.
         """
 
-    _doc_sample = 'np.random.randn(1, np.prod({shape}))'
+    _doc_sample = 'np.random.randn({shape})'
 
     _doc_has_shape = True
 

--- a/kymatio/frontend/sklearn_frontend.py
+++ b/kymatio/frontend/sklearn_frontend.py
@@ -31,7 +31,7 @@ class ScatteringTransformerMixin(BaseEstimator, TransformerMixin):
         extension, it can be included as part of a scikit-learn `Pipeline`.
         """
 
-    _doc_sample = 'np.random.randn((1, {shape}))'
+    _doc_sample = 'np.random.randn(1, np.prod({shape}))'
 
     _doc_has_shape = True
 

--- a/kymatio/frontend/sklearn_frontend.py
+++ b/kymatio/frontend/sklearn_frontend.py
@@ -7,10 +7,10 @@ class ScatteringTransformerMixin(BaseEstimator, TransformerMixin):
         return self
 
     def predict(self, x):
-        n_samples = x.shape[0]
+        batch_shape = x.shape[:-1]
         x = x.reshape((-1,) + self.shape)
         Sx = self.scattering(x)
-        Sx = Sx.reshape(n_samples, -1)
+        Sx = Sx.reshape(batch_shape + (-1,))
 
         return Sx
 

--- a/kymatio/frontend/sklearn_frontend.py
+++ b/kymatio/frontend/sklearn_frontend.py
@@ -31,7 +31,7 @@ class ScatteringTransformerMixin(BaseEstimator, TransformerMixin):
         extension, it can be included as part of a scikit-learn `Pipeline`.
         """
 
-    _doc_sample = 'np.random.randn(np.prod({shape}))'
+    _doc_sample = 'np.random.randn((1, {shape}))'
 
     _doc_has_shape = True
 

--- a/kymatio/frontend/torch_frontend.py
+++ b/kymatio/frontend/torch_frontend.py
@@ -22,7 +22,7 @@ class ScatteringTorch(nn.Module):
 
     _doc_alias_name = 'forward'
 
-    _doc_alias_call = '.forward'
+    _doc_alias_call = '.forward({x})'
 
     _doc_frontend_paragraph = \
         """

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -437,7 +437,7 @@ class ScatteringBase1D(ScatteringBase):
             Sx = S.scattering(x)
 
             # Equivalently, use the alias.
-            Sx = S{alias_call}(x)
+            Sx = S{alias_call}
 
         Above, the length of the signal is :math:`N = 2^{{13}} = 8192`, while the
         maximum scale of the scattering transform is set to :math:`2^J = 2^6 =
@@ -552,7 +552,7 @@ class ScatteringBase1D(ScatteringBase):
             array=cls._doc_array,
             frontend_paragraph=cls._doc_frontend_paragraph,
             alias_name=cls._doc_alias_name,
-            alias_call=cls._doc_alias_call,
+            alias_call=cls._doc_alias_call.format(x="x"),
             instantiation=instantiation,
             param_shape=param_shape,
             attrs_shape=attrs_shape,

--- a/kymatio/scattering2d/frontend/base_frontend.py
+++ b/kymatio/scattering2d/frontend/base_frontend.py
@@ -129,7 +129,7 @@ class ScatteringBase2D(ScatteringBase):
             Sx = S.scattering(x)
 
             # Equivalently, use the alias.
-            Sx = S{alias_call}(x)
+            Sx = S{alias_call}
 
         Parameters
         ----------
@@ -215,7 +215,7 @@ class ScatteringBase2D(ScatteringBase):
             array=cls._doc_array,
             frontend_paragraph=cls._doc_frontend_paragraph,
             alias_name=cls._doc_alias_name,
-            alias_call=cls._doc_alias_call,
+            alias_call=cls._doc_alias_call.format(x="x"),
             instantiation=instantiation,
             param_shape=param_shape,
             attrs_shape=attrs_shape,

--- a/kymatio/scattering3d/frontend/base_frontend.py
+++ b/kymatio/scattering3d/frontend/base_frontend.py
@@ -60,7 +60,7 @@ class ScatteringBase3D(ScatteringBase):
             Sx = S.scattering(x)
 
             # Equivalently, use the alias.
-            Sx = S{alias_call}(x)
+            Sx = S{alias_call}
 
         Parameters
         ----------
@@ -116,7 +116,7 @@ class ScatteringBase3D(ScatteringBase):
             array=cls._doc_array,
             frontend_paragraph=cls._doc_frontend_paragraph,
             alias_name=cls._doc_alias_name,
-            alias_call=cls._doc_alias_call,
+            alias_call=cls._doc_alias_call.format(x="x"),
             sample=cls._doc_sample.format(shape=cls._doc_shape))
 
         cls.scattering.__doc__ = ScatteringBase3D._doc_scattering.format(


### PR DESCRIPTION
This pull request corrects an incorrect docstring in the sklearn documentation. I remove the use of `np.prod` in the creation of the input, and additionally add a batch dimension. 

While the documentation now correctly shows how to apply it to an input of a certain shape, the sklearn documentation example is obviously not that great.

I don't know how to build the documentation. can someone send me a tutorial on how to build it? 

This solves issue #760