### PR TITLE
Remove vectorize + write frontend-agnostic runtime checks

### DIFF
--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,7 +1,7 @@
 
 def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
         pad_right=0, ind_start=None, ind_end=None, oversampling=0,
-        max_order=2, average=True, vectorize=False, out_type='array'):
+        max_order=2, average=True, out_type='array'):
     """
     Main function implementing the 1-D scattering transform.
 
@@ -42,12 +42,10 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
         how much to oversample the scattering (with respect to :math:`2^J`):
         the higher, the larger the resulting scattering
         tensor along time. Defaults to `0`
-    order2 : boolean, optional
-        Whether to compute the 2nd order or not. Defaults to `False`.
+    max_order : int, optional
+        Number of orders in the scattering transform. Either 1 or 2 (default).
     average : boolean, optional
         whether to average the first order vector. Defaults to `True`
-    vectorize : boolean, optional
-        whether to return a dictionary or a tensor. Defaults to False.
     """
     cdgmm = backend.cdgmm
     concatenate = backend.concatenate
@@ -160,9 +158,9 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
     out_S.extend(out_S_1)
     out_S.extend(out_S_2)
 
-    if out_type == 'array' and vectorize:
+    if out_type == 'array':
         out_S = concatenate([x['coef'] for x in out_S])
-    elif out_type == 'array' and not vectorize:
+    elif out_type == 'dict':
         out_S = {x['n']: x['coef'] for x in out_S}
     elif out_type == 'list':
         # NOTE: This overrides the vectorize flag.

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,5 +1,5 @@
 
-def scattering1d(x, pad, unpad, backend, log2_T, psi1, psi2, phi, pad_left=0,
+def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
         pad_right=0, ind_start=None, ind_end=None, oversampling=0,
         max_order=2, average=True, vectorize=False, out_type='array'):
     """
@@ -28,9 +28,6 @@ def scattering1d(x, pad, unpad, backend, log2_T, psi1, psi2, phi, pad_left=0,
         The array `phi[j]` is a real-valued filter.
     J : int
         scale of the scattering
-    log2_T : int
-        (log2 of) temporal support of low-pass filter, controlling amount of
-        imposed time-shift invariance and maximum subsampling
     pad_left : int, optional
         how much to pad the signal on the left. Defaults to `0`
     pad_right : int, optional
@@ -47,24 +44,22 @@ def scattering1d(x, pad, unpad, backend, log2_T, psi1, psi2, phi, pad_left=0,
         tensor along time. Defaults to `0`
     order2 : boolean, optional
         Whether to compute the 2nd order or not. Defaults to `False`.
-    average_U1 : boolean, optional
+    average : boolean, optional
         whether to average the first order vector. Defaults to `True`
     vectorize : boolean, optional
         whether to return a dictionary or a tensor. Defaults to False.
     """
-    subsample_fourier = backend.subsample_fourier
-    modulus = backend.modulus
-    rfft = backend.rfft
-    ifft = backend.ifft
-    irfft = backend.irfft
     cdgmm = backend.cdgmm
     concatenate = backend.concatenate
-
+    ifft = backend.ifft
+    irfft = backend.irfft
+    modulus = backend.modulus
+    rfft = backend.rfft
+    pad = backend.pad
+    subsample_fourier = backend.subsample_fourier
+    unpad = backend.unpad
 
     # S is simply a dictionary if we do not perform the averaging...
-    batch_size = x.shape[0]
-    klog2_T = max(log2_T - oversampling, 0)
-    temporal_size = ind_end[klog2_T] - ind_start[klog2_T]
     out_S_0, out_S_1, out_S_2 = [], [], []
 
     # pad to a dyadic size and make it complex
@@ -73,6 +68,7 @@ def scattering1d(x, pad, unpad, backend, log2_T, psi1, psi2, phi, pad_left=0,
     U_0_hat = rfft(U_0)
 
     # Get S0
+    log2_T = phi["j"]
     k0 = max(log2_T - oversampling, 0)
 
     if average:

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend=None):
+            oversampling=0, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -20,7 +20,6 @@ class ScatteringBase1D(ScatteringBase):
         self.max_order = max_order
         self.average = average
         self.oversampling = oversampling
-        self.vectorize = vectorize
         self.out_type = out_type
         self.backend = backend
 
@@ -116,6 +115,21 @@ class ScatteringBase1D(ScatteringBase):
         """
         return precompute_size_scattering(self.J, self.Q, self.T,
             self.max_order, self.r_psi, self.sigma0, self.alpha, detail=detail)
+
+    def _check_runtime_args(self):
+        if not self.out_type in ('array', 'dict', 'list'):
+            raise RuntimeError("The out_type must be one of 'array', 'dict', or 'list'.")
+
+        if not self.average and self.out_type == 'array':
+            raise ValueError("Cannot convert to out_type='array' with "
+                             "average=False. Please set out_type to 'dict' or 'list'.")
+
+    def _check_input(self, x):
+        # basic checking, should be improved
+        if len(x.shape) < 1:
+            raise ValueError(
+                'Input tensor x should have at least one axis, got {}'.format(
+                    len(x.shape)))
 
     _doc_shape = 'N'
 

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -9,8 +9,8 @@ from tensorflow.python.framework import tensor_shape
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, T=None, max_order=2, oversampling=0):
         ScatteringKeras.__init__(self)
-        ScatteringBase1D.__init__(self, J, None, Q, T, max_order, True,
-                oversampling, True, 'array', None)
+        ScatteringBase1D.__init__(self, J, shape=None, Q=Q, T=T, max_order=max_order,
+                average=True, oversampling=oversampling, out_type='array', backend=None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -10,7 +10,7 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
             oversampling=0, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -41,7 +41,7 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
 
         x = x.reshape((-1, 1) + signal_shape)
 
-        S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.log2_T, self.psi1_f, self.psi2_f,
+        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -7,7 +7,7 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='numpy'):
+            oversampling=0, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
                 oversampling, vectorize, out_type, backend)
@@ -16,25 +16,8 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         ScatteringBase1D.create_filters(self)
 
     def scattering(self, x):
-        # basic checking, should be improved
-        if len(x.shape) < 1:
-            raise ValueError(
-                'Input tensor x should have at least one axis, got {}'.format(
-                    len(x.shape)))
-
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
+        ScatteringBase1D._check_runtime_args(self)
+        ScatteringBase1D._check_input(self, x)
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
@@ -44,14 +27,14 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
-                         oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                         oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
 
             S = S.reshape(new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -12,7 +12,7 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
                  name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -44,7 +44,7 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
 
         x = tf.reshape(x, tf.concat(((-1, 1), signal_shape), 0))
 
-        S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.log2_T, self.psi1_f, self.psi2_f,
+        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -8,7 +8,7 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='tensorflow',
+            oversampling=0, out_type='array', backend='tensorflow',
                  name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
@@ -18,27 +18,8 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         ScatteringBase1D.create_filters(self)
 
     def scattering(self, x):
-        # basic checking, should be improved
-        if len(x.shape) < 1:
-            raise ValueError(
-                'Input tensor x should have at least one axis, got {}'.format(
-                    len(x.shape)))
-
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
-
+        ScatteringBase1D._check_runtime_args(self)
+        ScatteringBase1D._check_input(self, x)
         batch_shape = tf.shape(x)[:-1]
         signal_shape = tf.shape(x)[-1:]
 
@@ -47,14 +28,14 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
-                         oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                         oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = tf.shape(S)[-2:]
             new_shape = tf.concat((batch_shape, scattering_shape), 0)
 
             S = tf.reshape(S, new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -98,7 +98,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
 
         self.load_filters()
 
-        S = scattering1d(x, self.backend.pad, self.backend.unpad, self.backend, self.log2_T, self.psi1_f, self.psi2_f, self.phi_f,\
+        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
                          max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
                         ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
 

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -8,7 +8,7 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='torch'):
+            oversampling=0, out_type='array', backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
                 oversampling, vectorize, out_type, backend)
@@ -25,7 +25,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         # prepare for pytorch
         for k in self.phi_f.keys():
             if type(k) != str:
-                # view(-1, 1).repeat(1, 2) because real numbers!
                 self.phi_f[k] = torch.from_numpy(
                     self.phi_f[k]).float().view(-1, 1)
                 self.register_buffer('tensor' + str(n), self.phi_f[k])
@@ -33,7 +32,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         for psi_f in self.psi1_f:
             for sub_k in psi_f.keys():
                 if type(sub_k) != str:
-                    # view(-1, 1).repeat(1, 2) because real numbers!
                     psi_f[sub_k] = torch.from_numpy(
                         psi_f[sub_k]).float().view(-1, 1)
                     self.register_buffer('tensor' + str(n), psi_f[sub_k])
@@ -41,7 +39,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         for psi_f in self.psi2_f:
             for sub_k in psi_f.keys():
                 if type(sub_k) != str:
-                    # view(-1, 1).repeat(1, 2) because real numbers!
                     psi_f[sub_k] = torch.from_numpy(
                         psi_f[sub_k]).float().view(-1, 1)
                     self.register_buffer('tensor' + str(n), psi_f[sub_k])
@@ -70,26 +67,8 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                     n += 1
 
     def scattering(self, x):
-        # basic checking, should be improved
-        if len(x.shape) < 1:
-            raise ValueError(
-                'Input tensor x should have at least one axis, got {}'.format(
-                    len(x.shape)))
-
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
+        ScatteringBase1D._check_runtime_args(self)
+        ScatteringBase1D._check_input(self, x)
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
@@ -100,13 +79,13 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
                          max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
-                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
             S = S.reshape(new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -11,7 +11,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
             oversampling=0, out_type='array', backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)


### PR DESCRIPTION
Fix #843 
(a second attempt after some productive discussions during review of #844)

This is a planned change for v0.3

The default behavior is still `out_type="array"` (`vectorize=True`)
We introduce `out_type="dict"` to replicate the behavior of `out_type="array", vectorize=False`

A net reduction in code size thanks to utility methods `_check_runtime_args()` and `_check_input()` in `ScatteringBase1D`

Written on top of #860. I suggest we look at #860 first
Tests pass locally


Note that vectorize is still documented in the base frontend. I'll take care of updating these docs after code review.