### PR TITLE
ENH JTFS `_check_runtime_args`

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -588,5 +588,25 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
             "alpha": self.alpha, "r_psi": self.r_psi, "sigma0": self.sigma0}
         return spin(anden_generator, filterbank_kwargs)
 
+    def _check_runtime_args(self):
+        super(TimeFrequencyScatteringBase, self)._check_runtime_args(
+            out_types=['array', 'dict', 'list', '2D', '3D']
+        )
+
+        if not self.average and self.out_type in ['array', '2D', '3D']:
+            raise ValueError("Cannot convert to out_type='{}' with T=0. "
+                "Please set out_type to 'dict' or 'list'.".format(self.out_type))
+
+        if self.oversampling_fr < 0:
+            raise ValueError("oversampling_fr must be nonnegative. "
+                "Got: {}".format(self.oversampling_fr))
+
+        if not isinstance(self.oversampling_fr, numbers.Integral):
+            raise ValueError("oversampling_fr must be integer. "
+                "Got: {}".format(self.oversampling_fr))
+
+        if not self.average_fr and self.out_type == '3D':
+            raise ValueError("Cannot convert to out_type='3D' with F=0. "
+                             "Please set out_type to '2D', 'dict', or 'list'.")
 
 __all__ = ['ScatteringBase1D', 'TimeFrequencyScatteringBase']

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -93,7 +93,8 @@ class ScatteringBase1D(ScatteringBase):
         ScatteringBase._check_filterbanks(self.psi1_f, self.psi2_f)
 
     def scattering(self, x):
-        ScatteringBase1D._check_runtime_args(self)
+        ScatteringBase1D._check_runtime_args(
+            self, out_types=['array', 'dict', 'list'])
         ScatteringBase1D._check_input(self, x)
 
         x_shape = self.backend.shape(x)
@@ -210,10 +211,10 @@ class ScatteringBase1D(ScatteringBase):
             return tuple(Counter(self.meta()['order']).values())
         return len(self.meta()['key'])
 
-    def _check_runtime_args(self):
-        if not self.out_type in ('array', 'dict', 'list'):
-            raise ValueError("The out_type must be one of 'array', 'dict'"
-                             ", or 'list'. Got: {}".format(self.out_type))
+    def _check_runtime_args(self, out_types):
+        if not self.out_type in out_types:
+            raise ValueError("The out_type must be one of {}. Got: {}".format(
+                str(out_types), self.out_type))
 
         if not self.average and self.out_type == 'array':
             raise ValueError("Cannot convert to out_type='array' with "

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -82,6 +82,24 @@ def test_jtfs_check_runtime_args():
         S._check_runtime_args()
     assert "integer" in ve.value.args[0]
 
+    with pytest.raises(ValueError) as ve:
+        S = TimeFrequencyScatteringBase(**jtfs_kwargs, F=0, out_type='3D')
+        S.build()
+        S._check_runtime_args()
+    assert "Cannot convert" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        S = TimeFrequencyScatteringBase(**jtfs_kwargs, oversampling_fr=-1)
+        S.build()
+        S._check_runtime_args()
+    assert "nonnegative" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        S = TimeFrequencyScatteringBase(**jtfs_kwargs, oversampling_fr=0.5)
+        S.build()
+        S._check_runtime_args()
+    assert "integer" in ve.value.args[0]
+
 
 
 

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -56,6 +56,35 @@ def test_jtfs_create_filters():
     assert phi['N'] == jtfs._N_padded_fr
 
 
+def test_jtfs_check_runtime_args():
+    jtfs_kwargs = dict(J=10, J_fr=3, shape=4096, Q=8, backend='torch')
+    with pytest.raises(ValueError) as ve:
+        S = TimeFrequencyScatteringBase(**jtfs_kwargs, out_type='doesnotexist')
+        S._check_runtime_args()
+    assert "out_type must be one" in ve.value.args[0]
+
+    for out_type in ['array', '2D', '3D']:
+        with pytest.raises(ValueError) as ve:
+            S = TimeFrequencyScatteringBase(**jtfs_kwargs, T=0, out_type=out_type)
+            S.build()
+            S._check_runtime_args()
+        assert "Cannot convert" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        S = TimeFrequencyScatteringBase(**jtfs_kwargs, oversampling=-1)
+        S.build()
+        S._check_runtime_args()
+    assert "nonnegative" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        S = TimeFrequencyScatteringBase(**jtfs_kwargs, oversampling=0.5)
+        S.build()
+        S._check_runtime_args()
+    assert "integer" in ve.value.args[0]
+
+
+
+
 def test_scattering1d_widthfirst():
     """Checks that width-first and depth-first algorithms have same output."""
     J = 5

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -491,6 +491,12 @@ def test_check_runtime_args(device, backend):
         S(x)
     assert "nonnegative" in ve.value.args[0]
 
+    with pytest.raises(ValueError) as ve:
+        S = Scattering1D(J, shape, oversampling=0.5, backend=backend,
+                         frontend='torch').to(device)
+        S(x)
+    assert "integer" in ve.value.args[0]
+
 
 def test_Scattering1D_average_global():
     """


### PR DESCRIPTION
The beginning of `TimeFrequencyScatteringBase.scattering` will be:

```python
def scattering(self, x):
    TimeFrequencyScatteringBase._check_runtime_args(self)
    TimeFrequencyScatteringBase._check_input(self, x)

    x_shape = self.backend.shape(x)
    batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
    x = self.backend.reshape_input(x, signal_shape)
    U_0 = self.backend.pad(x, pad_left=self.pad_left, pad_right=self.pad_right)
```

This PR adds the checks for `average_fr`, `oversampling_fr`, and `out_types`.
the out_types i am anticipating are:
* 2D: batch, path, time (just like Scattering1D). includes zeroth order
* 3D: batch, second-order path, frequency, time. excludes zeroth order
* array: tries 3D if possible, otherwise falls back to 2D (this will be the default)
* dict: keys will be () at zeroth order, (n1,) at first order, and (n1, (n2, n_fr)) at second order. the unspinned phi-psi pair will be represented by n2=-1.
* list: all paths concatenated, including metadata.

2D requires T≠0 (i.e. some form of averaging, whether local or global)
3D requires both T≠0 and F≠0.

~Note that i am not anticipating `oversampling='full'` or `oversampling_fr='full'`, which may allow 3D concatenation despite T=0 and/or F=0. This might come as a later feature if someone requests it, but i don't want to complicate the runtime logic too much at this stage.~ (see #937)