### PR TITLE
ENH `core/scattering1d` now returns a generator

### DIFF
--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,12 +1,15 @@
 
-def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average):
+def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average=True):
     """
     Main function implementing the 1-D scattering transform.
 
     Parameters
     ----------
     U_0 : Tensor
-        a torch Tensor of size `(B, 1, N)` where `N` is the temporal size
+        an backend-compatible array of size `(B, 1, N)` where `B` is batch size
+        and `N` is the padded signal length.
+    backend : module
+        Kymatio module which matches the type of U_0.
     psi1 : dictionary
         a dictionary of filters (in the Fourier domain), with keys (`j`, `q`).
         `j` corresponds to the downsampling factor for
@@ -31,7 +34,7 @@ def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average
     max_order : int, optional
         Number of orders in the scattering transform. Either 1 or 2.
     average : boolean, optional
-        whether to average the first order vector.
+        whether to average the result. Default to True.
     """
     cdgmm = backend.cdgmm
     ifft = backend.ifft

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -50,9 +50,6 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
     subsample_fourier = backend.subsample_fourier
     unpad = backend.unpad
 
-    # S is simply a dictionary if we do not perform the averaging...
-    out_S_0, out_S_1, out_S_2 = [], [], []
-
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 
@@ -65,12 +62,10 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
         S_0_hat = subsample_fourier(S_0_c, 2**k0)
         S_0_r = irfft(S_0_hat)
 
-        S_0 = unpad(S_0_r, ind_start[k0], ind_end[k0])
+        coef = unpad(S_0_r, ind_start[k0], ind_end[k0])
     else:
-        S_0 = unpad(U_0, ind_start[0], ind_end[0])
-    out_S_0.append({'coef': S_0,
-                    'j': (),
-                    'n': ()})
+        coef = unpad(U_0, ind_start[0], ind_end[0])
+    yield {'coef': coef, 'j': (), 'n': ()}
 
     # First order:
     for n1 in range(len(psi1)):
@@ -97,13 +92,11 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
             S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
             S_1_r = irfft(S_1_hat)
 
-            S_1 = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
+            coef = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
         else:
-            S_1 = unpad(U_1_m, ind_start[k1], ind_end[k1])
+            coef = unpad(U_1_m, ind_start[k1], ind_end[k1])
 
-        out_S_1.append({'coef': S_1,
-                        'j': (j1,),
-                        'n': (n1,)})
+        yield {'coef': coef, 'j': (j1,), 'n': (n1,)}
 
         if max_order == 2:
             # 2nd order
@@ -132,20 +125,11 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
                         S_2_hat = subsample_fourier(S_2_c, 2**k2_log2_T)
                         S_2_r = irfft(S_2_hat)
 
-                        S_2 = unpad(S_2_r, ind_start[k1 + k2 + k2_log2_T],
+                        coef = unpad(S_2_r, ind_start[k1 + k2 + k2_log2_T],
                                     ind_end[k1 + k2 + k2_log2_T])
                     else:
-                        S_2 = unpad(U_2_m, ind_start[k1 + k2], ind_end[k1 + k2])
+                        coef = unpad(U_2_m, ind_start[k1 + k2], ind_end[k1 + k2])
 
-                    out_S_2.append({'coef': S_2,
-                                    'j': (j1, j2),
-                                    'n': (n1, n2)})
-
-    out_S = []
-    out_S.extend(out_S_0)
-    out_S.extend(out_S_1)
-    out_S.extend(out_S_2)
-
-    return out_S
+                    yield {'coef': coef, 'j': (j1, j2), 'n': (n1, n2)}
 
 __all__ = ['scattering1d']

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -61,11 +61,9 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
         S_0_c = cdgmm(U_0_hat, phi['levels'][0])
         S_0_hat = subsample_fourier(S_0_c, 2**k0)
         S_0_r = irfft(S_0_hat)
-
-        coef = unpad(S_0_r, ind_start[k0], ind_end[k0])
+        yield {'coef': S_0_r, 'j': (), 'n': ()}
     else:
-        coef = unpad(U_0, ind_start[0], ind_end[0])
-    yield {'coef': coef, 'j': (), 'n': ()}
+        yield {'coef': U_0, 'j': (), 'n': ()}
 
     # First order:
     for n1 in range(len(psi1)):
@@ -91,12 +89,9 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
             S_1_c = cdgmm(U_1_hat, phi['levels'][k1])
             S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
             S_1_r = irfft(S_1_hat)
-
-            coef = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
+            yield {'coef': S_1_r, 'j': (j1,), 'n': (n1,)}
         else:
-            coef = unpad(U_1_m, ind_start[k1], ind_end[k1])
-
-        yield {'coef': coef, 'j': (j1,), 'n': (n1,)}
+            yield {'coef': U_1_m, 'j': (j1,), 'n': (n1,)}
 
         if max_order == 2:
             # 2nd order
@@ -125,11 +120,8 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
                         S_2_hat = subsample_fourier(S_2_c, 2**k2_log2_T)
                         S_2_r = irfft(S_2_hat)
 
-                        coef = unpad(S_2_r, ind_start[k1 + k2 + k2_log2_T],
-                                    ind_end[k1 + k2 + k2_log2_T])
+                        yield {'coef': S_2_r, 'j': (j1, j2), 'n': (n1, n2)}
                     else:
-                        coef = unpad(U_2_m, ind_start[k1 + k2], ind_end[k1 + k2])
-
-                    yield {'coef': coef, 'j': (j1, j2), 'n': (n1, n2)}
+                        yield {'coef': U_2_m, 'j': (j1, j2), 'n': (n1, n2)}
 
 __all__ = ['scattering1d']

--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -1,6 +1,5 @@
 
-def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
-        oversampling=0, max_order=2, average=True):
+def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average):
     """
     Main function implementing the 1-D scattering transform.
 
@@ -25,22 +24,14 @@ def scattering1d(U_0, backend, psi1, psi2, phi, ind_start=None, ind_end=None,
         a dictionary of filters of scale :math:`2^J` with keys (`j`)
         where :math:`2^j` is the downsampling factor.
         The array `phi[j]` is a real-valued filter.
-    J : int
-        scale of the scattering
-    ind_start : dictionary of ints, optional
-        indices to truncate the signal to recover only the
-        parts which correspond to the actual signal after padding and
-        downsampling. Defaults to None
-    ind_end : dictionary of ints, optional
-        See description of ind_start
     oversampling : int, optional
         how much to oversample the scattering (with respect to :math:`2^J`):
         the higher, the larger the resulting scattering
-        tensor along time. Defaults to `0`
+        tensor along time.
     max_order : int, optional
-        Number of orders in the scattering transform. Either 1 or 2 (default).
+        Number of orders in the scattering transform. Either 1 or 2.
     average : boolean, optional
-        whether to average the first order vector. Defaults to `True`
+        whether to average the first order vector.
     """
     cdgmm = backend.cdgmm
     ifft = backend.ifft

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -11,7 +11,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 
 class ScatteringBase1D(ScatteringBase):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True, 
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
                  oversampling=0, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
@@ -50,10 +50,10 @@ class ScatteringBase1D(ScatteringBase):
 
         if isinstance(self.Q, int):
             self.Q = (self.Q, 1)
-        elif isinstance(self.Q, tuple): 
+        elif isinstance(self.Q, tuple):
             if len(self.Q) == 1:
                 self.Q = self.Q + (1, )
-            elif len(self.Q) < 1 or len(self.Q) > 2: 
+            elif len(self.Q) < 1 or len(self.Q) > 2:
                 raise NotImplementedError("Q should be an integer, 1-tuple or "
                                           "2-tuple. Scattering transforms "
                                           "beyond order 2 are not implemented.")
@@ -80,18 +80,18 @@ class ScatteringBase1D(ScatteringBase):
                              "cannot exceed input length (got {} > {})".format(
                                  self.T, N_input))
         elif self.T == 0:
-            if not self.average: 
+            if not self.average:
                 self.T = 2 ** self.J
                 self.average = False
             else:
-                raise ValueError("average must not be True if T=0 " 
-                                 "(got {})".format(self.average)) 
+                raise ValueError("average must not be True if T=0 "
+                                 "(got {})".format(self.average))
         elif self.T < 1:
             raise ValueError("T must be ==0 or >=1 (got {})".format(
                              self.T))
         else:
-            self.average = True if self.average is None else self.average 
-            if not self.average: 
+            self.average = True if self.average is None else self.average
+            if not self.average:
                 raise ValueError("average=False is not permitted when T>=1, "
                                  "(got {}). average is deprecated in v0.3 in "
                                  "favour of T and will "
@@ -128,7 +128,7 @@ class ScatteringBase1D(ScatteringBase):
     def scattering(self, x):
         ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
-        
+
         x_shape = self.backend.shape(x)
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
         x = self.backend.reshape_input(x, signal_shape)
@@ -263,8 +263,8 @@ class ScatteringBase1D(ScatteringBase):
             averaged output corresponds to the standard scattering transform,
             while the un-averaged output skips the last convolution by
             :math:`\phi_J(t)`.  This parameter may be modified after object
-            creation. Defaults to `True`. Deprecated in v0.3 in favour of `T` 
-            and will  be removed in v0.4. Replace `average=False` by `T=0` and 
+            creation. Defaults to `True`. Deprecated in v0.3 in favour of `T`
+            and will  be removed in v0.4. Replace `average=False` by `T=0` and
             set `T>1` or leave `T=None` for `average=True` (default).
         """
 
@@ -274,7 +274,7 @@ class ScatteringBase1D(ScatteringBase):
             scattering transform) or not (resulting in wavelet modulus
             coefficients). Note that to obtain unaveraged output, the
             `vectorize` flag must be set to `False` or `out_type` must be set
-            to `'list'`. Deprecated in favor of `T`. For more details, 
+            to `'list'`. Deprecated in favor of `T`. For more details,
             see the documentation for `scattering`.
      """
 
@@ -381,9 +381,9 @@ class ScatteringBase1D(ScatteringBase):
             the maximum scale is given by :math:`2^J`.
         {param_shape}Q : int or tuple
             By default, Q (int) is the number of wavelets per octave for the first
-            order and that for the second order has one wavelet per octave. This 
+            order and that for the second order has one wavelet per octave. This
             default value can be modified by passing Q as a tuple with two values,
-            i.e. Q = (Q1, Q2), where Q1 and Q2 are the number of wavelets per 
+            i.e. Q = (Q1, Q2), where Q1 and Q2 are the number of wavelets per
             octave for the first and second order, respectively.
         T : int
             temporal support of low-pass filter, controlling amount of imposed

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -29,6 +29,7 @@ class TestScattering1DNumpy:
         N = x.shape[-1]
         scattering = Scattering1D(J, N, Q, backend=backend, frontend='numpy')
         Sx = scattering(x)
+        assert Sx.shape == Sx0.shape
         assert np.allclose(Sx, Sx0)
 
     def test_Scattering1D_T(self, backend):

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -108,8 +108,7 @@ def test_sample_scattering(device, backend):
 
     Sx = scattering(x)
 
-    print(Sx.shape)
-
+    assert Sx.shape == Sx0.shape
     assert torch.allclose(Sx, Sx0)
 
 


### PR DESCRIPTION
dup of #880 except geared at main branch

Fourth item in a streak, after #871, #877, #879. This concludes the decoupling between core scattering versus pre-processing routines (type checks, reshaping, padding) as well as post-processing routines (reshaping again, padding, and formatting to `out_type`).

The LOC impact is more or less neutral, but the number of input arguments to `core/scattering1d` is significantly reduced:
```python
def scattering1d(U_0, backend, psi1, psi2, phi, oversampling, max_order, average=True):
```

Compare with current master branch:
```python
def scattering1d(x, pad, unpad, backend, J, psi1, psi2, phi, pad_left=0,
        pad_right=0, ind_start=None, ind_end=None, oversampling=0,
        max_order=2, average=True, size_scattering=(0, 0, 0),
        vectorize=False, out_type='array'):
```

This change is backwards compatible so it may happen in v0.3 
The main appeal behind this change is that it allows to envision making a "dry run" of the scattering transform in which `x` is replaced by `None` and the `backend` is replaced by 

```python


class DryBackend:
    __getattr__ = lambda self, attr: (lambda *args: None)
```

This dry run will simplify `self.meta()` and `self.out_size()` methods.

Small new features:
* paths now contain a field `order`, just like the `self.meta()` dictionary
* it would now be very easy to implement `out_type='generator'` for reduced memory footprint. Drink from the `ScatteringBase1D` faucet