### PR TITLE
DOC Use tight_layout to prevent plot axes from overlapping one another

### DIFF
--- a/examples/1d/plot_real_signal.py
+++ b/examples/1d/plot_real_signal.py
@@ -120,8 +120,8 @@ plt.title('First-order scattering')
 plt.subplot(3, 1, 3)
 plt.imshow(Sx[order2], aspect='auto')
 plt.title('Second-order scattering')
-plt.tight_layout()
 ###############################################################################
 # Display the plots!
 
+plt.tight_layout()
 plt.show()

--- a/examples/1d/plot_real_signal.py
+++ b/examples/1d/plot_real_signal.py
@@ -120,7 +120,7 @@ plt.title('First-order scattering')
 plt.subplot(3, 1, 3)
 plt.imshow(Sx[order2], aspect='auto')
 plt.title('Second-order scattering')
-
+plt.tight_layout()
 ###############################################################################
 # Display the plots!
 

--- a/examples/1d/plot_synthetic.py
+++ b/examples/1d/plot_synthetic.py
@@ -1,7 +1,6 @@
 """
 Compute the scattering transform of a synthetic signal
 ======================================================
-
 In this example we generate a harmonic signal of a few different frequencies
 and analyze it with the 1D scattering transform.
 """
@@ -94,5 +93,5 @@ plt.title('First-order scattering')
 plt.subplot(3, 1, 3)
 plt.imshow(Sx[order2], aspect='auto')
 plt.title('Second-order scattering')
-
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
This PR fixes plots in the 1d code from overlapping one another. 


From `plot_real_signal.py`.
![Figure_2](https://user-images.githubusercontent.com/39755015/171536172-229fd2fb-c79d-4946-8000-a54e0dfe9e7e.png)
![Figure_2_fixed](https://user-images.githubusercontent.com/39755015/171536179-57376d6d-d4ac-4cc4-8084-1a06bf4253b6.png)

From `plot_synthetic.py`.
![Figure_3](https://user-images.githubusercontent.com/39755015/171536181-e555b49b-357f-4390-b732-b8b2625e86b9.png)
![Figure_3_fixed](https://user-images.githubusercontent.com/39755015/171536183-8a0d3ec7-56f3-42ec-9e47-3baa3b48c888.png)

This goes a small way of solving #817 

