### PR TITLE
FIX `oversampling>0` in `ScatteringBase1D.scattering`

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -114,7 +114,7 @@ class ScatteringBase1D(ScatteringBase):
         for path in S_gen:
             path['order'] = len(path['n'])
             if self.average == 'local':
-                res = self.log2_T
+                res = max(self.log2_T - self.oversampling, 0)
             elif path['order']>0:
                 res = max(path['j'][-1] - self.oversampling, 0)
             else:

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -422,14 +422,16 @@ def test_T(device, backend):
     Sg0 = scattering0(x)
     Sg1 = scattering1(x)
     assert torch.allclose(Sg0, Sx0)
-    assert Sg1.shape == (Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**(sigma_low_scale_factor))
+    assert Sg1.shape == (Sg0.shape[0], Sg0.shape[1],
+        Sg0.shape[2]*(2**sigma_low_scale_factor))
 
     # adjust oversampling
     oversampling = 1
     scattering2 = Scattering1D(J, N, Q, backend=backend,
         frontend='torch', oversampling=oversampling).to(device)
-    Sg2 = scattering1(x)
-    assert Sg2.shape == (Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**oversampling)
+    Sg2 = scattering2(x)
+    assert Sg2.shape == (Sg0.shape[0], Sg0.shape[1],
+        Sg0.shape[2]*(2**oversampling))
 
 
 @pytest.mark.parametrize("device", devices)

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -424,6 +424,13 @@ def test_T(device, backend):
     assert torch.allclose(Sg0, Sx0)
     assert Sg1.shape == (Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**(sigma_low_scale_factor))
 
+    # adjust oversampling
+    oversampling = 1
+    scattering2 = Scattering1D(J, N, Q, backend=backend,
+        frontend='torch', oversampling=oversampling).to(device)
+    Sg2 = scattering1(x)
+    assert Sg2.shape == (Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**oversampling)
+
 
 @pytest.mark.parametrize("device", devices)
 @pytest.mark.parametrize("backend", backends)


### PR DESCRIPTION
Triggers and fixes a bug in `oversampling>0` (non-default), introduced by #937 a few days ago.