### PR TITLE
MAINT `parse_T` in 1d utils

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -8,7 +8,7 @@ from warnings import warn
 from ..core.scattering1d import scattering1d
 from ..filter_bank import (compute_temporal_support, gauss_1d,
     anden_generator, scattering_filter_factory)
-from ..utils import compute_border_indices, compute_padding
+from ..utils import compute_border_indices, compute_padding, parse_T
 
 
 class ScatteringBase1D(ScatteringBase):
@@ -65,24 +65,7 @@ class ScatteringBase1D(ScatteringBase):
         N_input = self.shape[0]
 
         # check T or set default
-        if self.T is None:
-            self.T = 2 ** self.J
-            self.average = 'local'
-        elif self.T == 'global':
-            self.T = 2 ** self.J
-            self.average = 'global'
-        elif self.T > N_input:
-            raise ValueError("The temporal support T of the low-pass filter "
-                "cannot exceed input length (got {} > {}). For large averaging "
-                "size, consider passing T='global'.".format(self.T, N_input))
-        elif self.T == 0:
-            self.T = 2 ** self.J
-            self.average = False
-        elif self.T < 1:
-            raise ValueError("T must be ==0 or >=1 (got {})".format(self.T))
-        else:
-            self.average = 'local'
-
+        self.T, self.average = parse_T(self.T, self.J, N_input)
         self.log2_T = math.floor(math.log2(self.T))
 
         # Compute the minimum support to pad (ideally)

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -66,3 +66,43 @@ def compute_padding(N, N_input):
     if max(pad_left, pad_right) >= N_input:
         raise ValueError('Too large padding value, will lead to NaN errors')
     return pad_left, pad_right
+
+
+def parse_T(T, J, N_input, T_alias='T'):
+    """
+    Parses T in Scattering1D base frontend.
+    Parses T and F in TimeFrequencyScattering base frontend.
+
+    Parameters
+    ----------
+    T : None, string, integer 0, or float >= 1
+        user-provided T value
+    J : int
+        user-provided J value
+    N_input : int
+        input size
+    T_alias : string
+        Used for printing error messages.
+        Typically 'T' (default) or 'F' (in TimeFrequencyScattering).
+
+    Returns
+    -------
+    T_parsed : int
+        (2**J) if T is None, zero, or 'global'; user-provided T otherwise
+    average : string
+        'global' if T is 'global'; False if T is zero; 'local' otherwise
+    """
+    if T is None:
+        return 2 ** J, 'local'
+    elif T == 'global':
+        return 2 ** J, 'global'
+    elif T > N_input:
+        raise ValueError("The support {} of the low-pass filter cannot exceed "
+            "input length (got {} > {}). For large averaging size, consider "
+            "passing {}='global'.".format(T_alias, T, N_input, T_alias))
+    elif T == 0:
+        return 2 ** J, False
+    elif T < 1:
+        raise ValueError("{} must be ==0 or >=1 (got {})".format(T_alias, T))
+    else:
+        return T, 'local'


### PR DESCRIPTION
i propose to put the self.T/self.average logic from #740 and friends into a dedicated `utils.py` function.
Advantages:
* `ScatteringBase1D.build` is more concise
* better documentation of what we're doing there. It's a 6-fold case switch so, best to be clear there
* dedicated unit tests
* will be re-usable for JTFS by passing `T_alias='F'`. Less boilerplate code