### PR TITLE
move core 1D asserts to `_check_filterbanks` in `ScatteringBase`

### DIFF
--- a/kymatio/frontend/base_frontend.py
+++ b/kymatio/frontend/base_frontend.py
@@ -1,4 +1,5 @@
 import importlib
+import itertools
 
 
 class ScatteringBase():
@@ -12,6 +13,17 @@ class ScatteringBase():
         self.create_filters() defined below. For instance, via:
         self.filters = self.create_filters() """
         raise NotImplementedError
+
+    def _check_filterbanks(psi1s, psi2s):
+        # Check that the Nyquist frequency of each filter, 2**(-j), is at least
+        # one octave above its frequency xi
+        assert all((psi1["xi"] < 0.5/(2**psi1["j"])) for psi1 in psi1s)
+
+        # Check that (j1 < j2) implies (xi1 > xi2)
+        psi_generator = itertools.product(psi1s, psi2s)
+        condition = lambda psi1_or_2: psi1_or_2[0]['j'] < psi1_or_2[1]['j']
+        implication = lambda psi1_or_2: psi1_or_2[0]['xi'] > psi1_or_2[1]['xi']
+        assert all(map(implication, filter(condition, psi_generator)))
 
     def _instantiate_backend(self, import_string):
         """ This function should instantiate the backend to be used if not already

--- a/kymatio/frontend/base_frontend.py
+++ b/kymatio/frontend/base_frontend.py
@@ -15,11 +15,15 @@ class ScatteringBase():
         raise NotImplementedError
 
     def _check_filterbanks(psi1s, psi2s):
-        # Check that the Nyquist frequency of each filter, 2**(-j), is at least
+        # Check for absence of aliasing at the first order
+        # that the Nyquist frequency of each filter, 2**(-j), is at least
         # one octave above its frequency xi
         assert all((psi1["xi"] < 0.5/(2**psi1["j"])) for psi1 in psi1s)
 
-        # Check that (j1 < j2) implies (xi1 > xi2)
+        # Check for absence of aliasing at the second order
+        # The filter function selects the (psi1, psi2) pairs such that j1<j2.
+        # The map function evaluates whether those pairs also satisfy xi1>xi2.
+        # Hence, the "assert all" statement guarantees that (j1<j2) => (xi1>xi2)
         psi_generator = itertools.product(psi1s, psi2s)
         condition = lambda psi1_or_2: psi1_or_2[0]['j'] < psi1_or_2[1]['j']
         implication = lambda psi1_or_2: psi1_or_2[0]['xi'] > psi1_or_2[1]['xi']

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -89,7 +89,6 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
         sub1_adj = min(j1, log2_T) if average else j1
         k1 = max(sub1_adj - oversampling, 0)
 
-        assert psi1[n1]['xi'] < 0.5 / (2**k1)
         U_1_c = cdgmm(U_0_hat, psi1[n1][0])
         U_1_hat = subsample_fourier(U_1_c, 2**k1)
         U_1_c = ifft(U_1_hat)
@@ -121,8 +120,6 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
                 j2 = psi2[n2]['j']
 
                 if j2 > j1:
-                    assert psi2[n2]['xi'] < psi1[n1]['xi']
-
                     # convolution + downsampling
                     sub2_adj = min(j2, log2_T) if average else j2
                     k2 = max(sub2_adj - k1 - oversampling, 0)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -81,6 +81,7 @@ class ScatteringBase1D(ScatteringBase):
         self.phi_f, self.psi1_f, self.psi2_f = scattering_filter_factory(
             self.J_pad, self.J, self.Q, self.T,
             r_psi=self.r_psi, sigma0=self.sigma0, alpha=self.alpha)
+        ScatteringBase._check_filterbanks(self.psi1_f, self.psi2_f)
 
     def meta(self):
         """Get meta information on the transform


### PR DESCRIPTION
Fixes #869 by @MuawizChaudhary 

don't mind the title of the branch: `oversampling` is not becoming immutable.
also don't mind the title of the commit: `_check_filterbanks` belongs in `ScatteringBase`, not `ScatteringBase1D`