### PR TITLE
ENH JTFS `meta()`, `out_type='dict'`, `out_type='list'`

### DIFF
--- a/kymatio/frontend/base_frontend.py
+++ b/kymatio/frontend/base_frontend.py
@@ -56,4 +56,4 @@ class ScatteringBase():
         raise NotImplementedError
 
     class _DryBackend:
-        __getattr__ = lambda self, attr: (lambda *args: None)
+        __getattr__ = lambda self, attr: (lambda *args, **kwargs: None)

--- a/kymatio/frontend/base_frontend.py
+++ b/kymatio/frontend/base_frontend.py
@@ -54,3 +54,6 @@ class ScatteringBase():
         will create the filters as numpy array, and then, it should
         save those arrays. """
         raise NotImplementedError
+
+    class _DryBackend:
+        __getattr__ = lambda self, attr: (lambda *args: None)

--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -121,4 +121,9 @@ class NumpyBackend1D(NumpyBackend):
     def swap_time_frequency(cls, x):
         return cls._np.moveaxis(x, source=(-1, -2), destination=(-2, -1))
 
+    @classmethod
+    def unpad_frequency(cls, x, n1_max, n1_stride):
+        n1_unpadded = 1 + (n1_max//n1_stride)
+        return x[..., :n1_unpadded, :]
+
 backend = NumpyBackend1D

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -429,10 +429,8 @@ def jtfs_average_and_format(U_gen, backend, phi_f, oversampling, average,
 
         # Frequential unpadding.
         if not (out_type == 'array' and format == 'joint'):
-            raise NotImplementedError
-        #     # TODO unpad_frequency
-        #     path['coef'] = backend.unpad_frequency(path['coef'],
-        #         path['n1_max'], path['n1_stride'])
+            path['coef'] = backend.unpad_frequency(
+                path['coef'], path['n1_max'], path['n1_stride'])
 
         # Splitting and reshaping
         if format == 'joint':

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -282,7 +282,8 @@ def frequency_scattering(X, backend, filters_fr, oversampling_fr,
         # as (X['n'][1:] + (n_fr,)), i.e., n=(n_fr,) is not spinned
         # and n=(n2, n_fr) if spinned. This 'n' tuple is unique.
         yield {**X, 'coef': Y_fr, 'n': (X['n'][1:] + (n_fr,)),
-            'j_fr': (j_fr,), 'n_fr': (n_fr,), 'spin': spin}
+            'j_fr': (j_fr,), 'n_fr': (n_fr,), 'n1_stride': (2**j_fr),
+            'spin': spin}
 
 
 def time_averaging(U_2, backend, phi_f, oversampling):

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -384,3 +384,59 @@ def frequency_averaging(U_2, backend, phi_fr_f, oversampling_fr, average_fr):
     elif not average_fr:
         n1_stride = 2**max(U_2['j_fr'][-1] - oversampling_fr, 0)
         return {**U_2, 'n1_stride': n1_stride}
+
+
+def jtfs_average_and_format(U_gen, backend, phi_f, oversampling, average,
+        phi_fr_f, oversampling_fr, average_fr, out_type, format):
+    # Zeroth order
+    path = next(U_gen)
+    log2_T = phi_f['j']
+    if average == 'global':
+        path['coef'] = backend.average_global(path['coef'])
+    yield {**path, 'order': 0}
+
+    # First and second order
+    for path in U_gen:
+        # "The phase of the integrand must be set to a constant. This
+        # freedom in setting the stationary phase to an arbitrary constant
+        # value suggests the existence of a gauge boson" — Glinsky
+        path['coef'] = backend.modulus(path['coef'])
+
+        # Temporal averaging. Switch cases:
+        # 1. If averaging is global, no need for unpadding at all.
+        # 2. If averaging is local, averaging depends on order:
+        #     2a. at order 1, U_gen yields
+        #               Y_1_fr = S_1 * psi_{n_fr}
+        #         no need for further averaging
+        #     2b. at order 2, U_gen yields
+        #               Y_2_fr = U_1 * psi_{n2} * psi_{n_fr}
+        #         average with phi
+        # (for simplicity, we assume oversampling=0 in the rationale above,
+        #  but the implementation below works for any value of oversampling)
+        if average == 'global':
+            # Case 1.
+            path['coef'] = backend.average_global(path['coef'])
+        elif average == 'local' and len(path['n']) > 1:
+            # Case 2b.
+            path = time_averaging(path, backend, phi_f, oversampling)
+
+        # Frequential averaging. NB. if spin==0, U_gen is already averaged.
+        # Hence, we only average if spin!=0, i.e. psi_{n_fr} in path.
+        if average_fr and not path['spin'] == 0:
+            path = frequency_averaging(path, backend,
+                phi_fr_f, oversampling_fr, average_fr)
+
+        # Frequential unpadding.
+        if not (out_type == 'array' and format == 'joint'):
+            raise NotImplementedError
+        #     # TODO unpad_frequency
+        #     path['coef'] = backend.unpad_frequency(path['coef'],
+        #         path['n1_max'], path['n1_stride'])
+
+        # Splitting and reshaping
+        if format == 'joint':
+            yield {**path, 'order': len(path['n'])}
+        elif format == 'time':
+            raise NotImplementedError
+        #     # TODO split
+        #     yield from self.backend.split(path)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -177,8 +177,9 @@ class ScatteringBase1D(ScatteringBase):
         """
         backend = self._DryBackend()
         filters = [self.phi_f, self.psi1_f, self.psi2_f][:(1+self.max_order)]
-        S = scattering1d(None, backend, filters, self.oversampling, average_local=False)
-        S = sorted(list(S), key=lambda path: (len(path['n']), path['n']))
+        S_gen = scattering1d(
+            None, backend, filters, self.oversampling, average_local=False)
+        S = sorted(list(S_gen), key=lambda path: (len(path['n']), path['n']))
         meta = dict(order=np.array([len(path['n']) for path in S]))
         meta['key'] = [path['n'] for path in S]
         meta['n'] = np.stack([np.append(
@@ -655,6 +656,18 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         #     return {path['n']: path['coef'] for path in S}
         # elif (self.out_type == 'list'):
         #     return S
+
+    def meta(self):
+        backend = self._DryBackend()
+        filters = [self.phi_f, self.psi1_f, self.psi2_f]
+        U_gen = joint_timefrequency_scattering(None, backend,
+            filters, self.oversampling, self.average=='local',
+            self.filters_fr, self.oversampling_fr, self.average_fr=='local')
+        S_gen = jtfs_average_and_format(U_gen, backend,
+            self.phi_f, self.oversampling, self.average,
+            self.filters_fr[0], self.oversampling_fr, self.average_fr,
+            self.out_type, self.format)
+        S = sorted(list(S_gen), key=lambda path: (len(path['n']), path['n']))
 
     def _check_runtime_args(self):
         super(TimeFrequencyScatteringBase, self)._check_runtime_args()

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -175,11 +175,9 @@ class ScatteringBase1D(ScatteringBase):
                 The tuples indexing the corresponding scattering coefficient
                 in the non-vectorized output.
         """
-        class DryBackend:
-            __getattr__ = lambda self, attr: (lambda *args: None)
-
+        backend = self._DryBackend()
         filters = [self.phi_f, self.psi1_f, self.psi2_f][:(1+self.max_order)]
-        S = scattering1d(None, DryBackend(), filters, self.oversampling, average_local=False)
+        S = scattering1d(None, backend, filters, self.oversampling, average_local=False)
         S = sorted(list(S), key=lambda path: (len(path['n']), path['n']))
         meta = dict(order=np.array([len(path['n']) for path in S]))
         meta['key'] = [path['n'] for path in S]

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -644,8 +644,11 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
             # Concatenate first and second order into a 4D tensor:
             # (batch, n_jtfs, freq, time) where n_jtfs aggregates (n2, n_fr)
             return self.backend.concatenate([path['coef'] for path in S], dim=-3)
-        else:
-            raise NotImplementedError
+        elif self.out_type == 'dict':
+            return {path['n']: path['coef'] for path in S}
+        elif self.out_type == 'list':
+            return S
+
 
     def meta(self):
         backend = self._DryBackend()

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -647,16 +647,6 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         else:
             raise NotImplementedError
 
-        # TODO
-        # # Sort paths by order and then by key 'n' (tuple)
-        # # Order 0: n=(). Order 1: n=(n1, n_fr). Order 2: n=(n1, n2, n_fr)
-        # S.sort(key=(lambda path: (path['order'], path['n'])))
-        #
-        # if (self.out_type == 'dict'):
-        #     return {path['n']: path['coef'] for path in S}
-        # elif (self.out_type == 'list'):
-        #     return S
-
     def meta(self):
         backend = self._DryBackend()
         filters = [self.phi_f, self.psi1_f, self.psi2_f]
@@ -692,7 +682,6 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
                     # Second order and format='time': n=(n1, n2, n_fr)
                     meta['n'].append([path['n'][2:]])
                 meta['n_fr'].append(path['n_fr'][0])
-        meta['n'] = np.stack(meta['n'])
         meta['n_fr'] = np.array(meta['n_fr'])
         for key in ['xi', 'sigma', 'j']:
             meta[key] = np.zeros((meta['n_fr'].shape[0], 2)) * np.nan

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -244,7 +244,7 @@ def test_joint_timefrequency_scattering():
     jtfs_gen = joint_timefrequency_scattering(U_0_in, backend,
         filters, S.oversampling, S.average=='local',
         S.filters_fr, S.oversampling_fr, S.average_fr=='local')
-    path_keys = ['coef', 'j', 'n', 'n1_max', 'j_fr', 'n_fr', 'spin']
+    path_keys = ['coef', 'j', 'n', 'n1_max', 'n1_stride', 'j_fr', 'n_fr', 'spin']
 
     # Zeroth order
     U_0 = next(jtfs_gen)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -419,3 +419,12 @@ def test_jtfs_numpy():
     Sx = S(x)
     assert Sx.ndim == 3
     assert Sx.shape[-1] == 1
+
+    # Dictionary output
+    S = TimeFrequencyScatteringNumPy(out_type='dict', **kwargs)
+    Sx = S(x)
+
+    # List output
+    S = TimeFrequencyScatteringNumPy(out_type='list', T=0, F=0, **kwargs)
+    Sx = S(x)
+    assert all([path['coef'].ndim==2 for path in Sx if path['order']>0])


### PR DESCRIPTION
Use of the `DryBackend` in JTFS ! (same as in #914)

Plus:
* `unpad_frequency`
* better `meta` information from `frequency_scattering` (including `n1_stride`)
* a new core JTFS function, `jtfs_average_and_format`, which takes care of the logic behind `average_global`, `time_averaging`, `frequency_averaging`, and `unpad_frequency`. Shortens and simplifies the `base_frontend`
* `out_type='dict'` and `out_type='list'` are now supported and tested. Coefficients in the dict / list are unpadded in frequency. (according to `n1_max` and `n1_stride` metadata)

Future work: 
* `format == 'time'` while require a new primitive, `backend.split`. Right now it raises a `NotImplementedError` in `jtfs_average_and_format`. This is next