### PR TITLE
`core/scattering1d` now returns a generator

### DIFF
--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -89,5 +89,14 @@ class NumpyBackend:
         return A * B
 
     @staticmethod
-    def shape(cls, x):
+    def reshape_input(x, signal_shape, n_inserted_dims=0):
+        return x.reshape((-1,) + (1,)*n_inserted_dims + signal_shape)
+
+    @staticmethod
+    def reshape_output(S, batch_shape, n_kept_dims):
+        new_shape = batch_shape + S.shape[-n_kept_dims:]
+        return S.reshape(new_shape)
+
+    @staticmethod
+    def shape(x):
         return x.shape

--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -93,8 +93,8 @@ class NumpyBackend:
         return x.reshape((-1,) + (1,)*n_inserted_dims + signal_shape)
 
     @staticmethod
-    def reshape_output(S, batch_shape, n_inserted_dims, n_kept_dims):
-        new_shape = batch_shape + (1,)*n_inserted_dims + S.shape[-n_kept_dims:]
+    def reshape_output(S, batch_shape, n_kept_dims):
+        new_shape = batch_shape + S.shape[-n_kept_dims:]
         return S.reshape(new_shape)
 
     @staticmethod

--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -87,3 +87,7 @@ class NumpyBackend:
             raise TypeError('The second input must be complex or real.')
 
         return A * B
+
+    @staticmethod
+    def shape(cls, x):
+        return x.shape

--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -32,7 +32,7 @@ class NumpyBackend:
         return (x.dtype == cls._np.float32) or (x.dtype == cls._np.float64)
 
     @classmethod
-    def concatenate(cls, arrays):
+    def concatenate(cls, arrays, dim=1):
         return cls._np.stack(arrays, axis=1)
 
     @classmethod
@@ -93,8 +93,8 @@ class NumpyBackend:
         return x.reshape((-1,) + (1,)*n_inserted_dims + signal_shape)
 
     @staticmethod
-    def reshape_output(S, batch_shape, n_kept_dims):
-        new_shape = batch_shape + S.shape[-n_kept_dims:]
+    def reshape_output(S, batch_shape, n_inserted_dims, n_kept_dims):
+        new_shape = batch_shape + (1,)*n_inserted_dims + S.shape[-n_kept_dims:]
         return S.reshape(new_shape)
 
     @staticmethod

--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -98,5 +98,5 @@ class NumpyBackend:
         return S.reshape(new_shape)
 
     @staticmethod
-    def shape(x):
-        return x.shape
+    def shape(x, signal_dim):
+        return x.shape[:-signal_dim], x.shape[-signal_dim:]

--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -98,5 +98,5 @@ class NumpyBackend:
         return S.reshape(new_shape)
 
     @staticmethod
-    def shape(x, signal_dim):
-        return x.shape[:-signal_dim], x.shape[-signal_dim:]
+    def shape(x):
+        return x.shape

--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -33,7 +33,7 @@ class NumpyBackend:
 
     @classmethod
     def concatenate(cls, arrays, dim=1):
-        return cls._np.stack(arrays, axis=1)
+        return cls._np.stack(arrays, axis=dim)
 
     @classmethod
     def modulus(cls, x):

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -21,9 +21,9 @@ class TensorFlowBackend(NumpyBackend):
         return tf.reshape(x, new_shape)
 
     @staticmethod
-    def reshape_output(S, batch_shape, n_inserted_dims, n_kept_dims):
+    def reshape_output(S, batch_shape, n_kept_dims):
         new_shape = tf.concat(
-            (batch_shape, (1,)*n_inserted_dims, S.shape[-n_kept_dims:]), 0)
+            (batch_shape, S.shape[-n_kept_dims:]), 0)
         return tf.reshape(S, new_shape)
 
     @staticmethod

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -28,4 +28,4 @@ class TensorFlowBackend(NumpyBackend):
 
     @staticmethod
     def shape(x, signal_dim):
-        return tf.shape(x)[-signal_dim:], tf.shape(x)[:-signal_dim]
+        return tf.shape(x)[:-signal_dim], tf.shape(x)[-signal_dim:]

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -28,4 +28,4 @@ class TensorFlowBackend(NumpyBackend):
 
     @staticmethod
     def shape(x, signal_dim):
-        return tf.shape(x)[:-signal_dim], tf.shape(x)[-signal_dim:]
+        return tf.shape(x)[-signal_dim:], tf.shape(x)[:-signal_dim]

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -15,3 +15,6 @@ class TensorFlowBackend(NumpyBackend):
 
         return norm
 
+    @staticmethod
+    def shape(x):
+        return tf.shape(x)

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -27,5 +27,5 @@ class TensorFlowBackend(NumpyBackend):
         return tf.reshape(S, new_shape)
 
     @staticmethod
-    def shape(x):
-        return tf.shape(x)
+    def shape(x, signal_dim):
+        return tf.shape(x)[-signal_dim:], tf.shape(x)[:-signal_dim]

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -6,8 +6,8 @@ class TensorFlowBackend(NumpyBackend):
     name = 'tensorflow'
 
     @staticmethod
-    def concatenate(arrays):
-        return tf.stack(arrays, axis=1)
+    def concatenate(arrays, dim=1):
+        return tf.stack(arrays, axis=dim)
 
     @staticmethod
     def modulus(x):
@@ -21,8 +21,9 @@ class TensorFlowBackend(NumpyBackend):
         return tf.reshape(x, new_shape)
 
     @staticmethod
-    def reshape_output(S, batch_shape, n_kept_dims):
-        new_shape = tf.concat((batch_shape, S.shape[-n_kept_dims:]), 0)
+    def reshape_output(S, batch_shape, n_inserted_dims, n_kept_dims):
+        new_shape = tf.concat(
+            (batch_shape, (1,)*n_inserted_dims, S.shape[-n_kept_dims:]), 0)
         return tf.reshape(S, new_shape)
 
     @staticmethod

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -16,5 +16,15 @@ class TensorFlowBackend(NumpyBackend):
         return norm
 
     @staticmethod
+    def reshape_input(x, signal_shape, n_inserted_dims=0):
+        new_shape = tf.concat(((-1,) + (1,)*n_inserted_dims, signal_shape), 0)
+        return tf.reshape(x, new_shape)
+
+    @staticmethod
+    def reshape_output(S, batch_shape, n_kept_dims):
+        new_shape = tf.concat((batch_shape, S.shape[-n_kept_dims:]), 0)
+        return tf.reshape(S, new_shape)
+
+    @staticmethod
     def shape(x):
         return tf.shape(x)

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -27,5 +27,5 @@ class TensorFlowBackend(NumpyBackend):
         return tf.reshape(S, new_shape)
 
     @staticmethod
-    def shape(x, signal_dim):
-        return tf.shape(x)[-signal_dim:], tf.shape(x)[:-signal_dim]
+    def shape(x):
+        return tf.shape(x)

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -223,8 +223,8 @@ class TorchBackend:
         return x.reshape((-1,) + (1,)*n_inserted_dims + signal_shape)
 
     @staticmethod
-    def reshape_output(S, batch_shape, n_inserted_dims, n_kept_dims):
-        new_shape = batch_shape + (1,)*n_inserted_dims + S.shape[-n_kept_dims:]
+    def reshape_output(S, batch_shape, n_kept_dims):
+        new_shape = batch_shape + S.shape[-n_kept_dims:]
         return S.reshape(new_shape)
 
     @staticmethod

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -223,8 +223,8 @@ class TorchBackend:
         return x.reshape((-1,) + (1,)*n_inserted_dims + signal_shape)
 
     @staticmethod
-    def reshape_output(S, batch_shape, n_kept_dims):
-        new_shape = batch_shape + S.shape[-n_kept_dims:]
+    def reshape_output(S, batch_shape, n_inserted_dims, n_kept_dims):
+        new_shape = batch_shape + (1,)*n_inserted_dims + S.shape[-n_kept_dims:]
         return S.reshape(new_shape)
 
     @staticmethod

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -217,3 +217,7 @@ class TorchBackend:
             C[..., 1].view(-1, B.nelement() // 2)[:] = A_r * B_i + A_i * B_r
 
             return C
+
+    @staticmethod
+    def shape(cls, x):
+        return x.shape

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -219,5 +219,14 @@ class TorchBackend:
             return C
 
     @staticmethod
-    def shape(cls, x):
+    def reshape_input(x, signal_shape, n_inserted_dims=0):
+        return x.reshape((-1,) + (1,)*n_inserted_dims + signal_shape)
+
+    @staticmethod
+    def reshape_output(S, batch_shape, n_kept_dims):
+        new_shape = batch_shape + S.shape[-n_kept_dims:]
+        return S.reshape(new_shape)
+
+    @staticmethod
+    def shape(x):
         return x.shape

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -228,5 +228,5 @@ class TorchBackend:
         return S.reshape(new_shape)
 
     @staticmethod
-    def shape(x, signal_dim):
-        return x.shape[:-signal_dim], x.shape[-signal_dim:]
+    def shape(x):
+        return x.shape

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -228,5 +228,5 @@ class TorchBackend:
         return S.reshape(new_shape)
 
     @staticmethod
-    def shape(x):
-        return x.shape
+    def shape(x, signal_dim):
+        return x.shape[:-signal_dim], x.shape[-signal_dim:]

--- a/kymatio/frontend/numpy_frontend.py
+++ b/kymatio/frontend/numpy_frontend.py
@@ -4,10 +4,6 @@ class ScatteringNumPy:
     def __init__(self):
         self.frontend_name = 'numpy'
 
-    def scattering(self, x):
-        """ This function should compute the scattering transform."""
-        raise NotImplementedError
-
     def __call__(self, x):
         """This method is an alias for `scattering`."""
 

--- a/kymatio/frontend/tensorflow_frontend.py
+++ b/kymatio/frontend/tensorflow_frontend.py
@@ -5,10 +5,6 @@ class ScatteringTensorFlow(tf.Module):
         super(ScatteringTensorFlow, self).__init__(name=name)
         self.frontend_name = 'tensorflow'
 
-    def scattering(self, x):
-        """ This function should call the functional scattering."""
-        raise NotImplementedError
-
     @tf.Module.with_name_scope
     def __call__(self, x):
         """This method is an alias for `scattering`."""

--- a/kymatio/frontend/torch_frontend.py
+++ b/kymatio/frontend/torch_frontend.py
@@ -10,10 +10,6 @@ class ScatteringTorch(nn.Module):
         saving those arrays as module buffers. """
         raise NotImplementedError
 
-    def scattering(self, x):
-        """ This function should compute the scattering transform."""
-        raise NotImplementedError
-
     def forward(self, x):
         """This method is an alias for `scattering`."""
 

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,13 +1,12 @@
 
-def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
-        pad_right=0, ind_start=None, ind_end=None, oversampling=0,
-        max_order=2, average=True):
+def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
+        oversampling=0, max_order=2, average=True):
     """
     Main function implementing the 1-D scattering transform.
 
     Parameters
     ----------
-    x : Tensor
+    U_0 : Tensor
         a torch Tensor of size `(B, 1, N)` where `N` is the temporal size
     psi1 : dictionary
         a dictionary of filters (in the Fourier domain), with keys (`j`, `q`).
@@ -28,10 +27,6 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
         The array `phi[j]` is a real-valued filter.
     J : int
         scale of the scattering
-    pad_left : int, optional
-        how much to pad the signal on the left. Defaults to `0`
-    pad_right : int, optional
-        how much to pad the signal on the right. Defaults to `0`
     ind_start : dictionary of ints, optional
         indices to truncate the signal to recover only the
         parts which correspond to the actual signal after padding and
@@ -52,15 +47,12 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
     irfft = backend.irfft
     modulus = backend.modulus
     rfft = backend.rfft
-    pad = backend.pad
     subsample_fourier = backend.subsample_fourier
     unpad = backend.unpad
 
     # S is simply a dictionary if we do not perform the averaging...
     out_S_0, out_S_1, out_S_2 = [], [], []
 
-    # pad to a dyadic size and make it complex
-    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right)
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 
@@ -75,7 +67,7 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
 
         S_0 = unpad(S_0_r, ind_start[k0], ind_end[k0])
     else:
-        S_0 = x
+        S_0 = unpad(U_0, ind_start[0], ind_end[0])
     out_S_0.append({'coef': S_0,
                     'j': (),
                     'n': ()})

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -50,9 +50,6 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
     subsample_fourier = backend.subsample_fourier
     unpad = backend.unpad
 
-    # S is simply a dictionary if we do not perform the averaging...
-    out_S_0, out_S_1, out_S_2 = [], [], []
-
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 
@@ -65,12 +62,10 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
         S_0_hat = subsample_fourier(S_0_c, 2**k0)
         S_0_r = irfft(S_0_hat)
 
-        S_0 = unpad(S_0_r, ind_start[k0], ind_end[k0])
+        coef = unpad(S_0_r, ind_start[k0], ind_end[k0])
     else:
-        S_0 = unpad(U_0, ind_start[0], ind_end[0])
-    out_S_0.append({'coef': S_0,
-                    'j': (),
-                    'n': ()})
+        coef = unpad(U_0, ind_start[0], ind_end[0])
+    yield {'coef': coef, 'j': (), 'n': ()}
 
     # First order:
     for n1 in range(len(psi1)):
@@ -98,13 +93,11 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
             S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
             S_1_r = irfft(S_1_hat)
 
-            S_1 = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
+            coef = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
         else:
-            S_1 = unpad(U_1_m, ind_start[k1], ind_end[k1])
+            coef = unpad(U_1_m, ind_start[k1], ind_end[k1])
 
-        out_S_1.append({'coef': S_1,
-                        'j': (j1,),
-                        'n': (n1,)})
+        yield {'coef': coef, 'j': (j1,), 'n': (n1,)}
 
         if max_order == 2:
             # 2nd order
@@ -135,20 +128,11 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
                         S_2_hat = subsample_fourier(S_2_c, 2**k2_log2_T)
                         S_2_r = irfft(S_2_hat)
 
-                        S_2 = unpad(S_2_r, ind_start[k1 + k2 + k2_log2_T],
+                        coef = unpad(S_2_r, ind_start[k1 + k2 + k2_log2_T],
                                     ind_end[k1 + k2 + k2_log2_T])
                     else:
-                        S_2 = unpad(U_2_m, ind_start[k1 + k2], ind_end[k1 + k2])
+                        coef = unpad(U_2_m, ind_start[k1 + k2], ind_end[k1 + k2])
 
-                    out_S_2.append({'coef': S_2,
-                                    'j': (j1, j2),
-                                    'n': (n1, n2)})
-
-    out_S = []
-    out_S.extend(out_S_0)
-    out_S.extend(out_S_1)
-    out_S.extend(out_S_2)
-
-    return out_S
+                    yield {'coef': coef, 'j': (j1, j2), 'n': (n1, n2)}
 
 __all__ = ['scattering1d']

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,12 +1,15 @@
 
-def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average):
+def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average=True):
     """
     Main function implementing the 1-D scattering transform.
 
     Parameters
     ----------
     U_0 : Tensor
-        a torch Tensor of size `(B, 1, N)` where `N` is the temporal size
+        an backend-compatible array of size `(B, 1, N)` where `B` is batch size
+        and `N` is the padded signal length.
+    backend : module
+        Kymatio module which matches the type of U_0.
     psi1 : dictionary
         a dictionary of filters (in the Fourier domain), with keys (`j`, `q`).
         `j` corresponds to the downsampling factor for
@@ -31,7 +34,7 @@ def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average
     max_order : int, optional
         Number of orders in the scattering transform. Either 1 or 2.
     average : boolean, optional
-        whether to average the first order vector.
+        whether to average the result. Default to True.
     """
     cdgmm = backend.cdgmm
     ifft = backend.ifft

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,7 +1,7 @@
 
 def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
         pad_right=0, ind_start=None, ind_end=None, oversampling=0,
-        max_order=2, average=True, vectorize=False, out_type='array'):
+        max_order=2, average=True, out_type='array'):
     """
     Main function implementing the 1-D scattering transform.
 
@@ -42,12 +42,10 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
         how much to oversample the scattering (with respect to :math:`2^J`):
         the higher, the larger the resulting scattering
         tensor along time. Defaults to `0`
-    order2 : boolean, optional
-        Whether to compute the 2nd order or not. Defaults to `False`.
+    max_order : int, optional
+        Number of orders in the scattering transform. Either 1 or 2 (default).
     average : boolean, optional
         whether to average the first order vector. Defaults to `True`
-    vectorize : boolean, optional
-        whether to return a dictionary or a tensor. Defaults to False.
     """
     cdgmm = backend.cdgmm
     concatenate = backend.concatenate
@@ -160,9 +158,9 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
     out_S.extend(out_S_1)
     out_S.extend(out_S_2)
 
-    if out_type == 'array' and vectorize:
+    if out_type == 'array':
         out_S = concatenate([x['coef'] for x in out_S])
-    elif out_type == 'array' and not vectorize:
+    elif out_type == 'dict':
         out_S = {x['n']: x['coef'] for x in out_S}
     elif out_type == 'list':
         # NOTE: This overrides the vectorize flag.

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -61,11 +61,9 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
         S_0_c = cdgmm(U_0_hat, phi[0])
         S_0_hat = subsample_fourier(S_0_c, 2**k0)
         S_0_r = irfft(S_0_hat)
-
-        coef = unpad(S_0_r, ind_start[k0], ind_end[k0])
+        yield {'coef': S_0_r, 'j': (), 'n': ()}
     else:
-        coef = unpad(U_0, ind_start[0], ind_end[0])
-    yield {'coef': coef, 'j': (), 'n': ()}
+        yield {'coef': U_0, 'j': (), 'n': ()}
 
     # First order:
     for n1 in range(len(psi1)):
@@ -92,12 +90,9 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
             S_1_c = cdgmm(U_1_hat, phi[k1])
             S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
             S_1_r = irfft(S_1_hat)
-
-            coef = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
+            yield {'coef': S_1_r, 'j': (j1,), 'n': (n1,)}
         else:
-            coef = unpad(U_1_m, ind_start[k1], ind_end[k1])
-
-        yield {'coef': coef, 'j': (j1,), 'n': (n1,)}
+            yield {'coef': U_1_m, 'j': (j1,), 'n': (n1,)}
 
         if max_order == 2:
             # 2nd order
@@ -128,11 +123,8 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
                         S_2_hat = subsample_fourier(S_2_c, 2**k2_log2_T)
                         S_2_r = irfft(S_2_hat)
 
-                        coef = unpad(S_2_r, ind_start[k1 + k2 + k2_log2_T],
-                                    ind_end[k1 + k2 + k2_log2_T])
+                        yield {'coef': S_2_r, 'j': (j1, j2), 'n': (n1, n2)}
                     else:
-                        coef = unpad(U_2_m, ind_start[k1 + k2], ind_end[k1 + k2])
-
-                    yield {'coef': coef, 'j': (j1, j2), 'n': (n1, n2)}
+                        yield {'coef': U_2_m, 'j': (j1, j2), 'n': (n1, n2)}
 
 __all__ = ['scattering1d']

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,6 +1,5 @@
 
-def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
-        oversampling=0, max_order=2, average=True):
+def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average):
     """
     Main function implementing the 1-D scattering transform.
 
@@ -25,22 +24,14 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
         a dictionary of filters of scale :math:`2^J` with keys (`j`)
         where :math:`2^j` is the downsampling factor.
         The array `phi[j]` is a real-valued filter.
-    J : int
-        scale of the scattering
-    ind_start : dictionary of ints, optional
-        indices to truncate the signal to recover only the
-        parts which correspond to the actual signal after padding and
-        downsampling. Defaults to None
-    ind_end : dictionary of ints, optional
-        See description of ind_start
     oversampling : int, optional
         how much to oversample the scattering (with respect to :math:`2^J`):
         the higher, the larger the resulting scattering
-        tensor along time. Defaults to `0`
+        tensor along time.
     max_order : int, optional
-        Number of orders in the scattering transform. Either 1 or 2 (default).
+        Number of orders in the scattering transform. Either 1 or 2.
     average : boolean, optional
-        whether to average the first order vector. Defaults to `True`
+        whether to average the first order vector.
     """
     cdgmm = backend.cdgmm
     ifft = backend.ifft

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -10,27 +10,30 @@ def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average
         and `N` is the padded signal length.
     backend : module
         Kymatio module which matches the type of U_0.
-    psi1 : dictionary
-        a dictionary of filters (in the Fourier domain), with keys (`j`, `q`).
-        `j` corresponds to the downsampling factor for
-        :math:`x \\ast psi1[(j, q)]``, and `q` corresponds to a pitch class
-        (chroma).
-        * psi1[(j, n)] is itself a dictionary, with keys corresponding to the
-        dilation factors: psi1[(j, n)][j2] corresponds to a support of size
-        :math:`2^{J_\\text{max} - j_2}`, where :math:`J_\\text{max}` has been
-        defined a priori (`J_max = size` of the padding support of the input)
-        * psi1[(j, n)] only has real values;
-        the tensors are complex so that broadcasting applies
+    psi1 : list
+        a list of dictionaries, expressing wavelet band-pass filters in the
+        Fourier domain for the first layer of the scattering transform.
+        Each `psi1[n1]` is a dictionary with keys:
+            * `j`: int, subsampling factor
+            * `xi`: float, center frequency
+            * `sigma`: float, bandwidth
+            * `levels`: list, values taken by the wavelet in the Fourier domain
+                        at different levels of detail.
+        Each psi1[n]['levels'][level] is an array with size N/2**level.
     psi2 : dictionary
-        a dictionary of filters, with keys (j2, n2). Same remarks as for psi1
+        Same as psi1, but for the second layer of the scattering transform.
     phi : dictionary
-        a dictionary of filters of scale :math:`2^J` with keys (`j`)
-        where :math:`2^j` is the downsampling factor.
-        The array `phi[j]` is a real-valued filter.
+        a dictionary expressing the low-pass filter in the Fourier domain.
+        Keys:
+        * `j`: int, subsampling factor (also known as log_T)
+        * `xi`: float, center frequency (=0 by convention)
+        * `sigma`: float, bandwidth
+        * 'levels': list, values taken by the lowpass in the Fourier domain
+                    at different levels of detail.
     oversampling : int, optional
-        how much to oversample the scattering (with respect to :math:`2^J`):
+        how much to oversample the scattering (with respect to `log2_T`):
         the higher, the larger the resulting scattering
-        tensor along time.
+        tensor along time. Must be nonnegative (`oversampling>=0     ).
     max_order : int, optional
         Number of orders in the scattering transform. Either 1 or 2.
     average : boolean, optional

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -105,7 +105,9 @@ class ScatteringBase1D(ScatteringBase):
         elif self.out_type=='dict':
             return {path['n']: path['coef'] for path in S}
         elif self.out_type=='list':
-            return list(map(lambda path: path.pop('n')), S)
+            for n in range(len(S)):
+                S[n].pop('n')
+            return S
 
     def meta(self):
         """Get meta information on the transform

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -104,9 +104,17 @@ class ScatteringBase1D(ScatteringBase):
 
         n_kept_dims = 1 + (self.out_type=='dict')
         for path in S_gen:
+            path['order'] = len(path['n'])
+            if self.average:
+                res = self.log2_T
+            elif path['order']>0:
+                res = max(path['j'][-1] - self.oversampling, 0)
+            else:
+                res = 0
+            path['coef'] = self.backend.unpad(
+                path['coef'], self.ind_start[res], self.ind_end[res])
             path['coef'] = self.backend.reshape_output(
                 path['coef'], batch_shape, n_kept_dims=n_kept_dims)
-            path['order'] = len(path['n'])
 
             if self.out_type in ['array', 'list']:
                 S.append(path)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -91,8 +91,10 @@ class ScatteringBase1D(ScatteringBase):
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
         x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
 
-        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
-                         max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
+        U_0 = self.backend.pad(x, pad_left=self.pad_left, pad_right=self.pad_right)
+
+        S = scattering1d(U_0, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
+                         max_order=self.max_order, average=self.average,
                         ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
 
         n_kept_dims = 1 + (self.out_type=="dict")

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend=None):
+            oversampling=0, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -20,7 +20,6 @@ class ScatteringBase1D(ScatteringBase):
         self.max_order = max_order
         self.average = average
         self.oversampling = oversampling
-        self.vectorize = vectorize
         self.out_type = out_type
         self.backend = backend
 
@@ -116,6 +115,21 @@ class ScatteringBase1D(ScatteringBase):
         """
         return precompute_size_scattering(self.J, self.Q, self.T,
             self.max_order, self.r_psi, self.sigma0, self.alpha, detail=detail)
+
+    def _check_runtime_args(self):
+        if not self.out_type in ('array', 'dict', 'list'):
+            raise RuntimeError("The out_type must be one of 'array', 'dict', or 'list'.")
+
+        if not self.average and self.out_type == 'array':
+            raise ValueError("Cannot convert to out_type='array' with "
+                             "average=False. Please set out_type to 'dict' or 'list'.")
+
+    def _check_input(self, x):
+        # basic checking, should be improved
+        if len(x.shape) < 1:
+            raise ValueError(
+                'Input tensor x should have at least one axis, got {}'.format(
+                    len(x.shape)))
 
     _doc_shape = 'N'
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -86,6 +86,7 @@ class ScatteringBase1D(ScatteringBase):
     def scattering(self, x):
         ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
+        
         x_shape = self.backend.shape(x)
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
         x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -86,7 +86,8 @@ class ScatteringBase1D(ScatteringBase):
     def scattering(self, x):
         ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
-        batch_shape, signal_shape = self.backend.shape(x, signal_dim=1)
+        x_shape = self.backend.shape(x)
+        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
         x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -4,6 +4,7 @@ import numbers
 
 import numpy as np
 
+from ..core.scattering1d import scattering1d
 from ..filter_bank import compute_temporal_support, gauss_1d, scattering_filter_factory
 from ..utils import (compute_border_indices, compute_padding,
 compute_meta_scattering, precompute_size_scattering)
@@ -81,6 +82,29 @@ class ScatteringBase1D(ScatteringBase):
         self.phi_f, self.psi1_f, self.psi2_f = scattering_filter_factory(
             self.J_pad, self.J, self.Q, self.T,
             r_psi=self.r_psi, sigma0=self.sigma0, alpha=self.alpha)
+
+    def scattering(self, x):
+        ScatteringBase1D._check_runtime_args(self)
+        ScatteringBase1D._check_input(self, x)
+        x_shape = self.backend.shape(x)
+        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
+        x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
+
+        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
+                         max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
+                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
+
+        n_kept_dims = 1 + (self.out_type=="dict")
+        for n, path in enumerate(S):
+            S[n]['coef'] = self.backend.reshape_output(
+                path['coef'], batch_shape, n_kept_dims=n_kept_dims)
+
+        if self.out_type=='array':
+            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
+        elif self.out_type=='dict':
+            return {path['n']: path['coef'] for path in S}
+        elif self.out_type=='list':
+            return list(map(lambda path: path.pop('n')), S)
 
     def meta(self):
         """Get meta information on the transform

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -86,8 +86,7 @@ class ScatteringBase1D(ScatteringBase):
     def scattering(self, x):
         ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
-        x_shape = self.backend.shape(x)
-        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
+        batch_shape, signal_shape = self.backend.shape(x, signal_dim=1)
         x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -93,9 +93,8 @@ class ScatteringBase1D(ScatteringBase):
 
         U_0 = self.backend.pad(x, pad_left=self.pad_left, pad_right=self.pad_right)
 
-        S_gen = scattering1d(U_0, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
-                         max_order=self.max_order, average=self.average,
-                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
+        S_gen = scattering1d(U_0, self.backend, self.psi1_f, self.psi2_f, self.phi_f,
+            self.oversampling, self.max_order, average=self.average)
 
         if self.out_type in ['array', 'list']:
             S = list()

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -9,8 +9,8 @@ from tensorflow.python.framework import tensor_shape
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, T=None, max_order=2, oversampling=0):
         ScatteringKeras.__init__(self)
-        ScatteringBase1D.__init__(self, J, None, Q, T, max_order, True,
-                oversampling, True, 'array', None)
+        ScatteringBase1D.__init__(self, J, shape=None, Q=Q, T=T, max_order=max_order,
+                average=True, oversampling=oversampling, out_type='array', backend=None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -1,7 +1,6 @@
 import warnings
 
 from ...frontend.numpy_frontend import ScatteringNumPy
-from ..core.scattering1d import scattering1d
 from .base_frontend import ScatteringBase1D
 
 
@@ -14,30 +13,6 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
-
-    def scattering(self, x):
-        ScatteringBase1D._check_runtime_args(self)
-        ScatteringBase1D._check_input(self, x)
-        x_shape = self.backend.shape(x)
-        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
-        x = self.backend.reshape_input(x, signal_shape)
-
-        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
-                         self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
-                         pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
-                         oversampling=self.oversampling)
-
-        n_kept_dims = 1 + (self.out_type=="dict")
-        for n, path in enumerate(S):
-            S[n]['coef'] = self.backend.reshape_output(
-                path['coef'], batch_shape, n_kept_dims=n_kept_dims)
-
-        if self.out_type=='array':
-            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
-        elif self.out_type=='dict':
-            return {path['n']: path['coef'] for path in S}
-        elif self.out_type=='list':
-            return list(map(lambda path: path.pop('n')), S)
 
 
 ScatteringNumPy1D._document()

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -27,16 +27,17 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling)
 
-        for n in range(len(S)):
+        n_kept_dims = 1 + (self.out_type=="dict")
+        for n, path in enumerate(S):
             S[n]['coef'] = self.backend.reshape_output(
-                S[n]['coef'], batch_shape, n_inserted_dims=1, n_kept_dims=1)
+                path['coef'], batch_shape, n_kept_dims=n_kept_dims)
 
         if self.out_type=='array':
             return self.backend.concatenate([path['coef'] for path in S], dim=-2)
         elif self.out_type == 'dict':
             return {path['n']: path['coef'] for path in S}
         elif self.out_type == 'list':
-            return S
+            return list(map(lambda path: path.pop('n')), S)
 
 
 ScatteringNumPy1D._document()

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -18,11 +18,9 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def scattering(self, x):
         ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
-
-        batch_shape = x.shape[:-1]
-        signal_shape = x.shape[-1:]
-
-        x = x.reshape((-1, 1) + signal_shape)
+        x_shape = self.backend.shape(x)
+        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
+        x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
@@ -30,24 +28,14 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
                          oversampling=self.oversampling, out_type=self.out_type)
 
         if self.out_type == 'array':
-            scattering_shape = S.shape[-2:]
-            new_shape = batch_shape + scattering_shape
-
-            S = S.reshape(new_shape)
+            S = self.backend.reshape_output(S, batch_shape, n_kept_dims=2)
         elif self.out_type == 'dict':
             for k, v in S.items():
-                # NOTE: Have to get the shape for each one since we may have
-                # average == False.
-                scattering_shape = v.shape[-2:]
-                new_shape = batch_shape + scattering_shape
-
-                S[k] = v.reshape(new_shape)
+                S[k] = self.backend.reshape_output(v, batch_shape, n_kept_dims=2)
         elif self.out_type == 'list':
-            for x in S:
-                scattering_shape = x['coef'].shape[-1:]
-                new_shape = batch_shape + scattering_shape
-
-                x['coef'] = x['coef'].reshape(new_shape)
+            for path in S:
+                path['coef'] = self.backend.reshape_output(
+                    path['coef'], batch_shape, n_kept_dims=1)
 
         return S
 

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -20,25 +20,23 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         ScatteringBase1D._check_input(self, x)
         x_shape = self.backend.shape(x)
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
-        x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
+        x = self.backend.reshape_input(x, signal_shape)
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling)
 
-        if self.out_type == 'array':
-            S = self.backend.reshape_output(S, batch_shape, n_kept_dims=2)
-        elif self.out_type == 'dict':
-            S = {x['n']: x['coef'] for x in S}
-            for k, v in S.items():
-                S[k] = self.backend.reshape_output(v, batch_shape, n_kept_dims=2)
-        elif self.out_type == 'list':
-            for path in S:
-                path['coef'] = self.backend.reshape_output(
-                    path['coef'], batch_shape, n_kept_dims=1)
+        for n in range(len(S)):
+            S[n]['coef'] = self.backend.reshape_output(
+                S[n]['coef'], batch_shape, n_inserted_dims=1, n_kept_dims=1)
 
-        return S
+        if self.out_type=='array':
+            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
+        elif self.out_type == 'dict':
+            return {path['n']: path['coef'] for path in S}
+        elif self.out_type == 'list':
+            return S
 
 
 ScatteringNumPy1D._document()

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -34,9 +34,9 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
 
         if self.out_type=='array':
             return self.backend.concatenate([path['coef'] for path in S], dim=-2)
-        elif self.out_type == 'dict':
+        elif self.out_type=='dict':
             return {path['n']: path['coef'] for path in S}
-        elif self.out_type == 'list':
+        elif self.out_type=='list':
             return list(map(lambda path: path.pop('n')), S)
 
 

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -7,34 +7,17 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='numpy'):
+            oversampling=0, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
 
     def scattering(self, x):
-        # basic checking, should be improved
-        if len(x.shape) < 1:
-            raise ValueError(
-                'Input tensor x should have at least one axis, got {}'.format(
-                    len(x.shape)))
-
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
+        ScatteringBase1D._check_runtime_args(self)
+        ScatteringBase1D._check_input(self, x)
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
@@ -44,14 +27,14 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
-                         oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                         oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
 
             S = S.reshape(new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -8,37 +8,18 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='tensorflow',
+            oversampling=0, out_type='array', backend='tensorflow',
                  name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
 
     def scattering(self, x):
-        # basic checking, should be improved
-        if len(x.shape) < 1:
-            raise ValueError(
-                'Input tensor x should have at least one axis, got {}'.format(
-                    len(x.shape)))
-
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
-
+        ScatteringBase1D._check_runtime_args(self)
+        ScatteringBase1D._check_input(self, x)
         batch_shape = tf.shape(x)[:-1]
         signal_shape = tf.shape(x)[-1:]
 
@@ -47,14 +28,14 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
-                         oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                         oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = tf.shape(S)[-2:]
             new_shape = tf.concat((batch_shape, scattering_shape), 0)
 
             S = tf.reshape(S, new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -22,25 +22,23 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         ScatteringBase1D._check_input(self, x)
         x_shape = self.backend.shape(x)
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
-        x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
+        x = self.backend.reshape_input(x, signal_shape)
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling)
 
-        if self.out_type == 'array':
-            S = self.backend.reshape_output(S, batch_shape, n_kept_dims=2)
-        elif self.out_type == 'dict':
-            S = {x['n']: x['coef'] for x in S}
-            for k, v in S.items():
-                S[k] = self.backend.reshape_output(v, batch_shape, n_kept_dims=2)
-        elif self.out_type == 'list':
-            for path in S:
-                path['coef'] = self.backend.reshape_output(
-                    path['coef'], batch_shape, n_kept_dims=1)
+        for n in range(len(S)):
+            S[n]['coef'] = self.backend.reshape_output(
+                S[n]['coef'], batch_shape, n_inserted_dims=1, n_kept_dims=1)
 
-        return S
+        if self.out_type=='array':
+            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
+        elif self.out_type == 'dict':
+            return {path['n']: path['coef'] for path in S}
+        elif self.out_type == 'list':
+            return S
 
 
 ScatteringTensorFlow1D._document()

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -36,9 +36,9 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
 
         if self.out_type=='array':
             return self.backend.concatenate([path['coef'] for path in S], dim=-2)
-        elif self.out_type == 'dict':
+        elif self.out_type=='dict':
             return {path['n']: path['coef'] for path in S}
-        elif self.out_type == 'list':
+        elif self.out_type=='list':
             return list(map(lambda path: path.pop('n')), S)
 
 

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -17,30 +17,6 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
 
-    def scattering(self, x):
-        ScatteringBase1D._check_runtime_args(self)
-        ScatteringBase1D._check_input(self, x)
-        x_shape = self.backend.shape(x)
-        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
-        x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
-
-        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
-                         self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
-                         pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
-                         oversampling=self.oversampling)
-
-        n_kept_dims = 1 + (self.out_type=="dict")
-        for n, path in enumerate(S):
-            S[n]['coef'] = self.backend.reshape_output(
-                path['coef'], batch_shape, n_kept_dims=n_kept_dims)
-
-        if self.out_type=='array':
-            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
-        elif self.out_type=='dict':
-            return {path['n']: path['coef'] for path in S}
-        elif self.out_type=='list':
-            return list(map(lambda path: path.pop('n')), S)
-
 
 ScatteringTensorFlow1D._document()
 

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -22,23 +22,24 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         ScatteringBase1D._check_input(self, x)
         x_shape = self.backend.shape(x)
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
-        x = self.backend.reshape_input(x, signal_shape)
+        x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling)
 
-        for n in range(len(S)):
+        n_kept_dims = 1 + (self.out_type=="dict")
+        for n, path in enumerate(S):
             S[n]['coef'] = self.backend.reshape_output(
-                S[n]['coef'], batch_shape, n_inserted_dims=1, n_kept_dims=1)
+                path['coef'], batch_shape, n_kept_dims=n_kept_dims)
 
         if self.out_type=='array':
             return self.backend.concatenate([path['coef'] for path in S], dim=-2)
         elif self.out_type == 'dict':
             return {path['n']: path['coef'] for path in S}
         elif self.out_type == 'list':
-            return S
+            return list(map(lambda path: path.pop('n')), S)
 
 
 ScatteringTensorFlow1D._document()

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -78,16 +78,17 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                          max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
                         ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
 
-        for n in range(len(S)):
+        n_kept_dims = 1 + (self.out_type=="dict")
+        for n, path in enumerate(S):
             S[n]['coef'] = self.backend.reshape_output(
-                S[n]['coef'], batch_shape, n_inserted_dims=1, n_kept_dims=1)
+                path['coef'], batch_shape, n_kept_dims=n_kept_dims)
 
         if self.out_type=='array':
             return self.backend.concatenate([path['coef'] for path in S], dim=-2)
         elif self.out_type == 'dict':
             return {path['n']: path['coef'] for path in S}
         elif self.out_type == 'list':
-            return S
+            return list(map(lambda path: path.pop('n')), S)
 
 
 ScatteringTorch1D._document()

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -8,10 +8,10 @@ from .base_frontend import ScatteringBase1D
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, vectorize=True, out_type='array', backend='torch'):
+            oversampling=0, out_type='array', backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,
-                oversampling, vectorize, out_type, backend)
+                oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -25,7 +25,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         # prepare for pytorch
         for k in self.phi_f.keys():
             if type(k) != str:
-                # view(-1, 1).repeat(1, 2) because real numbers!
                 self.phi_f[k] = torch.from_numpy(
                     self.phi_f[k]).float().view(-1, 1)
                 self.register_buffer('tensor' + str(n), self.phi_f[k])
@@ -33,7 +32,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         for psi_f in self.psi1_f:
             for sub_k in psi_f.keys():
                 if type(sub_k) != str:
-                    # view(-1, 1).repeat(1, 2) because real numbers!
                     psi_f[sub_k] = torch.from_numpy(
                         psi_f[sub_k]).float().view(-1, 1)
                     self.register_buffer('tensor' + str(n), psi_f[sub_k])
@@ -41,7 +39,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         for psi_f in self.psi2_f:
             for sub_k in psi_f.keys():
                 if type(sub_k) != str:
-                    # view(-1, 1).repeat(1, 2) because real numbers!
                     psi_f[sub_k] = torch.from_numpy(
                         psi_f[sub_k]).float().view(-1, 1)
                     self.register_buffer('tensor' + str(n), psi_f[sub_k])
@@ -70,26 +67,8 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                     n += 1
 
     def scattering(self, x):
-        # basic checking, should be improved
-        if len(x.shape) < 1:
-            raise ValueError(
-                'Input tensor x should have at least one axis, got {}'.format(
-                    len(x.shape)))
-
-        if not self.out_type in ('array', 'list'):
-            raise RuntimeError("The out_type must be one of 'array' or 'list'.")
-
-        if not self.average and self.out_type == 'array' and self.vectorize:
-            raise ValueError("Options average=False, out_type='array' and "
-                             "vectorize=True are mutually incompatible. "
-                             "Please set out_type to 'list' or vectorize to "
-                             "False.")
-
-        if not self.vectorize:
-            warnings.warn("The vectorize option is deprecated and will be "
-                          "removed in version 0.3. Please set "
-                          "out_type='list' for equivalent functionality.",
-                          DeprecationWarning)
+        ScatteringBase1D._check_runtime_args(self)
+        ScatteringBase1D._check_input(self, x)
 
         batch_shape = x.shape[:-1]
         signal_shape = x.shape[-1:]
@@ -100,13 +79,13 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
                          max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
-                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling, vectorize=self.vectorize, out_type=self.out_type)
+                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling, out_type=self.out_type)
 
-        if self.out_type == 'array' and self.vectorize:
+        if self.out_type == 'array':
             scattering_shape = S.shape[-2:]
             new_shape = batch_shape + scattering_shape
             S = S.reshape(new_shape)
-        elif self.out_type == 'array' and not self.vectorize:
+        elif self.out_type == 'dict':
             for k, v in S.items():
                 # NOTE: Have to get the shape for each one since we may have
                 # average == False.

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -78,18 +78,16 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                          max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
                         ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
 
-        if self.out_type == 'array':
-            S = self.backend.reshape_output(S, batch_shape, n_kept_dims=2)
-        elif self.out_type == 'dict':
-            S = {x['n']: x['coef'] for x in S}
-            for k, v in S.items():
-                S[k] = self.backend.reshape_output(v, batch_shape, n_kept_dims=2)
-        elif self.out_type == 'list':
-            for path in S:
-                path['coef'] = self.backend.reshape_output(
-                    path['coef'], batch_shape, n_kept_dims=1)
+        for n in range(len(S)):
+            S[n]['coef'] = self.backend.reshape_output(
+                S[n]['coef'], batch_shape, n_inserted_dims=1, n_kept_dims=1)
 
-        return S
+        if self.out_type=='array':
+            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
+        elif self.out_type == 'dict':
+            return {path['n']: path['coef'] for path in S}
+        elif self.out_type == 'list':
+            return S
 
 
 ScatteringTorch1D._document()

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -68,27 +68,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
 
     def scattering(self, x):
         self.load_filters()
-        ScatteringBase1D._check_runtime_args(self)
-        ScatteringBase1D._check_input(self, x)
-        x_shape = self.backend.shape(x)
-        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
-        x = self.backend.reshape_input(x, signal_shape, n_inserted_dims=1)
-
-        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
-                         max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
-                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
-
-        n_kept_dims = 1 + (self.out_type=="dict")
-        for n, path in enumerate(S):
-            S[n]['coef'] = self.backend.reshape_output(
-                path['coef'], batch_shape, n_kept_dims=n_kept_dims)
-
-        if self.out_type=='array':
-            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
-        elif self.out_type=='dict':
-            return {path['n']: path['coef'] for path in S}
-        elif self.out_type=='list':
-            return list(map(lambda path: path.pop('n')), S)
+        return super().scattering(x)
 
 
 ScatteringTorch1D._document()

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -85,9 +85,9 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
 
         if self.out_type=='array':
             return self.backend.concatenate([path['coef'] for path in S], dim=-2)
-        elif self.out_type == 'dict':
+        elif self.out_type=='dict':
             return {path['n']: path['coef'] for path in S}
-        elif self.out_type == 'list':
+        elif self.out_type=='list':
             return list(map(lambda path: path.pop('n')), S)
 
 

--- a/kymatio/scattering2d/frontend/base_frontend.py
+++ b/kymatio/scattering2d/frontend/base_frontend.py
@@ -35,6 +35,10 @@ class ScatteringBase2D(ScatteringBase):
         filters = filter_bank(self.M_padded, self.N_padded, self.J, self.L)
         self.phi, self.psi = filters['phi'], filters['psi']
 
+    def scattering(self, x):
+        """ This function should call the functional scattering."""
+        raise NotImplementedError
+
     _doc_shape = 'M, N'
 
     _doc_instantiation_shape = {True: 'S = Scattering2D(J, (M, N))',

--- a/kymatio/scattering3d/frontend/base_frontend.py
+++ b/kymatio/scattering3d/frontend/base_frontend.py
@@ -29,6 +29,10 @@ class ScatteringBase3D(ScatteringBase):
         self.gaussian_filters = gaussian_filter_bank(
             self.M, self.N, self.O, self.J + 1, self.sigma_0)
 
+    def scattering(self, x):
+        """ This function should call the functional scattering."""
+        raise NotImplementedError
+
     _doc_shape = 'M, N, O'
 
     _doc_class = \

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -29,6 +29,7 @@ class TestScattering1DNumpy:
         N = x.shape[-1]
         scattering = Scattering1D(J, N, Q, backend=backend, frontend='numpy')
         Sx = scattering(x)
+        assert Sx.shape == Sx0.shape
         assert np.allclose(Sx, Sx0)
 
     def test_Scattering1D_T(self, backend):

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -108,8 +108,7 @@ def test_sample_scattering(device, backend):
 
     Sx = scattering(x)
 
-    print(Sx.shape)
-
+    assert Sx.shape == Sx0.shape
     assert torch.allclose(Sx, Sx0)
 
 


### PR DESCRIPTION
fourth item in a streak, after #871, #877, #879. This concludes the decoupling between core scattering versus pre-processing routines (type checks, reshaping, padding) as well as post-processing routines (reshaping again, padding, and formatting to `out_type`).

The LOC impact is more or less neutral, but the number of input arguments to `core/scattering1d` is significantly reduced:
```python
def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average=True):
```

Compare with current master branch:
```python
def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
        pad_right=0, ind_start=None, ind_end=None, oversampling=0,
        max_order=2, average=True, size_scattering=(0, 0, 0),
        vectorize=False, out_type='array'):
```

This change is backwards compatible so it may happen in v0.3 
The main appeal behind this change is that it allows to envision making a "dry run" of the scattering transform in which `x` is replaced by `None` and the `backend` is replaced by 

```python
class DryBackend:
    __getattr__ = lambda self, attr: (lambda *args: None)
```

This dry run will simplify `self.meta()` and `self.out_size()` methods.

Small new features:
* paths now contain a field `order`, just like the `self.meta()` dictionary
* it would now be very easy to implement `out_type='generator'` for reduced memory footprint. Drink from the `ScatteringBase1D` faucet