### PR TITLE
`reshape_input`, `reshape_output` (#871)

### DIFF
--- a/kymatio/backend/numpy_backend.py
+++ b/kymatio/backend/numpy_backend.py
@@ -38,8 +38,8 @@ class NumpyBackend:
         return (x.dtype == cls._np.float32) or (x.dtype == cls._np.float64)
 
     @classmethod
-    def concatenate(cls, arrays):
-        return cls._np.stack(arrays, axis=1)
+    def concatenate(cls, arrays, dim=1):
+        return cls._np.stack(arrays, axis=dim)
 
     @classmethod
     def modulus(cls, x):
@@ -93,3 +93,16 @@ class NumpyBackend:
             raise TypeError('The second input must be complex or real.')
 
         return A * B
+
+    @staticmethod
+    def reshape_input(x, signal_shape):
+        return x.reshape((-1, 1) + signal_shape)
+
+    @staticmethod
+    def reshape_output(S, batch_shape, n_kept_dims):
+        new_shape = batch_shape + S.shape[-n_kept_dims:]
+        return S.reshape(new_shape)
+
+    @staticmethod
+    def shape(x):
+        return x.shape

--- a/kymatio/backend/tensorflow_backend.py
+++ b/kymatio/backend/tensorflow_backend.py
@@ -6,8 +6,8 @@ class TensorFlowBackend(NumpyBackend):
     name = 'tensorflow'
 
     @staticmethod
-    def concatenate(arrays):
-        return tf.stack(arrays, axis=1)
+    def concatenate(arrays, dim=1):
+        return tf.stack(arrays, axis=dim)
 
     @staticmethod
     def modulus(x):
@@ -15,3 +15,17 @@ class TensorFlowBackend(NumpyBackend):
 
         return norm
 
+    @staticmethod
+    def reshape_input(x, signal_shape):
+        new_shape = tf.concat(((-1, 1,), signal_shape), 0)
+        return tf.reshape(x, new_shape)
+
+    @staticmethod
+    def reshape_output(S, batch_shape, n_kept_dims):
+        new_shape = tf.concat(
+            (batch_shape, S.shape[-n_kept_dims:]), 0)
+        return tf.reshape(S, new_shape)
+
+    @staticmethod
+    def shape(x):
+        return tf.shape(x)

--- a/kymatio/backend/torch_backend.py
+++ b/kymatio/backend/torch_backend.py
@@ -217,3 +217,16 @@ class TorchBackend:
             C[..., 1].view(-1, B.nelement() // 2)[:] = A_r * B_i + A_i * B_r
 
             return C
+
+    @staticmethod
+    def reshape_input(x, signal_shape):
+        return x.reshape((-1, 1) + signal_shape)
+
+    @staticmethod
+    def reshape_output(S, batch_shape, n_kept_dims):
+        new_shape = batch_shape + S.shape[-n_kept_dims:]
+        return S.reshape(new_shape)
+
+    @staticmethod
+    def shape(x):
+        return x.shape

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -18,37 +18,25 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
     def scattering(self, x):
         ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
-
-        batch_shape = x.shape[:-1]
-        signal_shape = x.shape[-1:]
-
-        x = x.reshape((-1, 1) + signal_shape)
+        x_shape = self.backend.shape(x)
+        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
+        x = self.backend.reshape_input(x, signal_shape)
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f,
                          self.phi_f, max_order=self.max_order, average=self.average, pad_left=self.pad_left,
                          pad_right=self.pad_right, ind_start=self.ind_start, ind_end=self.ind_end,
                          oversampling=self.oversampling)
 
-        if self.out_type == 'array':
-            S = self.backend.concatenate([x['coef'] for x in S])
-            scattering_shape = S.shape[-2:]
-            new_shape = batch_shape + scattering_shape
-            S = S.reshape(new_shape)
-        elif self.out_type == 'dict':
-            S = {x['n']: x['coef'] for x in S}
-            for k, v in S.items():
-                # NOTE: Have to get the shape for each one since we may have
-                # average == False.
-                scattering_shape = v.shape[-1:]
-                new_shape = batch_shape + scattering_shape
-                S[k] = v.reshape(new_shape)
-        elif self.out_type == 'list':
-            for x in S:
-                scattering_shape = x['coef'].shape[-1:]
-                new_shape = batch_shape + scattering_shape
-                x['coef'] = x['coef'].reshape(new_shape)
+        for n, path in enumerate(S):
+            S[n]['coef'] = self.backend.reshape_output(
+                path['coef'], batch_shape, n_kept_dims=1)
 
-        return S
+        if self.out_type == 'array':
+            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
+        elif self.out_type == 'dict':
+            return {path['n']: path['coef'] for path in S}
+        elif self.out_type == 'list':
+            return S
 
 
 ScatteringNumPy1D._document()

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -61,40 +61,27 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
                 n += 1
 
     def scattering(self, x):
+        self.load_filters()
         ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
-
-        batch_shape = x.shape[:-1]
-        signal_shape = x.shape[-1:]
-
-        x = x.reshape((-1, 1) + signal_shape)
-
-        self.load_filters()
+        x_shape = self.backend.shape(x)
+        batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
+        x = self.backend.reshape_input(x, signal_shape)
 
         S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
                          max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
                         ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
 
-        if self.out_type == 'array':
-            S = self.backend.concatenate([x['coef'] for x in S])
-            scattering_shape = S.shape[-2:]
-            new_shape = batch_shape + scattering_shape
-            S = S.reshape(new_shape)
-        elif self.out_type == 'dict':
-            S = {x['n']: x['coef'] for x in S}
-            for k, v in S.items():
-                # NOTE: Have to get the shape for each one since we may have
-                # average == False.
-                scattering_shape = v.shape[-1:]
-                new_shape = batch_shape + scattering_shape
-                S[k] = v.reshape(new_shape)
-        elif self.out_type == 'list':
-            for x in S:
-                scattering_shape = x['coef'].shape[-1:]
-                new_shape = batch_shape + scattering_shape
-                x['coef'] = x['coef'].reshape(new_shape)
+        for n, path in enumerate(S):
+            S[n]['coef'] = self.backend.reshape_output(
+                path['coef'], batch_shape, n_kept_dims=1)
 
-        return S
+        if self.out_type == 'array':
+            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
+        elif self.out_type == 'dict':
+            return {path['n']: path['coef'] for path in S}
+        elif self.out_type == 'list':
+            return S
 
 
 ScatteringTorch1D._document()

--- a/tests/general/test_numpy_backend.py
+++ b/tests/general/test_numpy_backend.py
@@ -1,0 +1,29 @@
+import numpy as np
+from kymatio.backend.numpy_backend import NumpyBackend
+
+def test_reshape():
+    backend = NumpyBackend
+
+    # 1D
+    x = np.random.randn(3, 5, 16)
+    y = backend.reshape_input(x, signal_shape=(16,))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=1)
+    assert backend.shape(x) == x.shape
+    assert y.shape == (15, 1, 16)
+    assert np.allclose(x, xbis)
+
+    # 2D
+    x = np.random.randn(3, 5, 16, 16)
+    y = backend.reshape_input(x, signal_shape=(16, 16))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=2)
+    assert backend.shape(x) == x.shape
+    assert y.shape == (15, 1, 16, 16)
+    assert np.allclose(x, xbis)
+
+    # 3D
+    x = np.random.randn(3, 5, 16, 16, 16)
+    y = backend.reshape_input(x, signal_shape=(16, 16, 16))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=3)
+    assert backend.shape(x) == x.shape
+    assert y.shape == (15, 1, 16, 16, 16)
+    assert np.allclose(x, xbis)

--- a/tests/general/test_tensorflow_backend.py
+++ b/tests/general/test_tensorflow_backend.py
@@ -1,0 +1,30 @@
+import numpy as np
+import tensorflow as tf
+from kymatio.backend.tensorflow_backend import TensorFlowBackend
+
+def test_reshape():
+    backend = TensorFlowBackend
+
+    # 1D
+    x = tf.random.normal((3, 5, 16))
+    y = backend.reshape_input(x, signal_shape=(16,))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=1)
+    assert tuple(backend.shape(x)) == tuple(x.shape)
+    assert tuple(y.shape) == (15, 1, 16)
+    assert np.allclose(x.numpy(), xbis.numpy())
+
+    # 2D
+    x = tf.random.normal((3, 5, 16, 16))
+    y = backend.reshape_input(x, signal_shape=(16, 16))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=2)
+    assert tuple(backend.shape(x)) == tuple(x.shape)
+    assert tuple(y.shape) == (15, 1, 16, 16)
+    assert np.allclose(x.numpy(), xbis.numpy())
+
+    # 3D
+    x = tf.random.normal((3, 5, 16, 16, 16))
+    y = backend.reshape_input(x, signal_shape=(16, 16, 16))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=3)
+    assert tuple(backend.shape(x)) == tuple(x.shape)
+    assert tuple(y.shape) == (15, 1, 16, 16, 16)
+    assert np.allclose(x.numpy(), xbis.numpy())

--- a/tests/general/test_torch_backend.py
+++ b/tests/general/test_torch_backend.py
@@ -24,3 +24,31 @@ def test_modulus(random_state=42):
     y_grad = torch.ones_like(y)
     x_grad_manual = ModulusStable.backward(ctx, y_grad)
     assert torch.allclose(x_grad_manual, x_grad)
+
+
+def test_reshape():
+    backend = TorchBackend
+
+    # 1D
+    x = torch.randn(3, 5, 16)
+    y = backend.reshape_input(x, signal_shape=(16,))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=1)
+    assert backend.shape(x) == x.shape
+    assert y.shape == (15, 1, 16)
+    assert torch.allclose(x, xbis)
+
+    # 2D
+    x = torch.randn(3, 5, 16, 16)
+    y = backend.reshape_input(x, signal_shape=(16, 16))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=2)
+    assert backend.shape(x) == x.shape
+    assert y.shape == (15, 1, 16, 16)
+    assert torch.allclose(x, xbis)
+
+    # 3D
+    x = torch.randn(3, 5, 16, 16, 16)
+    y = backend.reshape_input(x, signal_shape=(16, 16, 16))
+    xbis = backend.reshape_output(y, batch_shape=(3, 5), n_kept_dims=3)
+    assert backend.shape(x) == x.shape
+    assert y.shape == (15, 1, 16, 16, 16)
+    assert torch.allclose(x, xbis)


### PR DESCRIPTION
Co-authored-by: Vincent Lostanlen [vincent.lostanlen@ls2n.fr](mailto:vincent.lostanlen@ls2n.fr)

* backend shape methods

* reshape_input, reshape_output in backends

* try to call reshape_output only once [ci skip]

* simplify PR, figure out "dict" as special case

* spaces around operator [ci skip]

* bugfix prev commit (concatenate dim in NP backend)

* manage multiple inheritance

move the NotImplementedError's of scattering to 2D and 3D 's base frontends

* implement scattering(self, x) in 1D base frontend

* shape(x, signal_dim) in backends

* bugfix previous commit

* Revert "bugfix previous commit"

This reverts commit de46c9efeab7ca01c2f8a74cbf8f3202148ab1b1.

* Revert "shape(x, signal_dim) in backends"

This reverts commit 937b87cf1e5287ec6b83df0eccd8b5b58d3d3728.

* add empty line in base_frontend 1D scattering

after review by Muawiz

* bugfix out_type=="list"

* remove pad from core scattering1d

compute padding in base frontend instead

* spaces around operator

* simplify reshape_input

* fix 895

* rename dim to axis

for compatibility with NumPy Array API

* update concatenate callsites

* Revert "update concatenate callsites"

This reverts commit 4222d10d7e15189e3fd52c45562daa30f84b9634.

* Revert "rename dim to axis"

This reverts commit f8cccf99118d02d4b0721c19ced144e27ba05769.

* unit test reshape in torch backend

* unit test reshape in NP backend

* unit test reshape in TF backend

* Revert "Merge branch 'pad-before-core-scattering' into backend-agnostic-reshape"

This reverts commit c31ef30d6250ce9107224bdbf69cdc12a6623ac1, reversing
changes made to a7a8f75e43bae49cc4cf3785b447bb1bb06c4a19.
