### PR TITLE
DOC fix reconstruct_torch.py example by calling detach

### DIFF
--- a/examples/1d/reconstruct_torch.py
+++ b/examples/1d/reconstruct_torch.py
@@ -105,7 +105,7 @@ for k in range(n_iterations):
         print('Iteration %3d, loss %.2f' % (k, err.detach().numpy()))
 
     # Measure the new loss.
-    history.append(err)
+    history.append(err.detach())
 
     backward(err)
 


### PR DESCRIPTION
This pull request fixes an example from erroring out due to not detaching tensors from the computational graph before converting to numpy. 

This goes a small way of solving #817 