### PR TITLE
MAINT decouple `scattering_filter_factory` from `ScatteringBase1D.build`

### DIFF
--- a/examples/1d/plot_filters.py
+++ b/examples/1d/plot_filters.py
@@ -69,7 +69,6 @@ def scattering1D_filter_factory():
   # first-order wavelet filters (`psi1_f`), and the second-order filters
   # (`psi2_f`).
   
-  
   phi_f, psi1_f, psi2_f = scattering_filter_factory(np.log2(N), J, Q, T)
   ###############################################################################
   # The `phi_f` output is a dictionary where each integer key corresponds points

--- a/examples/1d/plot_filters.py
+++ b/examples/1d/plot_filters.py
@@ -69,8 +69,8 @@ def scattering1D_filter_factory():
   # first-order wavelet filters (`psi1_f`), and the second-order filters
   # (`psi2_f`).
   
-  phi_f, psi1_f, psi2_f, _ = scattering_filter_factory(np.log2(N), J, Q, T)
   
+  phi_f, psi1_f, psi2_f = scattering_filter_factory(np.log2(N), J, Q, T)
   ###############################################################################
   # The `phi_f` output is a dictionary where each integer key corresponds points
   # to the instantiation of the filter at a certain resolution. In other words,

--- a/examples/1d/plot_filters.py
+++ b/examples/1d/plot_filters.py
@@ -151,8 +151,8 @@ def scattering1D_filter_factory_T():
               default_str = ' (default)'
           else: 
               default_str = ''
-          phi_f, psi1_f, psi2_f, _ = scattering_filter_factory(np.log2(N), J, Q, T)
           msg = 'J=' + str(J) + ', T=' +str(T) + default_str + ': LP-filter width $\sigma_{low}$=' + str(phi_f['sigma']) + ' (=0.1/T)'                
+          phi_f, psi1_f, psi2_f = scattering_filter_factory(np.log2(N), J, Q, T)
           print(msg)
           assert(phi_f['sigma']==0.1/T)
 

--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -556,7 +556,7 @@ def calibrate_scattering_filters(J, Q, T, alpha, r_psi=math.sqrt(0.5), sigma0=0.
 
 
 def scattering_filter_factory(J_support, J_scattering, Q, T, r_psi=math.sqrt(0.5),
-                              criterion_amplitude=1e-3, normalize='l1',
+                              normalize='l1',
                               max_subsampling=None, sigma0=0.1, alpha=5.,
                               P_max=5, eps=1e-7, **kwargs):
     """
@@ -589,9 +589,6 @@ def scattering_filter_factory(J_support, J_scattering, Q, T, r_psi=math.sqrt(0.5
         Should be >0 and <1. Controls the redundancy of the filters
         (the larger r_psi, the larger the overlap between adjacent wavelets).
         Defaults to sqrt(0.5).
-    criterion_amplitude : float, optional
-        Represents the numerical error which is allowed to be lost after
-        convolution and padding. Defaults to 1e-3.
     normalize : string, optional
         Normalization convention for the filters (in the
         temporal domain). Supported values include 'l1' and 'l2'; a ValueError
@@ -643,10 +640,6 @@ def scattering_filter_factory(J_support, J_scattering, Q, T, r_psi=math.sqrt(0.5
         The keys of this dictionary are of th etype (j, n) where n is an
         integer counting the filters and j is the maximal dyadic subsampling
         which can be performed on top of this filter without aliasing.
-    t_max_phi : int
-        temporal size to use to pad the signal on the right and on the
-        left by making at most criterion_amplitude error. Assumes that the
-        temporal support of the low-pass filter is larger than all filters.
 
     Refs
     ----
@@ -733,10 +726,5 @@ def scattering_filter_factory(J_support, J_scattering, Q, T, r_psi=math.sqrt(0.5
     phi_f['sigma'] = sigma_low
     phi_f['j'] = log2_T
 
-    # compute the support size allowing to pad without boundary errors
-    # at the finest resolution  # TODO
-    t_max_phi = compute_temporal_support(
-        phi_f[0].reshape(1, -1), criterion_amplitude=criterion_amplitude)
-
     # return results
-    return phi_f, psi1_f, psi2_f, t_max_phi
+    return phi_f, psi1_f, psi2_f

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -38,7 +38,6 @@ class ScatteringBase1D(ScatteringBase):
         self.alpha = 5.
         self.P_max = 5
         self.eps = 1e-7
-        self.criterion_amplitude = 1e-3
         self.normalize = 'l1'
 
         # check the shape
@@ -64,7 +63,8 @@ class ScatteringBase1D(ScatteringBase):
         # Compute the minimum support to pad (ideally)
         phi_f = gauss_1d(
             self.N, self.sigma0/self.T, self.normalize, self.P_max, self.eps)
-        min_to_pad = 3 * compute_temporal_support(phi_f, self.criterion_amplitude)
+        min_to_pad = 3 * compute_temporal_support(
+            phi_f.reshape(1, -1), criterion_amplitude=1e-3)
 
         # to avoid padding more than N - 1 on the left and on the right,
         # since otherwise torch sends nans
@@ -79,9 +79,8 @@ class ScatteringBase1D(ScatteringBase):
 
     def create_filters(self):
         # Create the filters
-        self.phi_f, self.psi1_f, self.psi2_f, _ = scattering_filter_factory(
+        self.phi_f, self.psi1_f, self.psi2_f = scattering_filter_factory(
             self.J_pad, self.J, self.Q, self.T, normalize=self.normalize,
-            criterion_amplitude=self.criterion_amplitude,
             r_psi=self.r_psi, sigma0=self.sigma0, alpha=self.alpha,
             P_max=self.P_max, eps=self.eps)
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -4,8 +4,8 @@ import numbers
 
 import numpy as np
 
-from ..filter_bank import scattering_filter_factory
-from ..utils import (compute_border_indices, compute_padding, compute_minimum_support_to_pad,
+from ..filter_bank import compute_temporal_support, gauss_1d, scattering_filter_factory
+from ..utils import (compute_border_indices, compute_padding,
 compute_meta_scattering, precompute_size_scattering)
 
 
@@ -62,11 +62,10 @@ class ScatteringBase1D(ScatteringBase):
         self.log2_T = math.floor(math.log2(self.T))
 
         # Compute the minimum support to pad (ideally)
-        min_to_pad = compute_minimum_support_to_pad(
-            self.N, self.J, self.Q, self.T, r_psi=self.r_psi, sigma0=self.sigma0,
-            alpha=self.alpha, P_max=self.P_max, eps=self.eps,
-            criterion_amplitude=self.criterion_amplitude,
-            normalize=self.normalize)
+        phi_f = gauss_1d(
+            self.N, self.sigma0/self.T, self.normalize, self.P_max, self.eps)
+        min_to_pad = 3 * compute_temporal_support(phi_f, self.criterion_amplitude)
+
         # to avoid padding more than N - 1 on the left and on the right,
         # since otherwise torch sends nans
         J_max_support = int(np.floor(np.log2(3 * self.N - 2)))

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import math
-from .filter_bank import scattering_filter_factory, calibrate_scattering_filters
+from .filter_bank import calibrate_scattering_filters
 
 def compute_border_indices(log2_T, J, i0, i1):
     """
@@ -68,74 +68,6 @@ def compute_padding(J_pad, N):
     if max(pad_left, pad_right) >= N:
         raise ValueError('Too large padding value, will lead to NaN errors')
     return pad_left, pad_right
-
-def compute_minimum_support_to_pad(N, J, Q, T, criterion_amplitude=1e-3,
-                                       normalize='l1', r_psi=math.sqrt(0.5),
-                                       sigma0=1e-1, alpha=5., P_max=5, eps=1e-7):
-
-
-    """
-    Computes the support to pad given the input size and the parameters of the
-    scattering transform.
-
-    Parameters
-    ----------
-    N : int
-        temporal size of the input signal
-    J : int
-        scale of the scattering
-    Q : int
-        number of wavelets per octave
-    T : int
-        temporal support of low-pass filter, controlling amount of imposed
-        time-shift invariance and maximum subsampling
-    normalize : string, optional
-        normalization type for the wavelets.
-        Only `'l2'` or `'l1'` normalizations are supported.
-        Defaults to `'l1'`
-    criterion_amplitude: float `>0` and `<1`, optional
-        Represents the numerical error which is allowed to be lost after
-        convolution and padding.
-        The larger criterion_amplitude, the smaller the padding size is.
-        Defaults to `1e-3`
-    r_psi : float, optional
-        Should be `>0` and `<1`. Controls the redundancy of the filters
-        (the larger r_psi, the larger the overlap between adjacent
-        wavelets).
-        Defaults to `sqrt(0.5)`.
-    sigma0 : float, optional
-        parameter controlling the frequential width of the
-        low-pass filter at J_scattering=0; at a an absolute J_scattering,
-        it is equal to :math:`\\frac{\\sigma_0}{2^J}`.
-        Defaults to `1e-1`.
-    alpha : float, optional
-        tolerance factor for the aliasing after subsampling.
-        The larger the alpha, the more conservative the value of maximal
-        subsampling is.
-        Defaults to `5`.
-    P_max : int, optional
-        maximal number of periods to use to make sure that the Fourier
-        transform of the filters is periodic.
-        `P_max = 5` is more than enough for double precision.
-        Defaults to `5`.
-    eps : float, optional
-        required machine precision for the periodization (single
-        floating point is enough for deep learning applications).
-        Defaults to `1e-7`.
-
-    Returns
-    -------
-    min_to_pad: int
-        minimal value to pad the signal on one size to avoid any
-        boundary error.
-    """
-    J_tentative = int(np.ceil(np.log2(N)))
-    _, _, _, t_max_phi = scattering_filter_factory(
-        J_tentative, J, Q, T, normalize=normalize, to_torch=False,
-        max_subsampling=0, criterion_amplitude=criterion_amplitude,
-        r_psi=r_psi, sigma0=sigma0, alpha=alpha, P_max=P_max, eps=eps)
-    min_to_pad = 3 * t_max_phi
-    return min_to_pad
 
 
 def precompute_size_scattering(J, Q, T, max_order=2, detail=False):

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -96,5 +96,5 @@ class TestScattering1DNumpy:
                     default_str = ' (default)'
                 else:
                     default_str = ''
-                phi_f, psi1_f, psi2_f, _ = scattering_filter_factory(np.log2(N), J, Q, T)
+                phi_f, psi1_f, psi2_f = scattering_filter_factory(np.log2(N), J, Q, T)
                 assert(phi_f['sigma']==0.1/T)


### PR DESCRIPTION
Fixes https://github.com/kymatio/kymatio/issues/840 
`scattering_filter_factory` should not return `t_max_phi`

* Net reduction in LOC count
* Simplification of the `scattering1d/filter_bank` module
* Faster `Scattering1D` constructor
* no more `criterion_amplitude` being passed to `scattering_filter_factory`
* no more `compute_minimum_support_to_pad`
* Backwards compatible as far as frontends are concerned


The calls to scattering_filter_factory will require a rebase from https://github.com/kymatio/kymatio/pull/833