### PR TITLE
ENH core width-first 1d scattering for JTFS

### DIFF
--- a/kymatio/scattering1d/core/scattering1d.py
+++ b/kymatio/scattering1d/core/scattering1d.py
@@ -30,10 +30,13 @@ def scattering1d(U_0, backend, filters, oversampling, average_local):
         * `sigma`: float, bandwidth
         * 'levels': list, values taken by the lowpass in the Fourier domain
                     at different levels of detail.
-    oversampling : int, optional
-        how much to oversample the scattering (with respect to `log2_T`):
-        the higher, the larger the resulting scattering
-        tensor along time. Must be nonnegative (`oversampling>=0     ).
+    oversampling : int >=0, optional
+        if average_local is True, return scattering coefficients at the sample
+        rate max(1, 2**(log2_T-oversampling)). Hence, raising oversampling by
+        doubles the sample rate, until reaching the native sample rate.
+        if average_local is False, return first-order coefficients at the sample
+        rate max(1, 2**(j1-oversampling)) and second-order coefficients at the
+        sample rate max(1, 2**(j2-oversampling)).
     max_order : int, optional
         Number of orders in the scattering transform. Either 1 or 2.
     average_local : boolean, optional

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -1,4 +1,4 @@
-def scattering1d_depthfirst(U0, backend, filters, oversampling, average_local):
+def scattering1d_widthfirst(U0, backend, filters, oversampling, average_local):
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 
@@ -34,7 +34,7 @@ def scattering1d_depthfirst(U0, backend, filters, oversampling, average_local):
 
         if average_local:
             U_1_hat = rfft(U_1_m)
-            # Depth-first algorithm: store U1 in anticipation of next layer
+            # Width-first algorithm: store U1 in anticipation of next layer
             U_1_hats.append({'coef': U_1_hat, 'j': (j1,), 'n': (n1,)})
 
             # Convolve with phi_J
@@ -56,7 +56,7 @@ def scattering1d_depthfirst(U0, backend, filters, oversampling, average_local):
     # separately for the sake of meta() and padding/unpadding downstream.
     yield {'coef': S_1, 'j': (-1,), 'n': (-1,), 'n1_max': len(S_1_list)}
 
-    # Second order. Note that n2 is the outer loop in the depth-first algorithm
+    # Second order. Note that n2 is the outer loop (width-first algorithm)
     psi2 = filters[2]
     for n2 in range(len(psi2)):
         j2 = psi2[n2]['j']

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -1,0 +1,74 @@
+def scattering1d_depthfirst(U0, backend, filters, oversampling, average_local):
+    # compute the Fourier transform
+    U_0_hat = rfft(U_0)
+
+    # Get S0
+    phi = filters[0]
+    log2_T = phi['j']
+    k0 = max(log2_T - oversampling, 0)
+
+    if average_local:
+        S_0_c = cdgmm(U_0_hat, phi['levels'][0])
+        S_0_hat = subsample_fourier(S_0_c, 2**k0)
+        S_0_r = irfft(S_0_hat)
+        # S_0_r and U_0 are 2D arrays indexed by (batch, time)
+        yield {'coef': S_0_r, 'j': (), 'n': ()}
+    else:
+        yield {'coef': U_0, 'j': (), 'n': ()}
+
+    # First order:
+    psi1 = filters[1]
+    U_1_hats = []
+    for n1 in range(len(psi1)):
+        # Convolution + downsampling
+        j1 = psi1[n1]['j']
+        sub1_adj = min(j1, log2_T) if average_local else j1
+        k1 = max(sub1_adj - oversampling, 0)
+        U_1_c = cdgmm(U_0_hat, psi1[n1]['levels'][0])
+        U_1_hat = subsample_fourier(U_1_c, 2**k1)
+        U_1_c = ifft(U_1_hat)
+
+        # Take the modulus
+        U_1_m = modulus(U_1_c)
+
+        if average_local:
+            U_1_hat = rfft(U_1_m)
+            # Depth-first algorithm: store U1 in anticipation of next layer
+            U_1_hats.append({'coef': U_1_hat, 'j': (j1,), 'n': (n1,)})
+
+        if average_local:
+            # Convolve with phi_J
+            k1_J = max(log2_T - k1 - oversampling, 0)
+            S_1_c = cdgmm(U_1_hat, phi['levels'][k1])
+            S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
+            S_1_r = irfft(S_1_hat)
+            # S_1_r and U_1_m are 2D arrays indexed by (batch, time)
+            yield {'coef': S_1_r, 'j': (j1,), 'n': (n1,)}
+        else:
+            yield {'coef': U_1_m, 'j': (j1,), 'n': (n1,)}
+
+    # Second order. Note that n2 is the outer loop in the depth-first algorithm
+    psi2 = filters[2]
+    for n2 in range(len(psi2)):
+        j2 = psi2[n2]['j']
+        Y2 = []
+
+        for U_1_hat in U_1_hats:
+            j1 = U_1_hat['j'][0]
+
+            if j2 > j1:
+                sub2_adj = min(j2, log2_T) if average else j2
+                k2 = max(sub2_adj - k1 - oversampling, 0)
+                U_2_c = cdgmm(U_1_hat['coef'], psi2[n2]['levels'][k1])
+                U_2_hat = subsample_fourier(U_2_c, 2**k2)
+                U_2_c = ifft(U_2_hat)
+                Y2.append(U_2_c)
+
+        # Concatenate over the penultimate dimension with shared n2.
+        # Y2 is a complex-valued 3D array indexed by (batch, n1, time)
+        Y2 = concatenate(Y2, -2)
+
+        # Y2 is a stack of multiple n1 paths so we put (-1) as placeholder.
+        # In practice n1 ranges between 0 (included) and Y2.shape[-2] (excluded)
+        # so there is no loss of information in this concatenation.
+        yield {'coef': Y2, 'j': (-1, j2), 'n': (-1, n2)}

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -1,4 +1,4 @@
-def scattering1d_widthfirst(U0, backend, filters, oversampling, average_local):
+def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     # compute the Fourier transform
     U_0_hat = rfft(U_0)
 

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -1,4 +1,35 @@
 def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
+    """
+    Inputs
+    ------
+    U_0 : array indexed by (batch, time)
+    backend : module
+    filters : (phi, psi1, psi2) tuple of dictionaries. same as scattering1d
+    oversampling : int >= 0. same as scattering1d
+    average_local : bool. same as scattering1d
+
+    Yields
+    ------
+    if average_local:
+        * S_0 indexed by (batch, time[log2_T])
+        * S_1 indexed by (batch, n1, time[log2_T])
+        * Y_2[n2=0] indexed by (batch, n1, time[log2_T]) and n1 s.t. j1 < j2
+        * etc. for every n2 < len(psi2)
+    else:
+        * U_0 indexed by (batch, time)
+        * U_1[n1=0] indexed by (batch, time[n1])
+        * etc. for every n1 < len(psi1)
+        * Y_2[n2=0] indexed by (batch, n1, time[n2]) and n1 s.t. j1 < j2
+        * etc. for every n2 < len(psi2)
+
+    Definitions
+    -----------
+    U_0(t) = x(t)
+    S_0(t) = (x * phi)(t)
+    U_1[n1](t) = |x * psi_{n1}|(t)
+    S_1(n1, t) = (|x * psi_{n1}| * phi)(t) broadcasted over n1
+    Y_2[n2](n1, t) = (U1 * psi_{n2})(n1, t) broadcasted over n1
+    """
     # compute the Fourier transform
     U_0_hat = backend.rfft(U_0)
 

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -17,9 +17,9 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
         * etc. for every n2 < len(psi2)
     else:
         * U_0 indexed by (batch, time)
-        * U_1[n1=0] indexed by (batch, time[n1])
+        * U_1[n1=0] indexed by (batch, time[j1])
         * etc. for every n1 < len(psi1)
-        * Y_2[n2=0] indexed by (batch, n1, time[n2]) and n1 s.t. j1 < j2
+        * Y_2[n2=0] indexed by (batch, n1, time[j2]) and n1 s.t. j1 < j2
         * etc. for every n2 < len(psi2)
 
     Definitions
@@ -27,8 +27,8 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     U_0(t) = x(t)
     S_0(t) = (x * phi)(t)
     U_1[n1](t) = |x * psi_{n1}|(t)
-    S_1(n1, t) = (|x * psi_{n1}| * phi)(t) broadcast over n1
-    Y_2[n2](n1, t) = (U1 * psi_{n2})(n1, t) broadcast over n1
+    S_1(n1, t) = (|x * psi_{n1}| * phi)(t), conv. over t, broadcast over n1
+    Y_2[n2](n1, t) = (U_1 * psi_{n2})(n1, t), conv. over t, broadcast over n1
     """
     # compute the Fourier transform
     U_0_hat = backend.rfft(U_0)

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -52,7 +52,7 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
         # S1 is a real-valued 3D array indexed by (batch, n1, time)
         S_1 = backend.concatenate(S_1_list)
 
-        # S1 is a stack of multiple n1 paths so we puth (-1) as placeholder.
+        # S1 is a stack of multiple n1 paths so we put (-1) as placeholder.
         # n1 ranges between 0 (included) and n1_max (excluded), which we store
         # separately for the sake of meta() and padding/unpadding downstream.
         yield {'coef': S_1, 'j': (-1,), 'n': (-1,), 'n1_max': len(S_1_list)}

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -4,7 +4,7 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     ------
     U_0 : array indexed by (batch, time)
     backend : module
-    filters : (phi, psi1, psi2) tuple of dictionaries. same as scattering1d
+    filters : [phi, psi1, psi2] list of dictionaries. same as scattering1d
     oversampling : int >= 0. same as scattering1d
     average_local : bool. same as scattering1d
 

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -1,6 +1,6 @@
 def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     # compute the Fourier transform
-    U_0_hat = rfft(U_0)
+    U_0_hat = backend.rfft(U_0)
 
     # Get S0
     phi = filters[0]
@@ -8,9 +8,9 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     k0 = max(log2_T - oversampling, 0)
 
     if average_local:
-        S_0_c = cdgmm(U_0_hat, phi['levels'][0])
-        S_0_hat = subsample_fourier(S_0_c, 2**k0)
-        S_0_r = irfft(S_0_hat)
+        S_0_c = backend.cdgmm(U_0_hat, phi['levels'][0])
+        S_0_hat = backend.subsample_fourier(S_0_c, 2 ** k0)
+        S_0_r = backend.irfft(S_0_hat)
         S_1_list = []
         # S_0_r and U_0 are 2D arrays indexed by (batch, time)
         yield {'coef': S_0_r, 'j': (), 'n': ()}
@@ -25,36 +25,37 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
         j1 = psi1[n1]['j']
         sub1_adj = min(j1, log2_T) if average_local else j1
         k1 = max(sub1_adj - oversampling, 0)
-        U_1_c = cdgmm(U_0_hat, psi1[n1]['levels'][0])
-        U_1_hat = subsample_fourier(U_1_c, 2**k1)
-        U_1_c = ifft(U_1_hat)
+        U_1_c = backend.cdgmm(U_0_hat, psi1[n1]['levels'][0])
+        U_1_hat = backend.subsample_fourier(U_1_c, 2 ** k1)
+        U_1_c = backend.ifft(U_1_hat)
 
         # Take the modulus
-        U_1_m = modulus(U_1_c)
+        U_1_m = backend.modulus(U_1_c)
+
+        U_1_hat = backend.rfft(U_1_m)
+        # Width-first algorithm: store U1 in anticipation of next layer
+        U_1_hats.append({'coef': U_1_hat, 'j': (j1,), 'n': (n1,)})
 
         if average_local:
-            U_1_hat = rfft(U_1_m)
-            # Width-first algorithm: store U1 in anticipation of next layer
-            U_1_hats.append({'coef': U_1_hat, 'j': (j1,), 'n': (n1,)})
-
             # Convolve with phi_J
             k1_J = max(log2_T - k1 - oversampling, 0)
-            S_1_c = cdgmm(U_1_hat, phi['levels'][k1])
-            S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
-            S_1_r = irfft(S_1_hat)
+            S_1_c = backend.cdgmm(U_1_hat, phi['levels'][k1])
+            S_1_hat = backend.subsample_fourier(S_1_c, 2 ** k1_J)
+            S_1_r = backend.irfft(S_1_hat)
             S_1_list.append(S_1_r)
         else:
             # U_1_m is a 2D array indexed by (batch, time)
             yield {'coef': U_1_m, 'j': (j1,), 'n': (n1,)}
 
-    # Concatenate S1 paths over the penultimate dimension with shared n1.
-    # S1 is a real-valued 3D array indexed by (batch, n1, time)
-    S_1 = concatenate(S_1_list, -2)
+    if average_local:
+        # Concatenate S1 paths over the penultimate dimension with shared n1.
+        # S1 is a real-valued 3D array indexed by (batch, n1, time)
+        S_1 = backend.concatenate(S_1_list, -2)
 
-    # S1 is a stack of multiple n1 paths so we puth (-1) as placeholder.
-    # n1 ranges between 0 (included) and n1_max (excluded), which we store
-    # separately for the sake of meta() and padding/unpadding downstream.
-    yield {'coef': S_1, 'j': (-1,), 'n': (-1,), 'n1_max': len(S_1_list)}
+        # S1 is a stack of multiple n1 paths so we puth (-1) as placeholder.
+        # n1 ranges between 0 (included) and n1_max (excluded), which we store
+        # separately for the sake of meta() and padding/unpadding downstream.
+        yield {'coef': S_1, 'j': (-1,), 'n': (-1,), 'n1_max': len(S_1_list)}
 
     # Second order. Note that n2 is the outer loop (width-first algorithm)
     psi2 = filters[2]
@@ -64,20 +65,23 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
 
         for U_1_hat in U_1_hats:
             j1 = U_1_hat['j'][0]
+            sub1_adj = min(j1, log2_T) if average_local else j1
+            k1 = max(sub1_adj - oversampling, 0)
 
             if j2 > j1:
-                sub2_adj = min(j2, log2_T) if average else j2
+                sub2_adj = min(j2, log2_T) if average_local else j2
                 k2 = max(sub2_adj - k1 - oversampling, 0)
-                U_2_c = cdgmm(U_1_hat['coef'], psi2[n2]['levels'][k1])
-                U_2_hat = subsample_fourier(U_2_c, 2**k2)
-                U_2_c = ifft(U_2_hat)
+                U_2_c = backend.cdgmm(U_1_hat['coef'], psi2[n2]['levels'][k1])
+                U_2_hat = backend.subsample_fourier(U_2_c, 2 ** k2)
+                U_2_c = backend.ifft(U_2_hat)
                 Y_2_list.append(U_2_c)
 
-        # Concatenate over the penultimate dimension with shared n2.
-        # Y_2 is a complex-valued 3D array indexed by (batch, n1, time)
-        Y_2 = concatenate(Y_2_list, -2)
+        if len(Y_2_list) > 0:
+            # Concatenate over the penultimate dimension with shared n2.
+            # Y_2 is a complex-valued 3D array indexed by (batch, n1, time)
+            Y_2 = backend.concatenate(Y_2_list, -2)
 
-        # Y_2 is a stack of multiple n1 paths so we put (-1) as placeholder.
-        # n1 ranges between 0 (included) and n1_max (excluded), which we store
-        # separately for the sake of meta() and padding/unpadding downstream.
-        yield {'coef': Y_2, 'j': (-1, j2), 'n': (-1, n2), 'n1_max': len(Y_2_list)}
+            # Y_2 is a stack of multiple n1 paths so we put (-1) as placeholder.
+            # n1 ranges between 0 (included) and n1_max (excluded), which we store
+            # separately for the sake of meta() and padding/unpadding downstream.
+            yield {'coef': Y_2, 'j': (-1, j2), 'n': (-1, n2), 'n1_max': len(Y_2_list)}

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -5,8 +5,15 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     U_0 : array indexed by (batch, time)
     backend : module
     filters : [phi, psi1, psi2] list of dictionaries. same as scattering1d
-    oversampling : int >= 0. same as scattering1d
-    average_local : bool. same as scattering1d
+    oversampling : int >=0, optional
+        if average_local is True, return scattering coefficients at the sample
+        rate max(1, 2**(log2_T-oversampling)). Hence, raising oversampling by
+        doubles the sample rate, until reaching the native sample rate.
+        if average_local is False, return first-order coefficients at the sample
+        rate max(1, 2**(j1-oversampling)) and second-order coefficients at the
+        sample rate max(1, 2**(j2-oversampling)).
+    average_local : boolean, optional
+        whether to locally average the result by means of a low-pass filter phi.
 
     Yields
     ------

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -27,8 +27,8 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     U_0(t) = x(t)
     S_0(t) = (x * phi)(t)
     U_1[n1](t) = |x * psi_{n1}|(t)
-    S_1(n1, t) = (|x * psi_{n1}| * phi)(t) broadcasted over n1
-    Y_2[n2](n1, t) = (U1 * psi_{n2})(n1, t) broadcasted over n1
+    S_1(n1, t) = (|x * psi_{n1}| * phi)(t) broadcast over n1
+    Y_2[n2](n1, t) = (U1 * psi_{n2})(n1, t) broadcast over n1
     """
     # compute the Fourier transform
     U_0_hat = backend.rfft(U_0)

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -50,7 +50,7 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     if average_local:
         # Concatenate S1 paths over the penultimate dimension with shared n1.
         # S1 is a real-valued 3D array indexed by (batch, n1, time)
-        S_1 = backend.concatenate(S_1_list, -2)
+        S_1 = backend.concatenate(S_1_list)
 
         # S1 is a stack of multiple n1 paths so we puth (-1) as placeholder.
         # n1 ranges between 0 (included) and n1_max (excluded), which we store
@@ -79,7 +79,7 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
         if len(Y_2_list) > 0:
             # Concatenate over the penultimate dimension with shared n2.
             # Y_2 is a complex-valued 3D array indexed by (batch, n1, time)
-            Y_2 = backend.concatenate(Y_2_list, -2)
+            Y_2 = backend.concatenate(Y_2_list)
 
             # Y_2 is a stack of multiple n1 paths so we put (-1) as placeholder.
             # n1 ranges between 0 (included) and n1_max (excluded), which we store

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+from kymatio.torch import Scattering1D
+
+from kymatio.scattering1d.core.scattering1d import scattering1d
+from kymatio.scattering1d.core.timefrequency_scattering import scattering1d_widthfirst
+
+backends = []
+skcuda_available = False
+try:
+    if torch.cuda.is_available():
+        from skcuda import cublas
+        import cupy
+        skcuda_available = True
+except:
+    Warning('torch_skcuda backend not available.')
+
+if skcuda_available:
+    from kymatio.scattering1d.backend.torch_skcuda_backend import backend
+    backends.append(backend)
+
+from kymatio.scattering1d.backend.torch_backend import backend
+backends.append(backend)
+
+if torch.cuda.is_available():
+    devices = ['cuda', 'cpu']
+else:
+    devices = ['cpu']
+
+
+@pytest.mark.parametrize("device", devices)
+@pytest.mark.parametrize("backend", backends)
+def test_scattering1d_widthfirst(device, backend):
+    """Checks that width-first and depth-first algorithms have same output."""
+    J = 5
+    shape = (1024,)
+    S = Scattering1D(J, shape, backend=backend).to(device)
+    x = torch.zeros(shape)
+    x[shape[0]//2] = 1
+
+    # Width-first scattering
+    x_shape = S.backend.shape(x)
+    batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
+    x = S.backend.reshape_input(x, signal_shape)
+    U_0 = S.backend.pad(x, pad_left=S.pad_left, pad_right=S.pad_right)
+    filters = [S.phi_f, S.psi1_f, S.psi2_f]
+    U_gen = scattering1d_widthfirst(U_0, S.backend, filters, S.oversampling,
+        average_local=False)
+    U_width = {path['n']: path['coef'] for path in U_gen}
+
+    # Depth-first scattering
+    U_gen = scattering1d(U_0, S.backend, S.psi1_f, S.psi2_f, S.phi_f,
+        S.oversampling, S.max_order, average=False)
+    U_depth = {path['n']: path['coef'] for path in U_gen}
+
+    # Check orders 0 and 1
+    skip_order2 = lambda item: (len(item[0]) < 2)
+    U_width_no_order2 = dict(filter(skip_order2, U_width.items()))
+    U_depth_no_order2 = dict(filter(skip_order2, U_depth.items()))
+    assert set(U_width_no_order2.keys()) == set(U_depth_no_order2.keys())
+    for key in U_width_no_order2:
+        assert torch.allclose(U_width_no_order2[key], U_depth_no_order2[key])
+
+    # Check order 2
+    keep_order2 = lambda item: (len(item[0]) == 2)
+    Y_width_order2 = dict(filter(keep_order2, U_width.items()))
+    U_depth_order2 = dict(filter(keep_order2, U_depth.items()))
+    for key in Y_width_order2:
+        n2 = key[-1]
+        keep_n2 = lambda item: (item[0][-1] == n2)
+        U_n2 = dict(filter(keep_n2, U_depth_order2.items()))
+        U_n2 = S.backend.concatenate([U_n2[key] for key in sorted(U_n2.keys())])
+        assert torch.allclose(S.backend.modulus(Y_width_order2[key]), U_n2)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -37,6 +37,7 @@ def test_scattering1d_widthfirst(device, backend):
     S = Scattering1D(J, shape, backend=backend).to(device)
     x = torch.zeros(shape)
     x[shape[0]//2] = 1
+    x = x.to(device)
 
     # Width-first scattering
     x_shape = S.backend.shape(x)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -5,39 +5,13 @@ from kymatio.torch import Scattering1D
 from kymatio.scattering1d.core.scattering1d import scattering1d
 from kymatio.scattering1d.core.timefrequency_scattering import scattering1d_widthfirst
 
-backends = []
-skcuda_available = False
-try:
-    if torch.cuda.is_available():
-        from skcuda import cublas
-        import cupy
-        skcuda_available = True
-except:
-    Warning('torch_skcuda backend not available.')
-
-if skcuda_available:
-    from kymatio.scattering1d.backend.torch_skcuda_backend import backend
-    backends.append(backend)
-
-from kymatio.scattering1d.backend.torch_backend import backend
-backends.append(backend)
-
-if torch.cuda.is_available():
-    devices = ['cuda', 'cpu']
-else:
-    devices = ['cpu']
-
-
-@pytest.mark.parametrize("device", devices)
-@pytest.mark.parametrize("backend", backends)
-def test_scattering1d_widthfirst(device, backend):
+def test_scattering1d_widthfirst():
     """Checks that width-first and depth-first algorithms have same output."""
     J = 5
     shape = (1024,)
-    S = Scattering1D(J, shape, backend=backend).to(device)
+    S = Scattering1D(J, shape)
     x = torch.zeros(shape)
     x[shape[0]//2] = 1
-    x = x.to(device)
 
     # Width-first scattering
     x_shape = S.backend.shape(x)
@@ -83,7 +57,6 @@ def test_scattering1d_widthfirst(device, backend):
 
     keep_order1 = lambda item: (len(item[0]) == 1)
     S1_width = dict(filter(keep_order1, S_width.items()))
-    print(list(S1_width.keys()))
     assert len(S1_width) == 1
     S1_width = S1_width[(-1,)]
     S1_depth = S.backend.concatenate([

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -57,8 +57,7 @@ def test_scattering1d_widthfirst():
     S_width = {path['n']: path['coef'] for path in S_gen}
 
     # Depth-first
-    S_gen = scattering1d(U_0, S.backend, S.psi1_f, S.psi2_f, S.phi_f,
-        S.oversampling, average_local)
+    S_gen = scattering1d(U_0, S.backend, filters, S.oversampling, average_local)
     S1_depth = {path['n']: path['coef'] for path in S_gen if len(path['n']) > 0}
 
     # Check order 1 (order 2 is unaveraged in width-first so irrelevant here)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -71,3 +71,20 @@ def test_scattering1d_widthfirst(device, backend):
         U_n2 = dict(filter(keep_n2, U_depth_order2.items()))
         U_n2 = S.backend.concatenate([U_n2[key] for key in sorted(U_n2.keys())])
         assert torch.allclose(S.backend.modulus(Y_width_order2[key]), U_n2)
+
+    # Local averaging
+    S_gen = scattering1d_widthfirst(U_0, S.backend, filters, S.oversampling,
+        average_local=True)
+    S_width = {path['n']: path['coef'] for path in S_gen}
+    S_gen = scattering1d(U_0, S.backend, S.psi1_f, S.psi2_f, S.phi_f,
+        S.oversampling, max_order=1, average=True)
+    S1_depth = {path['n']: path['coef'] for path in S_gen if len(path['n']) > 0}
+
+    keep_order1 = lambda item: (len(item[0]) == 1)
+    S1_width = dict(filter(keep_order1, S_width.items()))
+    print(list(S1_width.keys()))
+    assert len(S1_width) == 1
+    S1_width = S1_width[(-1,)]
+    S1_depth = S.backend.concatenate([
+        S1_depth[key] for key in sorted(S1_depth.keys())])
+    assert torch.allclose(S1_width, S1_depth)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -66,5 +66,5 @@ def test_scattering1d_widthfirst():
     assert len(S1_width) == 1
     S1_width = S1_width[(-1,)]
     S1_depth = S.backend.concatenate([
-        S1_depth[key] for key in sorted(S1_depth.keys())])
+        S1_depth[key] for key in sorted(S1_depth.keys()) if len(key)==1])
     assert torch.allclose(S1_width, S1_depth)


### PR DESCRIPTION
first step of the JTFS algorithm

Prototype:
```python
scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local)
```

yields: U0, S1 (concatenated), Y2 (concatened) if average_local is True
yields: U0, U1 (per n1), Y2 (concatenated) if average_local is false

same as scattering1d once #921 is merged

the unit test makes sure that depth-first and width-first versions of the time scattering algorithm lead to the same outcome

advice to code reviewers: it's worth to look at `core/scattering1d.py` and `core/timefrequency_scattering.py` modules in parallel to spot the meaningful similarities and differences

will document after CR is done and conflicts with other branches are resolved. the docstring will be very close to that of existing scattering1d (depth-first)