### PR TITLE
MAINT HarmonicScattering3D now outputs real coefficients in Numpy. 

### DIFF
--- a/kymatio/scattering3d/backend/numpy_backend.py
+++ b/kymatio/scattering3d/backend/numpy_backend.py
@@ -48,7 +48,7 @@ class NumpyBackend3D(NumpyBackend):
                 to the powers p (l_p norms).
         """
         integrals = cls._np.zeros((input_array.shape[0], len(integral_powers)),
-                dtype=cls._np.complex64)
+                dtype=cls._np.float32)
         for i_q, q in enumerate(integral_powers):
             integrals[:, i_q] = (input_array ** q).reshape((input_array.shape[0], -1)).sum(axis=1)
         return integrals

--- a/tests/scattering3d/test_numpy_scattering3d.py
+++ b/tests/scattering3d/test_numpy_scattering3d.py
@@ -57,13 +57,12 @@ def test_against_standard_computations(backend):
     orders_1_and_2_ref = scattering_ref[:, start:end]
 
     order_0_diff_cpu = relative_difference(order_0_ref, order_0)
-    print(orders_1_and_2_ref.shape)
-    print(orders_1_and_2.shape)
     orders_1_and_2_diff_cpu = relative_difference(
         orders_1_and_2_ref, orders_1_and_2)
 
     assert order_0_diff_cpu < 1e-6, "CPU : order 0 do not match, diff={}".format(order_0_diff_cpu)
     assert orders_1_and_2_diff_cpu < 1e-6, "CPU : orders 1 and 2 do not match, diff={}".format(orders_1_and_2_diff_cpu)
+    assert orders_1_and_2.dtype == np.dtype(np.float32)
 
 
 @pytest.mark.parametrize("backend", backends)
@@ -82,6 +81,7 @@ def test_scattering_batch_shape_agnostic(backend):
     Sx = S(x)
 
     assert len(Sx.shape) == 3
+    assert Sx.dtype == np.dtype(np.float32)
 
     coeffs_shape = Sx.shape[-3:]
 
@@ -97,3 +97,5 @@ def test_scattering_batch_shape_agnostic(backend):
         assert len(Sx.shape) == len(test_shape)
         assert Sx.shape[-3:] == coeffs_shape
         assert Sx.shape[:-3] == test_shape[:-3]
+        assert Sx.dtype == np.dtype(np.float32)
+

--- a/tests/scattering3d/test_tensorflow_scattering3d.py
+++ b/tests/scattering3d/test_tensorflow_scattering3d.py
@@ -52,6 +52,7 @@ def test_against_standard_computations():
 
     orders_1_and_2_diff_cpu = relative_difference(orders_1_and_2_ref, orders_1_and_2)
     assert orders_1_and_2_diff_cpu < 5e-7, "Tensorflow : orders 1 and 2 do not match, diff={}".format(orders_1_and_2_diff_cpu)
+    assert orders_1_and_2.dtype == np.dtype(np.float32)
 
 def test_scattering_batch_shape_agnostic():
     J = 2
@@ -69,6 +70,7 @@ def test_scattering_batch_shape_agnostic():
     Sx = S(x)
 
     assert len(Sx.shape) == 3
+    assert S(x).dtype == np.dtype(np.float32)
 
     coeffs_shape = Sx.shape[-3:]
 
@@ -82,3 +84,4 @@ def test_scattering_batch_shape_agnostic():
         assert len(Sx.shape) == len(test_shape)
         assert Sx.shape[-3:] == coeffs_shape
         assert Sx.shape[:-3] == test_shape[:-3]
+        assert S(x).dtype == np.dtype(np.float32)

--- a/tests/scattering3d/test_torch_scattering3d.py
+++ b/tests/scattering3d/test_torch_scattering3d.py
@@ -198,6 +198,7 @@ def test_against_standard_computations(device, backend):
 
     assert order_0_diff_cpu < 1e-6, "CPU : order 0 do not match, diff={}".format(order_0_diff_cpu)
     assert orders_1_and_2_diff_cpu < 1e-6, "CPU : orders 1 and 2 do not match, diff={}".format(orders_1_and_2_diff_cpu)
+    assert orders_1_and_2.dtype == np.dtype(np.float32)
 
 
 @pytest.mark.parametrize("device", devices)


### PR DESCRIPTION
This PR resolves issue #811 and adds a few tests confirming the fix.  