### PR TITLE
 FIX (v0.3.X backport) set `average=None` in Scattering1D frontends

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -10,7 +10,7 @@ compute_meta_scattering, precompute_size_scattering)
 
 
 class ScatteringBase1D(ScatteringBase):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True, 
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None,
                  oversampling=0, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
@@ -49,10 +49,10 @@ class ScatteringBase1D(ScatteringBase):
 
         if isinstance(self.Q, int):
             self.Q = (self.Q, 1)
-        elif isinstance(self.Q, tuple): 
+        elif isinstance(self.Q, tuple):
             if len(self.Q) == 1:
                 self.Q = self.Q + (1, )
-            elif len(self.Q) < 1 or len(self.Q) > 2: 
+            elif len(self.Q) < 1 or len(self.Q) > 2:
                 raise NotImplementedError("Q should be an integer, 1-tuple or "
                                           "2-tuple. Scattering transforms "
                                           "beyond order 2 are not implemented.")
@@ -79,18 +79,18 @@ class ScatteringBase1D(ScatteringBase):
                              "cannot exceed input length (got {} > {})".format(
                                  self.T, N_input))
         elif self.T == 0:
-            if not self.average: 
+            if not self.average:
                 self.T = 2 ** self.J
                 self.average = False
             else:
-                raise ValueError("average must not be True if T=0 " 
-                                 "(got {})".format(self.average)) 
+                raise ValueError("average must not be True if T=0 "
+                                 "(got {})".format(self.average))
         elif self.T < 1:
             raise ValueError("T must be ==0 or >=1 (got {})".format(
                              self.T))
         else:
-            self.average = True if self.average is None else self.average 
-            if not self.average: 
+            self.average = True if self.average is None else self.average
+            if not self.average:
                 raise ValueError("average=False is not permitted when T>=1, "
                                  "(got {}). average is deprecated in v0.3 in "
                                  "favour of T and will "
@@ -235,8 +235,8 @@ class ScatteringBase1D(ScatteringBase):
             averaged output corresponds to the standard scattering transform,
             while the un-averaged output skips the last convolution by
             :math:`\phi_J(t)`.  This parameter may be modified after object
-            creation. Defaults to `True`. Deprecated in v0.3 in favour of `T` 
-            and will  be removed in v0.4. Replace `average=False` by `T=0` and 
+            creation. Defaults to `True`. Deprecated in v0.3 in favour of `T`
+            and will  be removed in v0.4. Replace `average=False` by `T=0` and
             set `T>1` or leave `T=None` for `average=True` (default).
         """
 
@@ -246,7 +246,7 @@ class ScatteringBase1D(ScatteringBase):
             scattering transform) or not (resulting in wavelet modulus
             coefficients). Note that to obtain unaveraged output, the
             `vectorize` flag must be set to `False` or `out_type` must be set
-            to `'list'`. Deprecated in favor of `T`. For more details, 
+            to `'list'`. Deprecated in favor of `T`. For more details,
             see the documentation for `scattering`.
      """
 
@@ -353,9 +353,9 @@ class ScatteringBase1D(ScatteringBase):
             the maximum scale is given by :math:`2^J`.
         {param_shape}Q : int or tuple
             By default, Q (int) is the number of wavelets per octave for the first
-            order and that for the second order has one wavelet per octave. This 
+            order and that for the second order has one wavelet per octave. This
             default value can be modified by passing Q as a tuple with two values,
-            i.e. Q = (Q1, Q2), where Q1 and Q2 are the number of wavelets per 
+            i.e. Q = (Q1, Q2), where Q1 and Q2 are the number of wavelets per
             octave for the first and second order, respectively.
         T : int
             temporal support of low-pass filter, controlling amount of imposed

--- a/kymatio/scattering1d/frontend/jax_frontend.py
+++ b/kymatio/scattering1d/frontend/jax_frontend.py
@@ -11,7 +11,7 @@ class ScatteringJax1D(ScatteringJax, ScatteringNumPy1D):
     # be loaded
 
 
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None,
             oversampling=0, out_type='array', backend='jax'):
         
         ScatteringJax.__init__(self)

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -10,7 +10,7 @@ class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, T=None, max_order=2, oversampling=0):
         ScatteringKeras.__init__(self)
         ScatteringBase1D.__init__(self, J, shape=None, Q=Q, T=T, max_order=max_order,
-                average=True, oversampling=oversampling, out_type='array', backend=None)
+                average=None, oversampling=oversampling, out_type='array', backend=None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -6,7 +6,7 @@ from .base_frontend import ScatteringBase1D
 
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None,
             oversampling=0, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -7,7 +7,7 @@ from .base_frontend import ScatteringBase1D
 
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None,
             oversampling=0, out_type='array', backend='tensorflow',
                  name='Scattering1D'):
         ScatteringTensorFlow.__init__(self, name=name)

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -7,7 +7,7 @@ from .base_frontend import ScatteringBase1D
 
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=True,
+    def __init__(self, J, shape, Q=1, T=None, max_order=2, average=None,
             oversampling=0, out_type='array', backend='torch'):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(self, J, shape, Q, T, max_order, average,

--- a/tests/scattering1d/test_correctness.py
+++ b/tests/scattering1d/test_correctness.py
@@ -23,8 +23,8 @@ def test_T():
     xs = np.roll(x, shift)
 
     # make scattering objects
-    ts0 = Scattering1D(J=J, Q=Q, shape=N, T=T0, average=1, out_type='array')
-    ts1 = Scattering1D(J=J, Q=Q, shape=N, T=T1, average=1, out_type='array')
+    ts0 = Scattering1D(J=J, Q=Q, shape=N, T=T0, out_type='array')
+    ts1 = Scattering1D(J=J, Q=Q, shape=N, T=T1, out_type='array')
 
     # scatter
     ts0_x  = ts0.scattering(x)


### PR DESCRIPTION
closes https://github.com/kymatio/kymatio/issues/917

An oversight from https://github.com/kymatio/kymatio/pull/897 which closed https://github.com/kymatio/kymatio/issues/885. Many thanks to @cyrusvahidi for finding it and bringing it up.


Turns out, we have forgotten one important element: switch to the average=None by default! This causes DeprecationWarning in current user code even when they don't pass average. Worse, passing T=0 does not work because it clashes with the implicit average=True.