### PR TITLE
ENH Spinned wavelets

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -311,6 +311,15 @@ def anden_generator(J, Q, sigma0, r_psi, **unused_kwargs):
         yield xi, sigma_min
 
 
+def spin(filterbank):
+    filterbank_fn, filterbank_kwargs = filterbank
+    def spinned_fn(J, Q, **kwargs):
+        for xi, sigma in filterbank_fn(J, Q, **kwargs):
+            yield xi, sigma
+            yield -xi, sigma
+    return spinned_fn, filterbank_kwargs
+
+
 def scattering_filter_factory(N, J, Q, T, filterbank):
     """
     Builds in Fourier the Morlet filters used for the scattering transform.

--- a/tests/scattering1d/test_filters_scattering1d.py
+++ b/tests/scattering1d/test_filters_scattering1d.py
@@ -2,9 +2,9 @@
 Testing all functions in filters_bank
 """
 
-from kymatio.scattering1d.filter_bank import (adaptive_choice_P,
+from kymatio.scattering1d.filter_bank import (adaptive_choice_P, anden_generator,
     compute_sigma_psi, compute_temporal_support, compute_xi_max, morlet_1d,
-    get_max_dyadic_subsampling, gauss_1d)
+    get_max_dyadic_subsampling, gauss_1d, spin)
 import numpy as np
 import math
 import pytest
@@ -126,3 +126,16 @@ def test_compute_temporal_support():
     with pytest.warns(UserWarning) as record:
         compute_temporal_support(h_f)
     assert "too small to avoid border effects" in record[0].message.args[0]
+
+
+def test_spin():
+    J = 5
+    Q = 1
+    filterbank_kwargs = {"alpha": 5, "r_psi": math.sqrt(0.5), "sigma0": 0.1}
+    unspinned_xisigmas = list(anden_generator(J, Q, **filterbank_kwargs))
+    spinned_generator, spinned_kwargs = spin((anden_generator, filterbank_kwargs))
+    spinned_xisigmas = list(spinned_generator(J, Q, **spinned_kwargs))
+    assert len(spinned_xisigmas) == (2*len(unspinned_xisigmas))
+    assert spinned_xisigmas[0][0] == -spinned_xisigmas[1][0]
+    assert spinned_xisigmas[0][1] == spinned_xisigmas[1][1]
+    assert spinned_kwargs == filterbank_kwargs


### PR DESCRIPTION
For JTFS
may also serve #645 if there's interest in supporting complex-input signals in the future

very small PR. most of the interface for this was made possible by the `anden_generator` #915
no extra kwarg to the 1D factory :)

thanks to @cyrusvahidi and @MuawizChaudhary who had a first working solution for this back in May

will document this after code review
