### PR TITLE
DOC Enable `.to(device)` semantics for pytorch examples

### DIFF
--- a/examples/1d/reconstruct_torch.py
+++ b/examples/1d/reconstruct_torch.py
@@ -59,16 +59,16 @@ def generate_harmonic_signal(T, num_intervals=4, gamma=0.9, random_state=42):
 # Let’s take a look at what such a signal could look like.
 
 T = 2 ** 13
-x = torch.from_numpy(generate_harmonic_signal(T)).to(device)
+x = torch.from_numpy(generate_harmonic_signal(T))
 plt.figure(figsize=(8, 2))
-plt.plot(x.cpu().numpy())
+plt.plot(x.numpy())
 plt.title("Original signal")
 
 ###############################################################################
 # Let’s take a look at the signal spectrogram.
 
 plt.figure(figsize=(8, 8))
-plt.specgram(x.cpu().numpy(), Fs=1024)
+plt.specgram(x.numpy(), Fs=1024)
 plt.title("Spectrogram of original signal")
 
 ###############################################################################
@@ -78,6 +78,7 @@ J = 6
 Q = 16
 
 scattering = Scattering1D(J, T, Q).to(device)
+x = x.to(device)
 
 Sx = scattering(x)
 

--- a/examples/2d/cifar_resnet_torch.py
+++ b/examples/2d/cifar_resnet_torch.py
@@ -158,8 +158,7 @@ if __name__ == '__main__':
     else:
         scattering = Scattering2D(J=2, shape=(32, 32))
         K = 81*3
-    if use_cuda:
-        scattering = scattering.cuda()
+    scattering = scattering.to(device)
 
 
 
@@ -167,11 +166,10 @@ if __name__ == '__main__':
     model = Scattering2dResNet(K, args.width).to(device)
 
     # DataLoaders
+    num_workers = 4
     if use_cuda:
-        num_workers = 4
         pin_memory = True
     else:
-        num_workers = None
         pin_memory = False
 
     normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],

--- a/examples/2d/cifar_small_sample.py
+++ b/examples/2d/cifar_small_sample.py
@@ -180,19 +180,17 @@ def main():
         scattering = Scattering2D(J=2, shape=(32, 32))
         K = 81*3
         model = Scattering2dResNet(K, args.width).to(device)
-        if use_cuda:
-            scattering = scattering.cuda()
+        scattering = scattering.to(device)
     else:
         model = Scattering2dResNet(8, args.width,standard=True).to(device)
         scattering = Identity()
 
 
     # DataLoaders
+    num_workers = 4
     if use_cuda:
-        num_workers = 4
         pin_memory = True
     else:
-        num_workers = 0
         pin_memory = False
 
     normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],

--- a/examples/2d/cifar_torch.py
+++ b/examples/2d/cifar_torch.py
@@ -130,8 +130,7 @@ if __name__ == '__main__':
     else:
         scattering = Scattering2D(J=2, shape=(32, 32))
         K = 81*3
-    if use_cuda:
-        scattering = scattering.cuda()
+    scattering = scattering.to(device)
 
 
 
@@ -139,11 +138,10 @@ if __name__ == '__main__':
     model = Scattering2dCNN(K,args.classifier).to(device)
 
     # DataLoaders
+    num_workers = 4
     if use_cuda:
-        num_workers = 4
         pin_memory = True
     else:
-        num_workers = None
         pin_memory = False
 
     normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],

--- a/examples/2d/long_mnist_classify_torch.py
+++ b/examples/2d/long_mnist_classify_torch.py
@@ -27,11 +27,10 @@ prng = RandomState(42)
 from torchvision import datasets, transforms
 import kymatio.datasets as scattering_datasets
 
+num_workers = 4
 if use_cuda:
-    num_workers = 4
     pin_memory = True
 else:
-    num_workers = 0
     pin_memory = False
 
 train_data = datasets.MNIST(
@@ -107,11 +106,9 @@ import math
 
 
 # Evaluate linear model on top of scattering
-scattering = Scattering2D(shape = (28, 28), J=2)
+scattering = Scattering2D(shape = (28, 28), J=2).to(device)
 K = 81 #Number of output coefficients for each spatial postiion
 
-if use_cuda:
-    scattering = scattering.cuda()
 
 model = nn.Sequential(
     View(K, 7, 7),

--- a/examples/3d/scattering3d_qm7_torch.py
+++ b/examples/3d/scattering3d_qm7_torch.py
@@ -136,12 +136,8 @@ scattering = HarmonicScattering3D(J=J, shape=(M, N, O),
 ###############################################################################
 # We then check whether a GPU is available, in which case we transfer our
 # scattering object there.
-
-if torch.cuda.is_available():
-    device = 'cuda'
-else:
-    device = 'cpu'
-
+use_cuda = torch.cuda.is_available()
+device = torch.device("cuda" if use_cuda else "cpu")
 scattering.to(device)
 
 ###############################################################################
@@ -164,7 +160,7 @@ n_batches = int(np.ceil(n_molecules / batch_size))
 order_0, orders_1_and_2 = [], []
 print('Computing solid harmonic scattering coefficients of '
       '{} molecules from the QM7 database on {}'.format(
-        n_molecules, {'cuda': 'GPU', 'cpu': 'CPU'}[device]))
+        n_molecules,   "GPU" if use_cuda else "CPU"))
 print('sigma: {}, L: {}, J: {}, integral powers: {}'.format(
         sigma, L, J, integral_powers))
 


### PR DESCRIPTION
This PR enables `to(device)` semantics for the pytorch examples. 

This resolves issue #824 . 