### PR TITLE
 Make `Q2` customizable

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -359,9 +359,9 @@ def scattering_filter_factory(J_support, J_scattering, Q, T, r_psi=math.sqrt(0.5
     J_scattering : int
         parameter for the scattering transform (2**J_scattering
         corresponds to maximal temporal support of any filter)
-    Q : int
-        number of wavelets per octave at the first order. For audio signals,
-        a value Q >= 12 is recommended in order to separate partials.
+    Q : tuple
+        number of wavelets per octave at the first and second order 
+        Q = (Q1, Q2). Q1 and Q2 are both int >= 1.
     T : int
         temporal support of low-pass filter, controlling amount of imposed
         time-shift invariance and maximum subsampling
@@ -417,8 +417,9 @@ def scattering_filter_factory(J_support, J_scattering, Q, T, r_psi=math.sqrt(0.5
     """
     # compute the spectral parameters of the filters
     sigma_min = sigma0 / math.pow(2, J_scattering)
-    xi1s, sigma1s, j1s = compute_params_filterbank(sigma_min, Q, alpha, r_psi)
-    xi2s, sigma2s, j2s = compute_params_filterbank(sigma_min, 1, alpha, r_psi)
+    Q1, Q2 = Q
+    xi1s, sigma1s, j1s = compute_params_filterbank(sigma_min, Q1, alpha, r_psi)
+    xi2s, sigma2s, j2s = compute_params_filterbank(sigma_min, Q2, alpha, r_psi)
 
     # width of the low-pass filter
     sigma_low = sigma0 / T

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -40,6 +40,10 @@ class ScatteringBase1D(ScatteringBase):
         if self.Q < 1:
             raise ValueError('Q should always be >= 1, got {}'.format(self.Q))
 
+        # check the number of filters per octave
+        if self.Q < 1:
+            raise ValueError('Q should always be >= 1, got {}'.format(self.Q))
+
         # check the shape
         if isinstance(self.shape, numbers.Integral):
             self.N = self.shape

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -46,9 +46,11 @@ class ScatteringBase1D(ScatteringBase):
             if len(self.Q) == 1:
                 self.Q = self.Q + (1, )
             elif len(self.Q) < 1 or len(self.Q) > 2: 
-                raise NotImplementedError("Q should be an integer, 1-tuple or "
-                                          "2-tuple. Scattering transforms " 
-                                          "beyond order 2 are not implemented.")
+                raise NotImplementedError("Q should be a 1-tuple or 2-tuple. "
+                                          "Scattering transforms beyond "
+                                          "order 2 are not implemented.")
+        else:
+            raise ValueError("Q must be an integer or a tuple")
 
         # check the shape
         if isinstance(self.shape, numbers.Integral):

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -39,8 +39,6 @@ class ScatteringBase1D(ScatteringBase):
         # check the number of filters per octave
         if np.any(np.array(self.Q) < 1):
             raise ValueError('Q should always be >= 1, got {}'.format(self.Q))
-        elif not isinstance(self.Q, (int, tuple)):
-            raise ValueError("Q must be an integer or a tuple")
 
         if isinstance(self.Q, int):
             self.Q = (self.Q, 1)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -37,12 +37,20 @@ class ScatteringBase1D(ScatteringBase):
         self.alpha = 5.
 
         # check the number of filters per octave
-        if self.Q < 1:
+        if np.any(np.array(self.Q) < 1):
             raise ValueError('Q should always be >= 1, got {}'.format(self.Q))
+        elif not isinstance(self.Q, (int, tuple)):
+            raise ValueError("Q must be an integer or a tuple")
 
-        # check the number of filters per octave
-        if self.Q < 1:
-            raise ValueError('Q should always be >= 1, got {}'.format(self.Q))
+        if isinstance(self.Q, int):
+            self.Q = (self.Q, 1)
+        elif isinstance(self.Q, tuple): 
+            if len(self.Q) == 1:
+                self.Q = self.Q + (1, )
+            elif len(self.Q) < 1 or len(self.Q) > 2: 
+                raise NotImplementedError("Q should be an integer, 1-tuple or "
+                                          "2-tuple. Scattering transforms " 
+                                          "beyond order 2 are not implemented.")
 
         # check the shape
         if isinstance(self.shape, numbers.Integral):
@@ -290,9 +298,12 @@ class ScatteringBase1D(ScatteringBase):
         J : int
             The maximum log-scale of the scattering transform. In other words,
             the maximum scale is given by :math:`2^J`.
-        {param_shape}Q : int >= 1
-            The number of first-order wavelets per octave (second-order
-            wavelets are fixed to one wavelet per octave). Defaults to `1`.
+        {param_shape}Q : int or tuple
+            By default, Q (int) is the number of wavelets per octave for the first
+            order and that for the second order has one wavelet per octave. This 
+            default value can be modified by passing Q as a tuple with two values,
+            i.e. Q = (Q1, Q2), where Q1 and Q2 are the number of wavelets per 
+            octave for the first and second order, respectively.
         T : int
             temporal support of low-pass filter, controlling amount of imposed
             time-shift invariance and maximum subsampling

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -46,9 +46,9 @@ class ScatteringBase1D(ScatteringBase):
             if len(self.Q) == 1:
                 self.Q = self.Q + (1, )
             elif len(self.Q) < 1 or len(self.Q) > 2: 
-                raise NotImplementedError("Q should be a 1-tuple or 2-tuple. "
-                                          "Scattering transforms beyond "
-                                          "order 2 are not implemented.")
+                raise NotImplementedError("Q should be an integer, 1-tuple or "
+                                          "2-tuple. Scattering transforms "
+                                          "beyond order 2 are not implemented.")
         else:
             raise ValueError("Q must be an integer or a tuple")
 

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -82,9 +82,9 @@ def precompute_size_scattering(J, Q, T, max_order, r_psi, sigma0, alpha):
     J : int
         The maximum log-scale of the scattering transform.
         In other words, the maximum scale is given by `2**J`.
-    Q : int >= 1
-        The number of first-order wavelets per octave.
-        Second-order wavelets are fixed to one wavelet per octave.
+    Q : tuple
+        number of wavelets per octave at the first and second order 
+        Q = (Q1, Q2). Q1 and Q2 are both int >= 1.
     T : int
         temporal support of low-pass filter, controlling amount of imposed
         time-shift invariance and maximum subsampling
@@ -110,8 +110,9 @@ def precompute_size_scattering(J, Q, T, max_order, r_psi, sigma0, alpha):
         orders zero up to `max_order`, both included.
     """
     sigma_min = sigma0 / math.pow(2, J)
-    xi1s, sigma1s, j1s = compute_params_filterbank(sigma_min, Q, alpha, r_psi)
-    xi2s, sigma2s, j2s = compute_params_filterbank(sigma_min, 1, alpha, r_psi)
+    Q1, Q2 = Q
+    xi1s, sigma1s, j1s = compute_params_filterbank(sigma_min, Q1, alpha, r_psi)
+    xi2s, sigma2s, j2s = compute_params_filterbank(sigma_min, Q2, alpha, r_psi)
 
     sizes = [1, len(xi1s)]
     size_order2 = 0
@@ -136,9 +137,9 @@ def compute_meta_scattering(J, Q, T, max_order, r_psi, sigma0, alpha):
     J : int
         The maximum log-scale of the scattering transform.
         In other words, the maximum scale is given by `2**J`.
-    Q : int >= 1
-        The number of first-order wavelets per octave.
-        Second-order wavelets are fixed to one wavelet per octave.
+    Q : tuple
+        number of wavelets per octave at the first and second order 
+        Q = (Q1, Q2). Q1 and Q2 are both int >= 1.
     T : int
         temporal support of low-pass filter, controlling amount of imposed
         time-shift invariance and maximum subsampling
@@ -182,8 +183,9 @@ def compute_meta_scattering(J, Q, T, max_order, r_psi, sigma0, alpha):
             in the non-vectorized output.
     """
     sigma_min = sigma0 / math.pow(2, J)
-    xi1s, sigma1s, j1s = compute_params_filterbank(sigma_min, Q, alpha, r_psi)
-    xi2s, sigma2s, j2s = compute_params_filterbank(sigma_min, 1, alpha, r_psi)
+    Q1, Q2 = Q
+    xi1s, sigma1s, j1s = compute_params_filterbank(sigma_min, Q1, alpha, r_psi)
+    xi2s, sigma2s, j2s = compute_params_filterbank(sigma_min, Q2, alpha, r_psi)
 
     meta = {}
 

--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -16,8 +16,8 @@ def test_Scattering1D():
       buffer = io.BytesIO(f.read())
       data = np.load(buffer)
   x = data['x']
-  J = data['J']
-  Q = data['Q']
+  J = int(data['J'])
+  Q = int(data['Q'])
   Sx0 = data['Sx']
   # default
   inputs0 = Input(shape=(x.shape[-1]))
@@ -40,3 +40,38 @@ def test_Scattering1D():
   Sg1 = model1.predict(x)
   assert Sg1.shape == (Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**(sigma_low_scale_factor))
   
+  def test_Q():
+    J = 3
+    length = 1024
+    inputs = Input(shape=(length,))
+
+    # test different cases for Q
+    with pytest.raises(ValueError) as ve:
+        _ = Scattering1D(J=J, Q=0.9)(inputs)
+    assert "Q should always be >= 1" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        _ = Scattering1D(J=J, Q=[8])(inputs)
+    assert "Q must be an integer or a tuple" in ve.value.args[0]
+
+    Sc_int = Scattering1D(J=J, Q=(8, ))(inputs)
+    Sc_tuple = Scattering1D(J=J, Q=(8, 1))(inputs)
+
+    assert Sc_int.shape[1] == Sc_tuple.shape[1]
+
+    # test dummy input
+    x = np.zeros(length)
+    model0 = Model(inputs, Sc_int)
+    model0.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    Sc_int_out = model0.predict(x)
+
+    model1 = Model(inputs, Sc_tuple)
+    model1.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    Sc_tuple_out = model1.predict(x)
+
+    assert np.allclose(Sc_int_out, Sc_tuple_out)
+    assert Sc_int_out.shape == (Sc_tuple_out.shape[0], Sc_tuple_out.shape[1], Sc_tuple_out.shape[2])

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -23,8 +23,8 @@ class TestScattering1DNumpy:
             buffer = io.BytesIO(f.read())
             data = np.load(buffer)
         x = data['x']
-        J = data['J']
-        Q = data['Q']
+        J = int(data['J'])
+        Q = int(data['Q'])
         Sx0 = data['Sx']
         N = x.shape[-1]
         scattering = Scattering1D(J, N, Q, backend=backend, frontend='numpy')
@@ -41,8 +41,8 @@ class TestScattering1DNumpy:
             buffer = io.BytesIO(f.read())
             data = np.load(buffer)
         x = data['x']
-        J = data['J']
-        Q = data['Q']
+        J = int(data['J'])
+        Q = int(data['Q'])
         Sx0 = data['Sx']
         N = x.shape[-1]
         # default
@@ -84,7 +84,7 @@ class TestScattering1DNumpy:
         temporal extent of the low-pass sigma_log filter
         """
         N = 2**13
-        Q = 1
+        Q = (1, 1)
         sigma_low_scale_factor = [0, 5]
         Js = [5]
 
@@ -98,3 +98,34 @@ class TestScattering1DNumpy:
                     default_str = ''
                 phi_f, psi1_f, psi2_f = scattering_filter_factory(np.log2(N), J, Q, T)
                 assert(phi_f['sigma']==0.1/T)
+
+frontends = ['numpy', 'sklearn']
+@pytest.mark.parametrize("backend", backends)
+@pytest.mark.parametrize("frontend", frontends)
+
+def test_Q(backend, frontend):
+    J = 3
+    length = 1024
+    shape = (length,)
+
+    # test different cases for Q
+    with pytest.raises(ValueError) as ve:
+        _ = Scattering1D(J, shape, Q=0.9, backend=backend, frontend=frontend)
+    assert "Q should always be >= 1" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        _ = Scattering1D(J, shape, Q=[8], backend=backend, frontend=frontend)
+    assert "Q must be an integer or a tuple" in ve.value.args[0] 
+
+    Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend=frontend)
+    Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend=frontend)
+
+    assert Sc_int.Q == Sc_tuple.Q
+
+    # test dummy input
+    x = np.zeros(length)
+    Sc_int_out = Sc_int.scattering(x)
+    Sc_tuple_out = Sc_tuple.scattering(x)
+
+    assert np.allclose(Sc_int_out, Sc_tuple_out)
+    assert Sc_int_out.shape == Sc_tuple_out.shape

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -92,8 +92,8 @@ def test_sample_scattering(device, backend):
 
 
     x = torch.from_numpy(data['x']).to(device)
-    J = data['J']
-    Q = data['Q']
+    J = int(data['J'])
+    Q = int(data['Q'])
     Sx0 = torch.from_numpy(data['Sx']).to(device)
 
     T = x.shape[-1]
@@ -399,8 +399,8 @@ def test_T(device, backend):
 
 
     x = torch.from_numpy(data['x']).to(device)
-    J = data['J']
-    Q = data['Q']
+    J = int(data['J'])
+    Q = int(data['Q'])
     Sx0 = torch.from_numpy(data['Sx']).to(device)
 
     # default
@@ -434,7 +434,26 @@ def test_Q(device, backend):
     length = 1024
     shape = (length,)
 
+    # test different cases for Q
     with pytest.raises(ValueError) as ve:
         _ = Scattering1D(
-            J, shape, Q=0.9, backend=backend, frontend='torch').to(device)
+            J, shape, Q=0.9, backend=backend, frontend='torch')
     assert "Q should always be >= 1" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        _ = Scattering1D(
+            J, shape, Q=[8], backend=backend, frontend='torch')
+    assert "Q must be an integer or a tuple" in ve.value.args[0]
+
+    Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch')
+    Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend='torch')
+
+    assert Sc_int.Q == Sc_tuple.Q
+
+    # test dummy input
+    x = torch.zeros(shape)
+    Sc_int_out = Sc_int(x)
+    Sc_tuple_out = Sc_tuple(x)
+
+    assert torch.allclose(Sc_int_out, Sc_tuple_out)
+    assert Sc_int_out.shape == Sc_tuple_out.shape

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -445,13 +445,19 @@ def test_Q(device, backend):
             J, shape, Q=[8], backend=backend, frontend='torch')
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
-    Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch')
-    Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend='torch')
+    if backend.name.endswith('_skcuda') and device == 'cpu':
+        with pytest.raises(TypeError) as ve:
+            Sx = S(x)
+        assert "CUDA" in ve.value.args[0]
+        return
+
+    Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch').to(device)
+    Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend='torch').to(device)
 
     assert Sc_int.Q == Sc_tuple.Q
 
     # test dummy input
-    x = torch.zeros(shape)
+    x = torch.zeros(shape).to(device)
     Sc_int_out = Sc_int(x)
     Sc_tuple_out = Sc_tuple(x)
 

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -445,13 +445,13 @@ def test_Q(device, backend):
             J, shape, Q=[8], backend=backend, frontend='torch')
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
-    Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch').to(device)
-    Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend='torch').to(device)
+    Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch')
+    Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend='torch')
 
     assert Sc_int.Q == Sc_tuple.Q
 
     # test dummy input
-    x = torch.zeros(shape).to(device)
+    x = torch.zeros(shape)
     Sc_int_out = Sc_int(x)
     Sc_tuple_out = Sc_tuple(x)
 

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -445,13 +445,13 @@ def test_Q(device, backend):
             J, shape, Q=[8], backend=backend, frontend='torch')
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
-    Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch')
-    Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend='torch')
+    Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch').to(device)
+    Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend='torch').to(device)
 
     assert Sc_int.Q == Sc_tuple.Q
 
     # test dummy input
-    x = torch.zeros(shape)
+    x = torch.zeros(shape).to(device)
     Sc_int_out = Sc_int(x)
     Sc_tuple_out = Sc_tuple(x)
 

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -445,11 +445,6 @@ def test_Q(device, backend):
             J, shape, Q=[8], backend=backend, frontend='torch')
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
-    if backend.name.endswith('_skcuda') and device == 'cpu':
-        with pytest.raises(TypeError) as ve:
-            Sx = S(x)
-        assert "CUDA" in ve.value.args[0]
-        return
 
     Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch').to(device)
     Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend='torch').to(device)
@@ -458,6 +453,14 @@ def test_Q(device, backend):
 
     # test dummy input
     x = torch.zeros(shape).to(device)
+
+    if backend.name.endswith('_skcuda') and device == 'cpu':
+        for scattering in (Sc_int, Sc_tuple):
+            with pytest.raises(TypeError) as ve:
+                _ = scattering(x)
+            assert "CUDA" in ve.value.args[0]
+        return
+
     Sc_int_out = Sc_int(x)
     Sc_tuple_out = Sc_tuple(x)
 


### PR DESCRIPTION
Fix https://github.com/kymatio/kymatio/issues/853

This PR makes it flexible for users to specify the number of wavelets per octave at the first and second order scattering. Both cases are working:

- Set `Q` as an integer: `Q = Q1`. In this case, we use `Q1` wavelets per octave at the first order and that for the second order defaults to one. 
- Set `Q` as a tuple: `Q = (Q1, Q2)`, where users can specify both `Q1` and `Q2` according to their needs.