### PR TITLE
Remove `vectorize`, introduce `out_type="dict"`

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend=None):
+            oversampling=0, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -20,7 +20,6 @@ class ScatteringBase1D(ScatteringBase):
         self.max_order = max_order
         self.average = average
         self.oversampling = oversampling
-        self.vectorize = vectorize
         self.out_type = out_type
         self.backend = backend
 
@@ -165,20 +164,12 @@ class ScatteringBase1D(ScatteringBase):
     r"""average : boolean
             Controls whether the output should be averaged (the standard
             scattering transform) or not (resulting in wavelet modulus
-            coefficients). Note that to obtain unaveraged output, the
-            `vectorize` flag must be set to `False` or `out_type` must be set
-            to `'list'`.
+            coefficients). If `average` is set to `False`, `out_type` must be
+            set to `'list'`.
      """
 
-    _doc_param_vectorize = \
-    r"""vectorize : boolean, optional
-            Determines wheter to return a vectorized scattering transform
-            (that is, a large array containing the output) or a dictionary
-            (where each entry corresponds to a separate scattering
-            coefficient). This parameter may be modified after object
-            creation. Deprecated in favor of `out_type` (see below). Defaults
-            to True.
-        out_type : str, optional
+    _doc_param_out_type = \
+    r"""out_type : str, optional
             The format of the output of a scattering transform. If set to
             `'list'`, then the output is a list containing each individual
             scattering coefficient with meta information. Otherwise, if set to
@@ -187,13 +178,8 @@ class ScatteringBase1D(ScatteringBase):
             `'array'`.
         """
 
-    _doc_attr_vectorize = \
-    r"""vectorize : boolean
-            Controls whether the output should be vectorized into a single
-            Tensor or collected into a dictionary. Deprecated in favor of
-            `out_type`. For more details, see the documentation for
-            `scattering`.
-        out_type : str
+    _doc_attr_out_type = \
+    r"""out_type : str
             Specifices the output format of the transform, which is currently
             one of `'array'` or `'list`'. If `'array'`, the output is a large
             array containing the scattering coefficients. If `'list`', the
@@ -289,7 +275,7 @@ class ScatteringBase1D(ScatteringBase):
             calculation. If this is not desirable, `oversampling` can be set
             to a large value to prevent too much subsampling. This parameter
             may be modified after object creation. Defaults to `0`.
-        {param_vectorize}
+        {param_out_type}
         Attributes
         ----------
         J : int
@@ -306,7 +292,7 @@ class ScatteringBase1D(ScatteringBase):
         {attr_average}oversampling : int
             The number of powers of two to oversample the output compared to
             the default subsampling rate determined from the filters.
-        {attr_vectorize}"""
+        {attr_out_type}"""
 
     _doc_scattering = \
     """Apply the scattering transform
@@ -314,26 +300,16 @@ class ScatteringBase1D(ScatteringBase):
        Given an input `{array}` of size `(B, N)`, where `B` is the batch
        size (it can be potentially an integer or a shape) and `N` is the length
        of the individual signals, this function computes its scattering
-       transform. If the `vectorize` flag is set to `True` (or if it is not
+       transform. If `out_type` is set to `"array"` (or if it is not
        available in this frontend), the output is in the form of a `{array}`
        or size `(B, C, N1)`, where `N1` is the signal length after subsampling
        to the scale :math:`2^J` (with the appropriate oversampling factor to
        reduce aliasing), and `C` is the number of scattering coefficients. If
-       `vectorize` is set `False`, however, the output is a dictionary
-       containing `C` keys, each a tuple whose length corresponds to the
-       scattering order and whose elements are the sequence of filter indices
-       used.
-
-       Note that the `vectorize` flag has been deprecated in favor of the
-       `out_type` parameter. If this is set to `'array'` (the default), the
-       `vectorize` flag is still respected, but if not, `out_type` takes
-       precedence. The two current output types are `'array'` and `'list'`.
-       The former gives the type of output described above. If set to
-       `'list'`, however, the output is a list of dictionaries, each
-       dictionary corresponding to a scattering coefficient and its associated
-       meta information. The coefficient is stored under the `'coef'` key,
-       while other keys contain additional information, such as `'j'` (the
-       scale of the filter used) and `'n`' (the filter index).
+       `out_type` is set to `'list'`, however, the output is a list of
+       dictionaries, each dictionary corresponding to a scattering coefficient
+       and its associated meta information. The coefficient is stored under th
+       `'coef'` key, while other keys contain additional information, such as
+       `'j'` (the scale of the filter used) and `'n`' (the filter index).
 
        Furthermore, if the `average` flag is set to `False`, these outputs
        are not averaged, but are simply the wavelet modulus coefficients of
@@ -347,10 +323,8 @@ class ScatteringBase1D(ScatteringBase):
        Returns
        -------
        S : tensor or dictionary
-           If `out_type` is `'array'` and the `vectorize` flag is `True`, the
-           output is a{n} `{array}` containing the scattering coefficients,
-           while if `vectorize` is `False`, it is a dictionary indexed by
-           tuples of filter indices. If `out_type` is `'list'`, the output is
+           If `out_type` is `'array'`, the output is a{n} `{array}` containing
+           the scattering coefficients. If `out_type` is `'list'`, the output is
            a list of dictionaries as described above.
     """
 
@@ -362,8 +336,8 @@ class ScatteringBase1D(ScatteringBase):
 
         param_average = cls._doc_param_average if cls._doc_has_out_type else ''
         attr_average = cls._doc_attr_average if cls._doc_has_out_type else ''
-        param_vectorize = cls._doc_param_vectorize if cls._doc_has_out_type else ''
-        attr_vectorize = cls._doc_attr_vectorize if cls._doc_has_out_type else ''
+        param_out_type = cls._doc_param_out_type if cls._doc_has_out_type else ''
+        attr_out_type = cls._doc_attr_out_type if cls._doc_has_out_type else ''
 
         cls.__doc__ = ScatteringBase1D._doc_class.format(
             array=cls._doc_array,
@@ -375,8 +349,8 @@ class ScatteringBase1D(ScatteringBase):
             attrs_shape=attrs_shape,
             param_average=param_average,
             attr_average=attr_average,
-            param_vectorize=param_vectorize,
-            attr_vectorize=attr_vectorize,
+            param_out_type=param_out_type,
+            attr_out_type=attr_out_type,
             sample=cls._doc_sample.format(shape=cls._doc_shape))
 
         cls.scattering.__doc__ = ScatteringBase1D._doc_scattering.format(

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -10,7 +10,7 @@ class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, T=None, max_order=2, oversampling=0):
         ScatteringKeras.__init__(self)
         ScatteringBase1D.__init__(self, J, None, Q, T, max_order, True,
-                oversampling, True, 'array', None)
+                oversampling, 'array', None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -7,10 +7,10 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='numpy'):
+            oversampling=0, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -22,20 +22,6 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                 'Input tensor x should have at least one axis, got {}'.format(
                     len(x.shape)))
 
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
-
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
 
@@ -44,26 +30,23 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.log2_T, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
-                         oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                         oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
-
             S = S.reshape(new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.
                 scattering_shape = v.shape[-2:]
                 new_shape = batch_shape + scattering_shape
-
                 S[k] = v.reshape(new_shape)
         elif self.out_type == 'list':
             for x in S:
                 scattering_shape = x['coef'].shape[-1:]
                 new_shape = batch_shape + scattering_shape
-
                 x['coef'] = x['coef'].reshape(new_shape)
 
         return S

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -8,11 +8,10 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='tensorflow',
-                 name='Scattering1D'):
+            oversampling=0, out_type='array', backend='tensorflow', name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -24,21 +23,6 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
                 'Input tensor x should have at least one axis, got {}'.format(
                     len(x.shape)))
 
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
-
         batch_shape = tf.shape(x)[:-1]
         signal_shape = tf.shape(x)[-1:]
 
@@ -47,26 +31,23 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.log2_T, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
-                         oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                         oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = tf.shape(S)[-2:]
             new_shape = tf.concat((batch_shape, scattering_shape), 0)
-
             S = tf.reshape(S, new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.
                 scattering_shape = tf.shape(v)[-2:]
                 new_shape = tf.concat((batch_shape, scattering_shape), 0)
-
                 S[k] = tf.reshape(v, new_shape)
         elif self.out_type == 'list':
             for x in S:
                 scattering_shape = tf.shape(x['coef'])[-1:]
                 new_shape = tf.concat((batch_shape, scattering_shape), 0)
-
                 x['coef'] = tf.reshape(x['coef'], new_shape)
 
         return S

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -8,10 +8,10 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='torch'):
+            oversampling=0, out_type='array', backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -76,37 +76,19 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                 'Input tensor x should have at least one axis, got {}'.format(
                     len(x.shape)))
 
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
-
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
-
         x = x.reshape((-1, 1) + signal_shape)
-
         self.load_filters()
-
         S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.log2_T, self.psi1_f, self.psi2_f, self.phi_f,\
                          max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
-                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                         ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
             S = S.reshape(new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -235,8 +235,7 @@ def compute_meta_scattering(J, Q, T, max_order=2):
             A Tensor of size `(C, max_order)`, specifying the indices of
             the filters used at each order (padded with NaNs).
         - `'key'` : list
-            The tuples indexing the corresponding scattering coefficient
-            in the non-vectorized output.
+            The tuples indexing the corresponding scattering coefficient.
     """
     sigma_low, xi1s, sigma1s, j1s, xi2s, sigma2s, j2s = \
         calibrate_scattering_filters(J, Q, T, alpha=5.)

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -123,8 +123,8 @@ def test_computation_Ux(backend, device, random_state=42):
     J = 6
     Q = 8
     T = 2**12
-    scattering = Scattering1D(J, T, Q, average=False,
-                              max_order=1, vectorize=False, frontend='torch', backend=backend).to(device)
+    scattering = Scattering1D(J, T, Q, average=False, out_type="dict",
+                              max_order=1, frontend='torch', backend=backend).to(device)
     # random signal
     x = torch.from_numpy(rng.randn(1, T)).float().to(device)
 
@@ -154,11 +154,6 @@ def test_computation_Ux(backend, device, random_state=42):
                     count += 1
 
         assert count == len(s)
-
-        with pytest.raises(ValueError) as ve:
-            scattering.vectorize = True
-            scattering(x)
-        assert "mutually incompatible" in ve.value.args[0]
 
 
 # Technical tests
@@ -212,9 +207,7 @@ def test_coordinates(device, backend, random_state=42):
 
     for max_order in [1, 2]:
         scattering.max_order = max_order
-
-        scattering.vectorize = False
-
+        scattering.out_type = "dict"
         if backend.name.endswith('skcuda') and device == 'cpu':
             with pytest.raises(TypeError) as ve:
                 s_dico = scattering(x)
@@ -222,8 +215,8 @@ def test_coordinates(device, backend, random_state=42):
         else:
             s_dico = scattering(x)
             s_dico = {k: s_dico[k].data for k in s_dico.keys()}
-        scattering.vectorize = True
 
+        scattering.out_type = "array"
         if backend.name.endswith('_skcuda') and device == 'cpu':
             with pytest.raises(TypeError) as ve:
                 s_vec = scattering(x)
@@ -256,7 +249,8 @@ def test_precompute_size_scattering(device, backend, random_state=42):
     Q = 8
     N = 2**12
 
-    scattering = Scattering1D(J, N, Q, vectorize=False, backend=backend, frontend='torch')
+    scattering = Scattering1D(
+        J, N, Q, out_type="dict", backend=backend, frontend='torch')
 
     x = torch.randn(2, N)
 
@@ -357,7 +351,6 @@ def test_batch_shape_agnostic(device, backend):
         return
 
     Sx = S(x)
-
     assert Sx.dim() == 2
     assert Sx.shape[-1] == length_ds
 
@@ -368,7 +361,7 @@ def test_batch_shape_agnostic(device, backend):
     for test_shape in test_shapes:
         x = torch.zeros(test_shape).to(device)
 
-        S.vectorize = True
+        S.out_type = "array"
         Sx = S(x)
 
         assert Sx.dim() == len(test_shape)+1
@@ -376,7 +369,7 @@ def test_batch_shape_agnostic(device, backend):
         assert Sx.shape[-2] == n_coeffs
         assert Sx.shape[:-2] == test_shape[:-1]
 
-        S.vectorize = False
+        S.out_type = "dict"
         Sx = S(x)
 
         assert len(Sx) == n_coeffs


### PR DESCRIPTION
Fixes #843
I'm proposing a new value of `out_type`, namely, `dict`, to support the previous setting of `out_type="array"` and `not vectorize` (we will need to document the new `out_type` behavior a little bit better than it currently is. your feedback is valued)

Net loss in LOC count
Updated docs in base frontend accordingly

