### PR TITLE
MAINT removed useless apply function

### DIFF
--- a/kymatio/scattering3d/utils.py
+++ b/kymatio/scattering3d/utils.py
@@ -93,17 +93,3 @@ def sqrt(x):
     np.seterr(**old_settings)
 
     return y
-
-def _apply_filters(filters, fn):
-    """
-        Parameters
-        ----------
-        filters: a filter bank
-        fn: a function to apply on the parameters
-        Returns
-        -------
-        filters: the filters modified
-    """
-    for k in range(len(filters)):
-        filters[k] = fn(filters[k])
-    return filters


### PR DESCRIPTION
Back in the good old days, before I existed, [Kymatio reimplemented various calls](https://github.com/kymatio/kymatio/commit/12b082fca0e3fdc88bee3220c9e867a29fee5d11#diff-144c72d86c0312177446796e4be3836116b58a5e9169cdea6254a24ab3243134R236) that a `nn.module` had. These included `.cpu`,`cuda`, and were often implemented using a `_apply` call.

A reviewer of our JMLR submission kindly noted that we could just inherit from a `nn.module` instead of reimplementing all those calls. 

This `_apply_filters` tucked and hidden away in the 3d utils code is the last remaining vestige of this old way of doing things. 