### PR TITLE
MAINT make NumPy the default frontend

### DIFF
--- a/kymatio/frontend/entry.py
+++ b/kymatio/frontend/entry.py
@@ -17,9 +17,7 @@ class ScatteringEntry(object):
                              'sklearn': 'Transformer'}
 
         if 'frontend' not in kwargs:
-            warnings.warn("Torch frontend is currently the default, but NumPy will become the default in the next"
-                          " version.", DeprecationWarning)
-            frontend = 'torch'
+            frontend = 'numpy'
         else:
             frontend = kwargs['frontend'].lower()
             kwargs.pop('frontend')

--- a/tests/scattering1d/test_utils_scattering1d.py
+++ b/tests/scattering1d/test_utils_scattering1d.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from kymatio import Scattering1D
-from kymatio.scattering1d.frontend.torch_frontend import ScatteringTorch1D
+from kymatio.scattering1d.frontend.numpy_frontend import ScatteringNumPy1D
 from kymatio.scattering1d.utils import compute_border_indices, compute_padding
 
 
@@ -56,7 +56,7 @@ def test_border_indices(random_state=42):
 # Check that the default frontend is numpy and that errors are correctly launched.
 def test_scattering1d_frontend():
     scattering = Scattering1D(2, shape=(10, ))
-    assert isinstance(scattering, ScatteringTorch1D), 'could not be correctly imported'
+    assert isinstance(scattering, ScatteringNumPy1D), 'could not be correctly imported'
 
     with pytest.raises(RuntimeError) as ve:
         scattering = Scattering1D(2, shape=(10,), frontend='doesnotexist')

--- a/tests/scattering2d/test_frontend_scattering2d.py
+++ b/tests/scattering2d/test_frontend_scattering2d.py
@@ -3,16 +3,16 @@ import pytest
 from kymatio import Scattering2D
 from kymatio.scattering2d.frontend.numpy_frontend import ScatteringNumPy2D
 
-# Check that the default frontend is Torch and that errors are correctly launched.
+# Check that the default frontend is Numpy and that errors are correctly launched.
 def test_scattering2d_frontend():
     scattering = Scattering2D(2, shape=(10, 10))
-    assert isinstance(scattering, ScatteringNumPy2D), 'Torch frontend is not selected by default'
+    assert isinstance(scattering, ScatteringNumPy2D), 'Numpy frontend is not selected by default'
 
     with pytest.raises(RuntimeError) as ve:
         scattering = Scattering2D(2, shape=(10, 10), frontend='doesnotexist')
     assert "is not valid" in ve.value.args[0]
 
-# Check the default backend is Torch and that errors are correctly launched.
+# Check the default backend is Numpy and that errors are correctly launched.
 def test_scattering2d_backend():
     with pytest.raises(ImportError) as ve:
         scattering = Scattering2D(2, shape=(10, 10), backend='doesnotexist')

--- a/tests/scattering2d/test_frontend_scattering2d.py
+++ b/tests/scattering2d/test_frontend_scattering2d.py
@@ -1,12 +1,12 @@
 import pytest
 
 from kymatio import Scattering2D
-from kymatio.scattering2d.frontend.torch_frontend import ScatteringTorch2D
+from kymatio.scattering2d.frontend.numpy_frontend import ScatteringNumPy2D
 
 # Check that the default frontend is Torch and that errors are correctly launched.
 def test_scattering2d_frontend():
     scattering = Scattering2D(2, shape=(10, 10))
-    assert isinstance(scattering, ScatteringTorch2D), 'Torch frontend is not selected by default'
+    assert isinstance(scattering, ScatteringNumPy2D), 'Torch frontend is not selected by default'
 
     with pytest.raises(RuntimeError) as ve:
         scattering = Scattering2D(2, shape=(10, 10), frontend='doesnotexist')

--- a/tests/scattering2d/test_frontend_scattering2d.py
+++ b/tests/scattering2d/test_frontend_scattering2d.py
@@ -6,7 +6,7 @@ from kymatio.scattering2d.frontend.numpy_frontend import ScatteringNumPy2D
 # Check that the default frontend is Numpy and that errors are correctly launched.
 def test_scattering2d_frontend():
     scattering = Scattering2D(2, shape=(10, 10))
-    assert isinstance(scattering, ScatteringNumPy2D), 'Numpy frontend is not selected by default'
+    assert isinstance(scattering, ScatteringNumPy2D), 'NumPy frontend is not selected by default'
 
     with pytest.raises(RuntimeError) as ve:
         scattering = Scattering2D(2, shape=(10, 10), frontend='doesnotexist')

--- a/tests/scattering3d/test_torch_scattering3d.py
+++ b/tests/scattering3d/test_torch_scattering3d.py
@@ -4,7 +4,7 @@ import os
 import io
 import numpy as np
 import pytest
-from kymatio import HarmonicScattering3D
+from kymatio.torch import HarmonicScattering3D
 from kymatio.scattering3d.utils import generate_weighted_sum_of_gaussians
 
 backends = []
@@ -171,7 +171,7 @@ def test_against_standard_computations(device, backend):
 
     scattering = HarmonicScattering3D(J=J, shape=(M, N, O), L=L,
             sigma_0=sigma, method='integral',
-            integral_powers=integral_powers, max_order=2, backend=backend, frontend='torch')
+            integral_powers=integral_powers, max_order=2, backend=backend)
 
     scattering.to(device)
     x = x.to(device)
@@ -218,8 +218,8 @@ def test_solid_harmonic_scattering(device, backend):
     x = torch.from_numpy(generate_weighted_sum_of_gaussians(grid, centers,
         weights, sigma_gaussian)).to(device).float()
     scattering = HarmonicScattering3D(J=J, shape=(M, N, O), L=L,
-            sigma_0=sigma_0_wavelet,max_order=1, method='integral',
-            integral_powers=[1], frontend='torch',backend=backend).to(device)
+            sigma_0=sigma_0_wavelet, max_order=1, method='integral',
+            integral_powers=[1], backend=backend).to(device)
 
     scattering.max_order = 1
     scattering.method = 'integral'
@@ -248,7 +248,7 @@ def test_larger_scales(device, backend):
     x = torch.randn((1,) + shape).to(device)
 
     for J in range(3, 4+1):
-        scattering = HarmonicScattering3D(J=J, shape=shape, L=L, sigma_0=sigma_0, frontend='torch', backend=backend).to(device)
+        scattering = HarmonicScattering3D(J=J, shape=shape, L=L, sigma_0=sigma_0, backend=backend).to(device)
         scattering.method = 'integral'
         Sx = scattering(x)
 
@@ -262,7 +262,7 @@ def test_scattering_batch_shape_agnostic(device, backend):
     J = 2
     shape = (16, 16, 16)
 
-    S = HarmonicScattering3D(J=J, shape=shape)
+    S = HarmonicScattering3D(J=J, shape=shape, backend=backend)
 
     for k in range(3):
         with pytest.raises(RuntimeError) as ve:


### PR DESCRIPTION
This PR resolves #868, making Numpy the default frontend like we said we would. 