### PR TITLE
MAINT Speed up `test_gradients`

### DIFF
--- a/tests/scattering2d/test_torch_scattering2d.py
+++ b/tests/scattering2d/test_torch_scattering2d.py
@@ -245,4 +245,4 @@ class TestScatteringTorch2D:
             scattering = Scattering2D(2, shape=(8, 8), backend=backend,
                                       frontend='torch').double().to(device)
             x = torch.rand(2, 1, 8, 8).double().to(device).requires_grad_()
-            gradcheck(scattering, x, nondet_tol=1e-5)
+            gradcheck(scattering, x, nondet_tol=1e-5, fast_mode=True)


### PR DESCRIPTION
This pull request speeds up `test_gradients` by enabling `fast_mode`. Previously it took 109 seconds to run, now it takes 17 seconds. 

> fast_mode ([bool](https://docs.python.org/3/library/functions.html#bool), optional) – Fast mode for gradcheck and gradgradcheck is currently only implemented for R to R functions. If none of the inputs and outputs are complex a faster implementation of gradcheck that no longer computes the entire jacobian is run; otherwise, we fall back to the slow implementation.

Note that since our scattering takes in as input a real valued signal, and outputs a real valued signal, torch allows us to enable `fast_mode` to avoid computing additional entries of a jacobian. 


[See more here.](https://pytorch.org/docs/master/generated/torch.autograd.gradcheck.html#torch.autograd.gradcheck)

This PR resolves issue #872