### PR TITLE
FIX JTFS `average_local=False` in `scattering1d_widthfirst`

### DIFF
--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -19,16 +19,16 @@ def scattering1d_widthfirst(U_0, backend, filters, oversampling, average_local):
     else:
         * U_0 indexed by (batch, time)
     * S_1 indexed by (batch, n1, time[log2_T])
-    * Y_2[n2=0] indexed by (batch, n1, time[j1]) and n1 s.t. j1 < j2
-    * etc. for every n2 < len(psi2)
+    for n2 < len(psi2):
+        * Y_2{n2} indexed by (batch, n1, time[j1]) and n1 s.t. j1 < j2
 
     Definitions
     -----------
     U_0(t) = x(t)
     S_0(t) = (x * phi)(t)
-    U_1[n1](t) = |x * psi_{n1}|(t)
+    U_1{n1}(t) = |x * psi_{n1}|(t)
     S_1(n1, t) = (|x * psi_{n1}| * phi)(t), conv. over t, broadcast over n1
-    Y_2[n2](n1, t) = (U_1 * psi_{n2})(n1, t), conv. over t, broadcast over n1
+    Y_2{n2}(n1, t) = (U_1 * psi_{n2})(n1, t), conv. over t, broadcast over n1
     """
     # compute the Fourier transform
     U_0_hat = backend.rfft(U_0)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -12,59 +12,40 @@ def test_scattering1d_widthfirst():
     S = Scattering1D(J, shape)
     x = torch.zeros(shape)
     x[shape[0]//2] = 1
-
-    ### average_local == False ###
-    average_local = False
-    # Width-first scattering
     x_shape = S.backend.shape(x)
     batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
     x = S.backend.reshape_input(x, signal_shape)
     U_0 = S.backend.pad(x, pad_left=S.pad_left, pad_right=S.pad_right)
-    filters = [S.phi_f, S.psi1_f, S.psi2_f]
-    U_gen = scattering1d_widthfirst(U_0, S.backend, filters, S.oversampling,
-        average_local)
-    U_width = {path['n']: path['coef'] for path in U_gen}
-
-    # Depth-first scattering
-    U_gen = scattering1d(U_0, S.backend, filters, S.oversampling, average_local)
-    U_depth = {path['n']: path['coef'] for path in U_gen}
-
-    # Check orders 0 and 1
-    skip_order2 = lambda item: (len(item[0]) < 2)
-    U_width_no_order2 = dict(filter(skip_order2, U_width.items()))
-    U_depth_no_order2 = dict(filter(skip_order2, U_depth.items()))
-    assert set(U_width_no_order2.keys()) == set(U_depth_no_order2.keys())
-    for key in U_width_no_order2:
-        assert torch.allclose(U_width_no_order2[key], U_depth_no_order2[key])
-
-    # Check order 2
-    keep_order2 = lambda item: (len(item[0]) == 2)
-    Y_width_order2 = dict(filter(keep_order2, U_width.items()))
-    U_depth_order2 = dict(filter(keep_order2, U_depth.items()))
-    for key in Y_width_order2:
-        n2 = key[-1]
-        keep_n2 = lambda item: (item[0][-1] == n2)
-        U_n2 = dict(filter(keep_n2, U_depth_order2.items()))
-        U_n2 = S.backend.concatenate([U_n2[key] for key in sorted(U_n2.keys())])
-        assert torch.allclose(S.backend.modulus(Y_width_order2[key]), U_n2)
-
-    ### average_local == True ###
-    average_local = True
 
     # Width-first
-    S_gen = scattering1d_widthfirst(U_0, S.backend, filters, S.oversampling,
-        average_local)
-    S_width = {path['n']: path['coef'] for path in S_gen}
+    filters = [S.phi_f, S.psi1_f, S.psi2_f]
+    W_gen = scattering1d_widthfirst(U_0, S.backend, filters, S.oversampling,
+        average_local=True)
+    W = {path['n']: path['coef'] for path in W_gen}
 
     # Depth-first
-    S_gen = scattering1d(U_0, S.backend, filters, S.oversampling, average_local)
+    S_gen = scattering1d(U_0, S.backend, filters, S.oversampling,
+        average_local=True)
     S1_depth = {path['n']: path['coef'] for path in S_gen if len(path['n']) > 0}
+    U_gen = scattering1d(U_0, S.backend, filters, S.oversampling,
+        average_local=False)
+    U2_depth = {path['n']: path['coef'] for path in U_gen if len(path['n']) == 2}
 
-    # Check order 1 (order 2 is unaveraged in width-first so irrelevant here)
+    # Check order 1
     keep_order1 = lambda item: (len(item[0]) == 1)
-    S1_width = dict(filter(keep_order1, S_width.items()))
+    S1_width = dict(filter(keep_order1, W.items()))
     assert len(S1_width) == 1
     S1_width = S1_width[(-1,)]
     S1_depth = S.backend.concatenate([
         S1_depth[key] for key in sorted(S1_depth.keys()) if len(key)==1])
     assert torch.allclose(S1_width, S1_depth)
+
+    # Check order 2
+    keep_order2 = lambda item: (len(item[0]) == 2)
+    Y_width_order2 = dict(filter(keep_order2, W.items()))
+    for key in Y_width_order2:
+        n2 = key[-1]
+        keep_n2 = lambda item: (item[0][-1] == n2)
+        U_n2 = dict(filter(keep_n2, U2_depth.items()))
+        U_n2 = S.backend.concatenate([U_n2[key] for key in sorted(U_n2.keys())])
+        assert torch.allclose(S.backend.modulus(Y_width_order2[key]), U_n2)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -49,3 +49,9 @@ def test_scattering1d_widthfirst():
         U_n2 = dict(filter(keep_n2, U2_depth.items()))
         U_n2 = S.backend.concatenate([U_n2[key] for key in sorted(U_n2.keys())])
         assert torch.allclose(S.backend.modulus(Y_width_order2[key]), U_n2)
+
+    # Check order 0 under average_local=False
+    W_gen = scattering1d_widthfirst(U_0, S.backend, filters, S.oversampling,
+        average_local=False)
+    U_0_width = next(W_gen)
+    assert torch.allclose(U_0_width['coef'], U_0)


### PR DESCRIPTION
So, i made a benign mistake in #923: i implemented `average_false` as yielding `U0, U1, Y2`. 
But instead it should yield `U0, S1, Y2`. 

Indeed `S1` will be passed through frequential scattering to yield `U2_phi_psi = | S1 * psi_fr |` (conv over n1, no spin)

This simplifies the logic: U1 is always averaged into S1, no matter what is the value of `average_local`. I have rewritten the tests against the depth-first implementation