### PR TITLE
ENH JTFS `frequency_averaging`

### DIFF
--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -282,7 +282,7 @@ def frequency_scattering(X, backend, filters_fr, oversampling_fr,
         # as (X['n'][1:] + (n_fr,)), i.e., n=(n_fr,) is not spinned
         # and n=(n2, n_fr) if spinned. This 'n' tuple is unique.
         yield {**X, 'coef': Y_fr, 'n': (X['n'][1:] + (n_fr,)),
-            'j_fr': j_fr, 'n_fr': n_fr, 'spin': spin}
+            'j_fr': (j_fr,), 'n_fr': (n_fr,), 'spin': spin}
 
 
 def time_averaging(U_2, backend, phi_f, oversampling):

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -361,10 +361,10 @@ def frequency_averaging(U_2, backend, phi_fr_f, oversampling_fr):
     """
     log2_F = phi_fr_f['j']
     k_in = U_2['j_fr'][-1]
-    k_J = max(log2_F - k_in - oversampling, 0)
+    k_J = max(log2_F - k_in - oversampling_fr, 0)
     U_2_T = backend.swap_time_frequency(U_2['coef'])
     U_hat = backend.rfft(U_2_T)
-    S_c = backend.cdgmm(U_hat, phi_f['levels'][k_in])
+    S_c = backend.cdgmm(U_hat, phi_fr_f['levels'][k_in])
     S_hat = backend.subsample_fourier(S_c, 2 ** k_J)
     S_2_T = backend.irfft(S_hat)
     S_2 = backend.swap_time_frequency(S_2_T)

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -382,5 +382,5 @@ def frequency_averaging(U_2, backend, phi_fr_f, oversampling_fr):
         S_2 = backend.swap_time_frequency(S_2_T)
         return {**U_2, 'coef': S_2, 'n1_stride': n1_stride}
     elif not average_fr:
-        n1_stride = 2**max(log2_F - oversampling_fr, 0)
+        n1_stride = 2**max(U_2['j_fr'][-1] - oversampling_fr, 0)
         return {**U_2, 'n1_stride': n1_stride}

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -327,7 +327,7 @@ def time_averaging(U_2, backend, phi_f, oversampling):
     return {**U_2, 'coef': S_2}
 
 
-def frequency_averaging(U_2, backend, phi_fr_f, oversampling_fr):
+def frequency_averaging(U_2, backend, phi_fr_f, oversampling_fr, average_fr):
     """
     Parameters
     ----------

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -148,7 +148,7 @@ def test_frequency_scattering():
         jtfs.oversampling_fr, jtfs.average_fr=='local', spinned=False)
     for Y_fr in freq_gen:
         assert Y_fr['spin'] >= 0
-        assert Y_fr['n'] == (Y_fr['n_fr'],)
+        assert Y_fr['n'] == Y_fr['n_fr']
 
     # spinned=True
     X['coef'] = X['coef'].astype('complex64')
@@ -157,7 +157,7 @@ def test_frequency_scattering():
         jtfs.oversampling_fr, jtfs.average_fr=='local', spinned=True)
     for Y_fr in freq_gen:
         assert Y_fr['coef'].shape[-1] == X['coef'].shape[-1]
-        assert Y_fr['n'] == (4, Y_fr['n_fr'])
+        assert Y_fr['n'] == ((4,) + Y_fr['n_fr'])
 
 
 def test_joint_timefrequency_scattering():
@@ -223,7 +223,7 @@ def test_joint_timefrequency_scattering():
         assert (path['coef'].shape[-1]*stride) == S._N_padded
 
         # Check that frequential stride works as intended
-        stride_fr = 2**max(path['j_fr'] - S.oversampling_fr, 0)
+        stride_fr = 2**max(path['j_fr'][0] - S.oversampling_fr, 0)
         assert (path['coef'].shape[-2]*stride_fr) == S._N_padded_fr
 
         # Check that padding is sufficient
@@ -245,7 +245,7 @@ def test_joint_timefrequency_scattering():
         assert (path['coef'].shape[-1]*stride) == S._N_padded
 
         # Check that frequential stride works as intended
-        stride_fr = 2**max(path['j_fr'] - S.oversampling_fr, 0)
+        stride_fr = 2**max(path['j_fr'][0] - S.oversampling_fr, 0)
         assert (path['coef'].shape[-2]*stride_fr) == S._N_padded_fr
 
         # Check that padding is sufficient

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -157,7 +157,7 @@ def test_frequency_scattering():
         jtfs.oversampling_fr, jtfs.average_fr=='local', spinned=True)
     for Y_fr in freq_gen:
         assert Y_fr['coef'].shape[-1] == X['coef'].shape[-1]
-        assert Y_fr['n'] == ((4,) + Y_fr['n_fr'])
+        assert Y_fr['n'] == (4,) + Y_fr['n_fr']
 
 
 def test_joint_timefrequency_scattering():

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -266,7 +266,7 @@ def test_joint_timefrequency_scattering():
         S.average_fr = 'local'
         U_2 = {**path, 'coef': backend.modulus(path['coef'])}
         S_2 = frequency_averaging(
-            U_2, backend, S.filters_fr[0], S.oversampling_fr)
+            U_2, backend, S.filters_fr[0], S.oversampling_fr, S.average_fr)
 
         # Check that averaged coefficients have the same frequential stride
         stride_fr = 2**max(S.log2_F - S.oversampling_fr, 0)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -263,14 +263,30 @@ def test_joint_timefrequency_scattering():
         assert (S_2['coef'].shape[-1]*stride) == S._N_padded
         
         # Test frequential averaging
-        S.average_fr = 'local'
         U_2 = {**path, 'coef': backend.modulus(path['coef'])}
+
+        # average_fr == 'local'
+        S.average_fr = 'local'
         S_2 = frequency_averaging(
             U_2, backend, S.filters_fr[0], S.oversampling_fr, S.average_fr)
-
-        # Check that averaged coefficients have the same frequential stride
         stride_fr = 2**max(S.log2_F - S.oversampling_fr, 0)
+        assert S_2['n1_stride'] == stride_fr
         assert (S_2['coef'].shape[-2]*stride_fr) == S._N_padded_fr
+
+        # average_fr == 'global'
+        S.average_fr = 'global'
+        S_2 = frequency_averaging(
+            U_2, backend, S.filters_fr[0], S.oversampling_fr, S.average_fr)
+        assert S_2['n1_stride'] == S_2['n1_max']
+        assert S_2['coef'].shape[-2] == 1
+
+        # average_fr == False
+        S.average_fr = False
+        S_2 = frequency_averaging(
+            U_2, backend, S.filters_fr[0], S.oversampling_fr, S.average_fr)
+        stride_fr = 2**max(S_2['j_fr'][0] - S.oversampling_fr, 0)
+        assert S_2['n1_stride'] == stride_fr
+        assert np.allclose(S_2['coef'], U_2['coef'])
 
     # Check that second-order spins are mirrors of each other
     for path in S2_jtfs:

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -7,7 +7,7 @@ from kymatio.scattering1d.core.scattering1d import scattering1d
 from kymatio.scattering1d.filter_bank import compute_temporal_support, gauss_1d
 from kymatio.scattering1d.core.timefrequency_scattering import (
     joint_timefrequency_scattering, time_scattering_widthfirst,
-    frequency_scattering, time_averaging)
+    frequency_scattering, time_averaging, frequency_averaging)
 from kymatio.scattering1d.frontend.base_frontend import TimeFrequencyScatteringBase
 
 
@@ -261,6 +261,16 @@ def test_joint_timefrequency_scattering():
         # Check that averaged coefficients have the same temporal stride
         stride = 2**max(S.log2_T - S.oversampling, 0)
         assert (S_2['coef'].shape[-1]*stride) == S._N_padded
+        
+        # Test frequential averaging
+        S.average_fr = 'local'
+        U_2 = {**path, 'coef': backend.modulus(path['coef'])}
+        S_2 = frequency_averaging(
+            U_2, backend, S.filters_fr[0], S.oversampling_fr)
+
+        # Check that averaged coefficients have the same frequential stride
+        stride_fr = 2**max(S.log2_F - S.oversampling_fr, 0)
+        assert (S_2['coef'].shape[-2]*stride_fr) == S._N_padded_fr
 
     # Check that second-order spins are mirrors of each other
     for path in S2_jtfs:


### PR DESCRIPTION
#945's frequential sibling

while writing this i found a metadata bug in `frequency_scattering` (#935), i.e. that we were returning `j_fr` and `n_fr` as integers instead of 1-tuples. This was unnecessarily inconsistent with first-order time scattering. So i fixed that and updated the tests. 

This is the last element of core JTFS. When #945 and this PR will be merged, i'll be able to work on a `scattering` method for the base frontend.