### PR TITLE
MAINT remove pad from core scattering1d

### DIFF
--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,13 +1,12 @@
 
-def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
-        pad_right=0, ind_start=None, ind_end=None, oversampling=0,
-        max_order=2, average=True):
+def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
+        oversampling=0, max_order=2, average=True):
     """
     Main function implementing the 1-D scattering transform.
 
     Parameters
     ----------
-    x : Tensor
+    U_0 : Tensor
         a torch Tensor of size `(B, 1, N)` where `N` is the temporal size
     psi1 : dictionary
         a dictionary of filters (in the Fourier domain), with keys (`j`, `q`).
@@ -28,10 +27,6 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
         The array `phi[j]` is a real-valued filter.
     J : int
         scale of the scattering
-    pad_left : int, optional
-        how much to pad the signal on the left. Defaults to `0`
-    pad_right : int, optional
-        how much to pad the signal on the right. Defaults to `0`
     ind_start : dictionary of ints, optional
         indices to truncate the signal to recover only the
         parts which correspond to the actual signal after padding and
@@ -52,15 +47,12 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
     irfft = backend.irfft
     modulus = backend.modulus
     rfft = backend.rfft
-    pad = backend.pad
     subsample_fourier = backend.subsample_fourier
     unpad = backend.unpad
 
     # S is simply a dictionary if we do not perform the averaging...
     out_S_0, out_S_1, out_S_2 = [], [], []
 
-    # pad to a dyadic size and make it complex
-    U_0 = pad(x, pad_left=pad_left, pad_right=pad_right)
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 
@@ -75,7 +67,7 @@ def scattering1d(x, backend, psi1, psi2, phi, pad_left=0,
 
         S_0 = unpad(S_0_r, ind_start[k0], ind_end[k0])
     else:
-        S_0 = x
+        S_0 = unpad(U_0, ind_start[0], ind_end[0])
     out_S_0.append({'coef': S_0,
                     'j': (),
                     'n': ()})

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -135,9 +135,9 @@ class ScatteringBase1D(ScatteringBase):
 
         U_0 = self.backend.pad(x, pad_left=self.pad_left, pad_right=self.pad_right)
 
-        S = scattering1d(U_0, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
-                         max_order=self.max_order, average=self.average,
-                        ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
+        S = scattering1d(U_0, self.backend, self.psi1_f, self.psi2_f, self.phi_f,
+            max_order=self.max_order, average=self.average,
+            ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
 
         for n, path in enumerate(S):
             S[n]['coef'] = self.backend.reshape_output(

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -133,8 +133,10 @@ class ScatteringBase1D(ScatteringBase):
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
         x = self.backend.reshape_input(x, signal_shape)
 
-        S = scattering1d(x, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
-                         max_order=self.max_order, average=self.average, pad_left=self.pad_left, pad_right=self.pad_right,
+        U_0 = self.backend.pad(x, pad_left=self.pad_left, pad_right=self.pad_right)
+
+        S = scattering1d(U_0, self.backend, self.psi1_f, self.psi2_f, self.phi_f,\
+                         max_order=self.max_order, average=self.average,
                         ind_start=self.ind_start, ind_end=self.ind_end, oversampling=self.oversampling)
 
         for n, path in enumerate(S):

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -14,7 +14,6 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
 
-
 ScatteringNumPy1D._document()
 
 

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -16,7 +16,6 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
 
-
 ScatteringTensorFlow1D._document()
 
 


### PR DESCRIPTION
dup of #879 but geared towards main this time


segue of https://github.com/kymatio/kymatio/pull/877, and moves further in the direction of https://github.com/kymatio/kymatio/pull/855 which closed https://github.com/kymatio/kymatio/issues/852
remove pad from core scattering1d

backwards compatible. opens the door towards custom padding in 1d (https://github.com/kymatio/kymatio/issues/859)
no additional tests
contributes to https://github.com/kymatio/kymatio/issues/735