### PR TITLE
MAINT deprecate `average` in `Scattering1D`

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -10,15 +10,14 @@ compute_meta_scattering, precompute_size_scattering)
 
 
 class ScatteringBase1D(ScatteringBase):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
-            oversampling=0, out_type='array', backend=None):
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, oversampling=0, 
+                 out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
         self.Q = Q
         self.T = T
         self.max_order = max_order
-        self.average = average
         self.oversampling = oversampling
         self.out_type = out_type
         self.backend = backend
@@ -65,11 +64,17 @@ class ScatteringBase1D(ScatteringBase):
 
         # check T or set default
         if self.T is None:
-            self.T = 2**(self.J)
+            self.average = True
+            self.T = 2 ** self.J
         elif self.T > N_input:
             raise ValueError("The temporal support T of the low-pass filter "
                              "cannot exceed input length (got {} > {})".format(
                                  self.T, N_input))
+        elif type(self.T) is not int or self.T < 0:
+            raise ValueError("T must be a nonnegative integer (got {})".format(
+                                self.T))
+        else: 
+            self.average = T != 0
         self.log2_T = math.floor(math.log2(self.T))
 
         # Compute the minimum support to pad (ideally)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 class ScatteringBase1D(ScatteringBase):
     def __init__(self, J, shape, Q=1, T=None, max_order=2, oversampling=0, 
-                 out_type='array', backend=None):
+                 out_type='array', backend=None, average=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -21,6 +21,11 @@ class ScatteringBase1D(ScatteringBase):
         self.oversampling = oversampling
         self.out_type = out_type
         self.backend = backend
+
+        if average is not None:
+            warn("`average` is deprecated v0.3 and will be removed in v0.4."
+                 "Replace `average=False` by `T=0` and set `T>1` or leave" 
+                 "`T=None` for `average=True` (default)", DeprecationWarning)
 
     def build(self):
         """Set up padding and filters
@@ -223,9 +228,9 @@ class ScatteringBase1D(ScatteringBase):
             averaged output corresponds to the standard scattering transform,
             while the un-averaged output skips the last convolution by
             :math:`\phi_J(t)`.  This parameter may be modified after object
-            creation. Defaults to `True`. Deprecated in favour of `T` and will 
-            be removed in v0.4. Replace `average=False` by `T=0` and set `T>1` 
-            or leave `T=None` for `average=True` (default).
+            creation. Defaults to `True`. Deprecated in v0.3 in favour of `T` 
+            and will  be removed in v0.4. Replace `average=False` by `T=0` and 
+            set `T>1` or leave `T=None` for `average=True` (default).
         """
 
     _doc_attr_average = \

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -10,8 +10,8 @@ compute_meta_scattering, precompute_size_scattering)
 
 
 class ScatteringBase1D(ScatteringBase):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, oversampling=0, 
-                 out_type='array', backend=None, average=None):
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None, 
+                 oversampling=0, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
@@ -75,11 +75,11 @@ class ScatteringBase1D(ScatteringBase):
             raise ValueError("The temporal support T of the low-pass filter "
                              "cannot exceed input length (got {} > {})".format(
                                  self.T, N_input))
-        elif type(self.T) is not int or self.T < 0:
+        elif self.T < 0 or (self.T > 0 and self.T < 1):
             raise ValueError("T must be a nonnegative integer (got {})".format(
                                 self.T))
         else: 
-            self.average = T != 0
+            self.average = self.T != 0
         self.log2_T = math.floor(math.log2(self.T))
 
         # Compute the minimum support to pad (ideally)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -173,6 +173,15 @@ class ScatteringBase1D(ScatteringBase):
         "or access shape[0] for the unpadded length (previously N).", DeprecationWarning)
         return int(self.shape[0])
 
+    @property
+    def average(self):
+        warn("The average option is deprecated and will be "
+             "removed in v0.4. Please set "
+             "T=None for equivalent functionality to average=False.",
+             "T appropriately for equivalent functionality.",
+             DeprecationWarning)
+        return self.T != 0
+
     _doc_shape = 'N'
 
     _doc_instantiation_shape = {True: 'S = Scattering1D(J, N, Q)',

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -69,17 +69,19 @@ class ScatteringBase1D(ScatteringBase):
 
         # check T or set default
         if self.T is None:
-            self.average = True
+            self._average = True
             self.T = 2 ** self.J
         elif self.T > N_input:
             raise ValueError("The temporal support T of the low-pass filter "
                              "cannot exceed input length (got {} > {})".format(
                                  self.T, N_input))
-        elif self.T < 0 or (self.T > 0 and self.T < 1):
+        elif self.T < 0:
             raise ValueError("T must be a nonnegative integer (got {})".format(
-                                self.T))
+                             self.T))
         else: 
-            self.average = self.T != 0
+            self._average = self.T != 0 
+
+            self.T = self.T if self._average else 2 ** self.J
         self.log2_T = math.floor(math.log2(self.T))
 
         # Compute the minimum support to pad (ideally)
@@ -150,7 +152,7 @@ class ScatteringBase1D(ScatteringBase):
             raise ValueError("The out_type must be one of 'array', 'dict'"
                              ", or 'list'. Got: {}".format(self.out_type))
 
-        if not self.average and self.out_type == 'array':
+        if not self._average and self.out_type == 'array':
             raise ValueError("Cannot convert to out_type='array' with "
                              "average=False. Please set out_type to 'dict' or 'list'.")
 
@@ -190,7 +192,7 @@ class ScatteringBase1D(ScatteringBase):
              "Replace `average=False` by `T=0` and set `T>1` or leave `T=None`" 
              "for `average=True` (default)",
              DeprecationWarning)
-        return self.T != 0 
+        return self._average
 
     _doc_shape = 'N'
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -176,11 +176,11 @@ class ScatteringBase1D(ScatteringBase):
     @property
     def average(self):
         warn("The average option is deprecated and will be "
-             "removed in v0.4. Please set "
-             "T=None for equivalent functionality to average=False.",
-             "T appropriately for equivalent functionality.",
+             "removed in v0.4. Please replace "
+             "Replace `average=False` by `T=0` and set `T>1` or leave `T=None`" 
+             "for `average=True` (default)",
              DeprecationWarning)
-        return self.T != 0
+        return self.T != 0 
 
     _doc_shape = 'N'
 
@@ -218,7 +218,9 @@ class ScatteringBase1D(ScatteringBase):
             averaged output corresponds to the standard scattering transform,
             while the un-averaged output skips the last convolution by
             :math:`\phi_J(t)`.  This parameter may be modified after object
-            creation. Defaults to `True`.
+            creation. Defaults to `True`. Deprecated in favour of `T` and will 
+            be removed in v0.4. Replace `average=False` by `T=0` and set `T>1` 
+            or leave `T=None` for `average=True` (default).
         """
 
     _doc_attr_average = \
@@ -227,7 +229,8 @@ class ScatteringBase1D(ScatteringBase):
             scattering transform) or not (resulting in wavelet modulus
             coefficients). Note that to obtain unaveraged output, the
             `vectorize` flag must be set to `False` or `out_type` must be set
-            to `'list'`.
+            to `'list'`. Deprecated in favor of `T`. For more details, 
+            see the documentation for `scattering`.
      """
 
     _doc_param_vectorize = \

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -6,7 +6,7 @@ from .base_frontend import ScatteringBase1D
 
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None,
             oversampling=0, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -7,7 +7,7 @@ from .base_frontend import ScatteringBase1D
 
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None,
             oversampling=0, out_type='array', backend='tensorflow',
                  name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -7,7 +7,7 @@ from .base_frontend import ScatteringBase1D
 
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None,
             oversampling=0, out_type='array', backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,

--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -31,7 +31,7 @@ def test_Scattering1D():
     assert np.allclose(Sg0, Sx0, atol=1e-07)
     # adjust T
     sigma_low_scale_factor = 2
-    T=2**(J-sigma_low_scale_factor)
+    T = 2**(J-sigma_low_scale_factor)
     inputs1 = Input(shape=(x.shape[-1]))
     scat1 = Scattering1D(J=J, Q=Q, T=T)(inputs1)
     model1 = Model(inputs1, scat1)

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -54,7 +54,7 @@ class TestScattering1DNumpy:
         order2_1 = np.where(meta1['order'] == 2)
         # adjust T
         sigma_low_scale_factor = 2
-        T=2**(J-sigma_low_scale_factor)
+        T = 2**(J-sigma_low_scale_factor)
         scattering2 = Scattering1D(J, N, Q, T=T, backend=backend, frontend='numpy')
         Sx2 = scattering2(x)
         assert Sx2.shape == (Sx1.shape[0], Sx1.shape[1], Sx1.shape[2]*2**(sigma_low_scale_factor))        
@@ -99,10 +99,10 @@ class TestScattering1DNumpy:
                 phi_f, psi1_f, psi2_f = scattering_filter_factory(N, J, Q, T)
                 assert(phi_f['sigma']==0.1/T)
 
+
 frontends = ['numpy', 'sklearn']
 @pytest.mark.parametrize("backend", backends)
 @pytest.mark.parametrize("frontend", frontends)
-
 def test_Q(backend, frontend):
     J = 3
     length = 1024

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -122,9 +122,10 @@ def test_computation_Ux(backend, device, random_state=42):
     rng = np.random.RandomState(random_state)
     J = 6
     Q = 8
-    T = 2**12
-    scattering = Scattering1D(J, T, Q, average=False,
-                              max_order=1, out_type="dict", frontend='torch', backend=backend).to(device)
+    T = 0
+    scattering = Scattering1D(J, T, Q,
+                              max_order=1, out_type="dict", frontend='torch', 
+                              backend=backend).to(device)
     # random signal
     x = torch.from_numpy(rng.randn(1, T)).float().to(device)
 
@@ -427,6 +428,7 @@ def test_T(device, backend):
     assert torch.allclose(Sg0, Sx0)
     assert Sg1.shape == (Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**(sigma_low_scale_factor))
 
+
 @pytest.mark.parametrize("device", devices)
 @pytest.mark.parametrize("backend", backends)
 def test_Q(device, backend):
@@ -482,7 +484,7 @@ def test_check_runtime_args(device, backend):
     assert "out_type must be one" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
-        S = Scattering1D(J, shape, backend=backend, average=False,
+        S = Scattering1D(J, shape, backend=backend, T=0,
                          out_type='array', frontend='torch').to(device)
         S(x)
     assert "Cannot convert" in ve.value.args[0]

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -123,11 +123,12 @@ def test_computation_Ux(backend, device, random_state=42):
     J = 6
     Q = 8
     T = 0
-    scattering = Scattering1D(J, T, Q,
+    shape = 2**J
+    scattering = Scattering1D(J, shape, Q, T=T,
                               max_order=1, out_type="dict", frontend='torch', 
                               backend=backend).to(device)
     # random signal
-    x = torch.from_numpy(rng.randn(1, T)).float().to(device)
+    x = torch.from_numpy(rng.randn(1, shape)).float().to(device)
 
     if not backend.name.endswith('skcuda') or device != 'cpu':
         s = scattering(x)


### PR DESCRIPTION
Addressing #885. Deprecation of `Scattering1D` `average` for v0.3, in preparation for removal in v0.4

Alters the semantics of `T`:

- `T=None` performs default mode averaging, i.e. `T=2**J`
- `T=0` is no averaging
- Any other integer`T` will stride over the specified support

