### PR TITLE
ENH JTFS `TimeFrequencyScatteringBase.scattering`

### DIFF
--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -72,8 +72,8 @@ def joint_timefrequency_scattering(U_0, backend, filters, oversampling,
     S_1 = next(time_gen)
 
     # Y_1_fr_{n_fr}(n1, t[log2_T]) = (|x*psi_{n1}|*phi*psi_{n_fr})(t[log2_T])
-    yield from frequency_scattering(S_1, backend, filters_fr, average_local_fr,
-        oversampling_fr, spinned=False)
+    yield from frequency_scattering(S_1, backend,
+        filters_fr, oversampling_fr, average_local_fr, spinned=False)
 
     # Second order: Y_2_{n2}(t[log2_T], n1[j_fr])
     #                   = (|x*psi_{n1}|*psi_{n2})(t[j2], n1[j_fr])
@@ -82,7 +82,7 @@ def joint_timefrequency_scattering(U_0, backend, filters, oversampling,
         # Y_2_fr_{n2,n_fr}(t[j2], n1[j_fr])
         #     = (|x*psi_{n1}|*psi_{n2}*psi_{n_fr})(t[j2], n1[j_fr])
         yield from frequency_scattering(Y_2, backend, filters_fr,
-            average_local_fr, oversampling_fr, spinned=True)
+            oversampling_fr, average_local_fr, spinned=True)
 
 
 def time_scattering_widthfirst(U_0, backend, filters, oversampling, average_local):

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -620,11 +620,15 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
             # Temporal averaging and unpadding. Switch cases:
             # 1. If averaging is global, no need for unpadding at all.
             # 2. If averaging is local, averaging depends on order:
-            #     2a. at order 1, unpad at resolution log2_T
-            #     2b. at order 2, average and unpad at resolution log2_T
+            #     2a. at order 1, S_gen yields
+            #               Y_1_fr = S_1 * psi_{n_fr}
+            #         unpad at resolution log2_T
+            #     2b. at order 2, S_gen yields
+            #               Y_2_fr = U_1 * psi_{n2} * psi_{n_fr}
+            #         average and unpad at resolution log2_T
             # 3. If there is no averaging, unpadding depends on order:
-            #     3a. at order 1, unpad at resolution log2_T
-            #     3b. at order 2, unpad at resolution j2
+            #     3a. at order 1, unpad Y_1_fr at resolution log2_T
+            #     3b. at order 2, unpad Y_2_fr at resolution j2
             # (for simplicity, we assume oversampling=0 in the rationale above,
             #  but the implementation below works for any value of oversampling)
             if self.average == 'global':

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -581,6 +581,10 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         # Check for absence of aliasing
         assert all((abs(psi1["xi"]) < 0.5/(2**psi1["j"])) for psi1 in psis_fr_f)
 
+    def scattering(self, x):
+        TimeFrequencyScatteringBase._check_runtime_args(self)
+        TimeFrequencyScatteringBase._check_input(self, x)
+
     def _check_runtime_args(self):
         super(TimeFrequencyScatteringBase, self)._check_runtime_args()
 

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -1,7 +1,7 @@
 import warnings
 
 from ...frontend.numpy_frontend import ScatteringNumPy
-from .base_frontend import ScatteringBase1D
+from .base_frontend import ScatteringBase1D, TimeFrequencyScatteringBase
 
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
@@ -17,4 +17,19 @@ class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
 ScatteringNumPy1D._document()
 
 
-__all__ = ['ScatteringNumPy1D']
+class TimeFrequencyScatteringNumPy(
+        ScatteringNumPy1D, TimeFrequencyScatteringBase):
+    def __init__(self, *, J, J_fr, shape, Q, T=None, oversampling=0, Q_fr=1,
+            F=None, oversampling_fr=0, out_type='array', backend='numpy'):
+        ScatteringNumPy.__init__(self)
+        TimeFrequencyScatteringBase.__init__(self, J=J, J_fr=J_fr, shape=shape,
+            Q=Q, T=T, oversampling=oversampling, Q_fr=Q_fr, F=F,
+            oversampling_fr=oversampling_fr, out_type=out_type, backend=backend)
+        ScatteringBase1D._instantiate_backend(
+            self, 'kymatio.scattering1d.backend.')
+        TimeFrequencyScatteringBase.build(self)
+        TimeFrequencyScatteringBase.create_filters(self)
+
+TimeFrequencyScatteringNumPy._document()
+
+__all__ = ['ScatteringNumPy1D', 'TimeFrequencyScatteringNumPy']

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -9,6 +9,7 @@ from kymatio.scattering1d.core.timefrequency_scattering import (
     joint_timefrequency_scattering, time_scattering_widthfirst,
     frequency_scattering, time_averaging, frequency_averaging)
 from kymatio.scattering1d.frontend.base_frontend import TimeFrequencyScatteringBase
+from kymatio.scattering1d.frontend.numpy_frontend import TimeFrequencyScatteringNumPy
 
 
 def test_jtfs_build():
@@ -352,3 +353,10 @@ def test_joint_timefrequency_scattering():
     S2_neg = filter(lambda path: path['spin']<0, S2_jtfs)
     assert len(list(S2_pos)) == len(list(S2_neg))
     assert set(S2_pos) == set(S2_neg)
+
+
+def test_jtfs_numpy():
+    # Test __init__
+    S = TimeFrequencyScatteringNumPy(
+        J=10, J_fr=3, shape=4096, Q=8, backend='numpy')
+    assert S.F == (2 ** S.J_fr)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -361,34 +361,12 @@ def test_jtfs_numpy():
     J_fr = 3
     shape = (1024,)
     Q = 3
-    S = TimeFrequencyScatteringNumPy(J=J, J_fr=J_fr,
-        shape=shape, Q=Q, out_type='list')
+    S = TimeFrequencyScatteringNumPy(J=J, J_fr=J_fr, shape=shape, Q=Q)
     assert S.F == (2 ** S.J_fr)
 
     x = torch.zeros(shape)
     x[shape[0]//2] = 1
     Sx = S(x)
 
-    # Check that all path keys are unique
-    ns = [path['n'] for path in Sx]
-    assert len(ns) == len(set(ns))
-
-    # Check that order 1 comes before order 2
-    orders = [len(path['n']) for path in Sx]
-    assert set(orders) == {0, 1, 2}
-    assert orders == sorted(orders)
-
-    # Check that coefficients are NumPy arrays
-    assert all([isinstance(path['coef'], np.ndarray) for path in Sx])
-
-    # Test T='global'
-    S = TimeFrequencyScatteringNumPy(J=J, J_fr=J_fr,
-        shape=shape, Q=Q, out_type='list', T='global')
-    Sx = S(x)
-    assert all([(path['coef'].shape[-1] == 1) for path in Sx])
-
-    # Test T=0, F=0
-    S = TimeFrequencyScatteringNumPy(J=J, J_fr=J_fr, oversampling=0,
-        shape=shape, Q=Q, out_type='list', T=0, F=0)
-    Sx = S(x)
-    assert all([(path['coef']>=0).all() for path in Sx])
+    assert isinstance(Sx, np.ndarray)
+    assert Sx.ndim == 3

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -357,6 +357,38 @@ def test_joint_timefrequency_scattering():
 
 def test_jtfs_numpy():
     # Test __init__
-    S = TimeFrequencyScatteringNumPy(
-        J=10, J_fr=3, shape=4096, Q=8, backend='numpy')
+    J = 8
+    J_fr = 3
+    shape = (1024,)
+    Q = 3
+    S = TimeFrequencyScatteringNumPy(J=J, J_fr=J_fr,
+        shape=shape, Q=Q, out_type='list')
     assert S.F == (2 ** S.J_fr)
+
+    x = torch.zeros(shape)
+    x[shape[0]//2] = 1
+    Sx = S(x)
+
+    # Check that all path keys are unique
+    ns = [path['n'] for path in Sx]
+    assert len(ns) == len(set(ns))
+
+    # Check that order 1 comes before order 2
+    orders = [len(path['n']) for path in Sx]
+    assert set(orders) == {0, 1, 2}
+    assert orders == sorted(orders)
+
+    # Check that coefficients are NumPy arrays
+    assert all([isinstance(path['coef'], np.ndarray) for path in Sx])
+
+    # Test T='global'
+    S = TimeFrequencyScatteringNumPy(J=J, J_fr=J_fr,
+        shape=shape, Q=Q, out_type='list', T='global')
+    Sx = S(x)
+    assert all([(path['coef'].shape[-1] == 1) for path in Sx])
+
+    # Test T=0, F=0
+    S = TimeFrequencyScatteringNumPy(J=J, J_fr=J_fr, oversampling=0,
+        shape=shape, Q=Q, out_type='list', T=0, F=0)
+    Sx = S(x)
+    assert all([(path['coef']>=0).all() for path in Sx])

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -357,16 +357,23 @@ def test_joint_timefrequency_scattering():
 
 def test_jtfs_numpy():
     # Test __init__
+    kwargs = {"J": 8, "J_fr": 3, "shape": (1024,), "Q": 3}
     J = 8
     J_fr = 3
     shape = (1024,)
     Q = 3
-    S = TimeFrequencyScatteringNumPy(J=J, J_fr=J_fr, shape=shape, Q=Q)
+    x = torch.zeros(kwargs["shape"])
+    x[kwargs["shape"][0]//2] = 1
+
+    # Local averaging
+    S = TimeFrequencyScatteringNumPy(**kwargs)
     assert S.F == (2 ** S.J_fr)
-
-    x = torch.zeros(shape)
-    x[shape[0]//2] = 1
     Sx = S(x)
-
     assert isinstance(Sx, np.ndarray)
     assert Sx.ndim == 3
+
+    # Global averaging
+    S = TimeFrequencyScatteringNumPy(T='global', **kwargs)
+    Sx = S(x)
+    assert Sx.ndim == 3
+    assert Sx.shape[-1] == 1


### PR DESCRIPTION
NumPy frontend and tests

The implementation of JTFS is now complete in NumPy for the default parameters: `out_type='array'` and `format='joint'`.
Supporting other `out_type`'s (`dict` and `list`) will require another Kymatio primitive: `backend.unpad_frequency`.
Supporting `format='time'` will require another Kymatio primitive: `backend.split`.

I am raising`NotImplementedError`'s where these primitive calls need to happen.
This PR adds some missed lines and thus reduces the test coverage. This is only temporary: test coverage will go back up once we implement `unpad_frequency` and `split` + corresponding tests.

NB. while writing this i found out a bug in `frequency_scattering` callsites (#935). `average_fr` and `oversampling` were being mixed up. This PR fixes the bug. 
