### PR TITLE
MAINT update GitHub workflows

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,8 +10,8 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.6, 3.7]
-                pytorch-version: [1.7, 1.8]
+                python-version: [3.6, 3.10]
+                pytorch-version: [1.7, 1.9, 1.11]
 
         env:
             CONDA_ENV: test-env-py${{ matrix.python-version }}-torch${{ matrix.pytorch-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,9 @@ jobs:
                   python3 -m pip install --upgrade pip
                   python3 -m pip install -r requirements.txt
                   python3 -m pip install -r requirements_optional.txt
-                  pip install torch==1.8.0+cpu \
-                              torchvision==0.9.0+cpu \
-                              torchaudio==0.8.0 \
+                  pip install torch==1.11.0+cpu \
+                              torchaudio-0.11.0+cpu \
+                              torchvision-0.12.0 \
                               -f https://download.pytorch.org/whl/torch_stable.html
             - name: Set up Kymatio
               run: python3 setup.py develop

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -10,11 +10,8 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.6, 3.7]
-                pytorch-version: [1.7, 1.8]
-                include:
-                    - python-version: 3.5
-                      pytorch-version: 1.5
+                python-version: [3.6, 3.10]
+                pytorch-version: [1.7, 1.9, 1.11]
 
         steps:
             - uses: actions/checkout@v1
@@ -27,19 +24,20 @@ jobs:
                   python3 -m pip install --upgrade pip
                   python3 -m pip install pytest pytest-cov
 
-                  if [ ${{ matrix.pytorch-version }} == '1.5' ]; then
-                      pip install torch==1.5.1+cpu \
-                                  torchvision==0.6.1+cpu \
-                                  -f https://download.pytorch.org/whl/torch_stable.html
-                  elif [ ${{ matrix.pytorch-version }} == '1.7' ]; then
+                  if [ ${{ matrix.pytorch-version }} == '1.7' ]; then
                       pip install torch==1.7.1+cpu \
                                   torchvision==0.8.2+cpu \
                                   torchaudio==0.7.2 \
                                   -f https://download.pytorch.org/whl/torch_stable.html
-                  elif [ ${{ matrix.pytorch-version }} == '1.8' ]; then
-                      pip install torch==1.8.0+cpu \
-                                  torchvision==0.9.0+cpu \
-                                  torchaudio==0.8.0 \
+                  elif [ ${{ matrix.pytorch-version }} == '1.9' ]; then
+                      pip install torch==1.9.1+cpu \
+                                  torchvision==0.10.1+cpu \
+                                  torchaudio==0.9.1 -f \
+                                  https://download.pytorch.org/whl/torch_stable.html
+                  elif [ ${{ matrix.pytorch-version }} == '1.11' ]; then
+                      pip install torch==1.11.0+cpu \
+                                  torchaudio-0.11.0+cpu \
+                                  torchvision-0.12.0 \
                                   -f https://download.pytorch.org/whl/torch_stable.html
                   fi
                   python3 -m pip install "tensorflow>=2.0.0a"


### PR DESCRIPTION
A proposed fix for Muawiz's

>  Looking at making the jenkins and github workflows use pytorch 1.10, 1.11, instead of 1.7, 1.8, would be baller.

Except i think it would be more secure to set the widest version span possible. So i propose:

```
python-version = [3.6, 3.10]
pytorch-version = [1.7, 1.9, 1.11]
```

Note that i have remove Python 3.5 (hence the PR name), which has reached EOL and is throwing a `DeprecationWarning` in the test suite.

I have also removed Torch 1.5, which was released in April 2020.