### PR TITLE
1D deprecation warning for average

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -24,6 +24,11 @@ class ScatteringBase1D(ScatteringBase):
         self.out_type = out_type
         self.backend = backend
 
+        warnings.warn("The average option is deprecated and will be "
+                      "removed in version 0.4. Please set "
+                      "T=None for equivalent functionality to average=False.",
+                      DeprecationWarning)
+
     def build(self):
         """Set up padding and filters
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -26,7 +26,7 @@ class ScatteringBase1D(ScatteringBase):
 
         warnings.warn("The average option is deprecated and will be "
                       "removed in version 0.4. Please set "
-                      "T=None for equivalent functionality to average=False.",
+                      "T appropriately for equivalent functionality.",
                       DeprecationWarning)
 
     def build(self):


### PR DESCRIPTION
Altering the semantics of `T` parameter. It will effectively replace `average` in 1D in preparation for JTFS release in 0.4. `T` will also be used for frequency averaging in the frequential filterbank.

* `T=None` will perform default mode averaging, i.e. `T=2^J`
* `T=0` corresponds to `average=False`
* Any other integer `T` will stride over the specified support