### PR TITLE
ENH JTFS `format="time"`

### DIFF
--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -126,4 +126,8 @@ class NumpyBackend1D(NumpyBackend):
         n1_unpadded = 1 + (n1_max // n1_stride)
         return x[..., :n1_unpadded, :]
 
+    @staticmethod
+    def split_frequency_axis(cls, x):
+        return cls._np.split(x, indices_or_sections=x.shape[-2], axis=-2)
+
 backend = NumpyBackend1D

--- a/kymatio/scattering1d/backend/numpy_backend.py
+++ b/kymatio/scattering1d/backend/numpy_backend.py
@@ -126,7 +126,7 @@ class NumpyBackend1D(NumpyBackend):
         n1_unpadded = 1 + (n1_max // n1_stride)
         return x[..., :n1_unpadded, :]
 
-    @staticmethod
+    @classmethod
     def split_frequency_axis(cls, x):
         return cls._np.split(x, indices_or_sections=x.shape[-2], axis=-2)
 

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -124,4 +124,8 @@ class TensorFlowBackend1D(TensorFlowBackend):
         n1_unpadded = 1 + (n1_max // n1_stride)
         return x[:, :, :n1_unpadded, :]
 
+    @staticmethod
+    def split_frequency_axis(x):
+        return tf.split(x, tuple(tf.shape(x))[-2], axis=-2)
+
 backend = TensorFlowBackend1D

--- a/kymatio/scattering1d/backend/tensorflow_backend.py
+++ b/kymatio/scattering1d/backend/tensorflow_backend.py
@@ -126,6 +126,6 @@ class TensorFlowBackend1D(TensorFlowBackend):
 
     @staticmethod
     def split_frequency_axis(x):
-        return tf.split(x, tuple(tf.shape(x))[-2], axis=-2)
+        return tf.split(x, x.shape[-2], axis=-2)
 
 backend = TensorFlowBackend1D

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -220,7 +220,7 @@ class TorchBackend1D(TorchBackend):
         output : list of tensors, each of shape (batch, 1, time, 1). The number
         of elements in the list is equal to that of the frequency axis.
         """
-        return torch.split(x, x.shape[-3], axis=-3)
+        return torch.split(x, 1, dim=-3)
 
 
 backend = TorchBackend1D

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -191,6 +191,7 @@ class TorchBackend1D(TorchBackend):
         averaging. This is called at the end of `jtfs_average_and_format`
         unless `out_type='array'` and `format='joint'`.
         NB. Unpadding is one-sided. See point 3 of pad_frequency docstring.
+
         Parameters
         ----------
         x : tensor (batch, frequency, time, 1), corresponds to path['coef']
@@ -198,12 +199,28 @@ class TorchBackend1D(TorchBackend):
             for the scattering path of x. By definition, lower than len(psi1_f).
         n1_stride: integer frequential subsampling factor associated to the
             scattering path of x. Equal to max(1, 2**(j_fr - oversampling_fr)).
+
         Returns
         -------
         output : tensor (batch, time, unpadded frequency, 1)
         """
         n1_unpadded = 1 + (n1_max // n1_stride)
         return x[:, :, :n1_unpadded, :]
+
+    @staticmethod
+    def split_frequency_axis(x):
+        """Split tensor along its frequency axis.
+
+        Parameters
+        ----------
+        x : tensor (batch, frequency, time, 1), corresponds to path['coef']
+
+        Returns
+        -------
+        output : list of tensors, each of shape (batch, 1, time, 1). The number
+        of elements in the list is equal to that of the frequency axis.
+        """
+        return torch.split(x, x.shape[-3], axis=-3)
 
 
 backend = TorchBackend1D

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -387,6 +387,17 @@ def frequency_averaging(U_2, backend, phi_fr_f, oversampling_fr, average_fr):
         return {**U_2, 'n1_stride': n1_stride}
 
 
+def time_formatting(path, backend):
+    n1 = 0
+    for split_coef in backend.split_frequency_axis(path["coef"]):
+        split_path = {**path, "coef": split_coef, "order": len(path["n"])}
+        split_path["n"][0] = n1
+        del split_path["n1_max"]
+        del split_path["n1_stride"]
+        yield split_path
+        n1 += path["n1_stride"]
+
+
 def jtfs_average_and_format(U_gen, backend, phi_f, oversampling, average,
         phi_fr_f, oversampling_fr, average_fr, out_type, format):
     # Zeroth order
@@ -436,6 +447,4 @@ def jtfs_average_and_format(U_gen, backend, phi_f, oversampling, average,
         if format == 'joint':
             yield {**path, 'order': len(path['n'])}
         elif format == 'time':
-            raise NotImplementedError
-        #     # TODO split
-        #     yield from self.backend.split(path)
+            yield from time_formatting(path)

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -20,7 +20,7 @@ def joint_timefrequency_scattering(U_0, backend, filters, oversampling,
      * phi is a dictionary describing the low-pass filter of width F, used
        to average S1 and S2 in frequency if and only if average_local_fr.
      * psis is a list of dictionaries, each describing a low-pass or band-pass
-       band-pass filter indexed by n_fr. The first element, n_fr=0, corresponds
+       filter indexed by n_fr. The first element, n_fr=0, corresponds
        to a low-pass filter of width 2**J_fr and satisfies xi=0, i.e, spin=0.
        Other elements, such that n_fr>0, correspond to "spinned" band-pass
        filter, where spin denotes the sign of the center frequency xi.
@@ -63,7 +63,7 @@ def joint_timefrequency_scattering(U_0, backend, filters, oversampling,
     Y_2_fr{n2,n_fr}(t, n1) = (Y_2*psi_{n_fr})(t[j2], n1[j_fr]),
      conv. over n1, broadcast over t, n1 zero-padded up to N_fr
     """
-    # Zeroth order: S0(t[log_T]) if average_local, U0(t) otherwise
+    # Zeroth order: S0(t[log2_T]) if average_local, U0(t) otherwise
     time_gen = time_scattering_widthfirst(
         U_0, backend, filters, oversampling, average_local)
     yield next(time_gen)
@@ -213,7 +213,7 @@ def frequency_scattering(X, backend, filters_fr, oversampling_fr,
         * phi is a dictionary describing the low-pass filter of width F, used
           to average S1 and S2 in frequency if and only if average_local_fr.
         * psis is a list of dictionaries, each describing a low-pass or band-pass
-          band-pass filter indexed by n_fr. The first element, n_fr=0, corresponds
+          filter indexed by n_fr. The first element, n_fr=0, corresponds
           to a low-pass filter of width 2**J_fr and satisfies xi=0, i.e, spin=0.
           Other elements, such that n_fr>0, correspond to "spinned" band-pass
           filter, where spin denotes the sign of the center frequency xi.

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -391,7 +391,7 @@ def time_formatting(path, backend):
     n1 = 0
     for split_coef in backend.split_frequency_axis(path["coef"]):
         split_path = {**path, "coef": split_coef, "order": len(path["n"])}
-        split_path["n"][0] = n1
+        split_path["n"] = (n1,) + split_path["n"][1:]
         del split_path["n1_max"]
         del split_path["n1_stride"]
         yield split_path
@@ -447,4 +447,4 @@ def jtfs_average_and_format(U_gen, backend, phi_f, oversampling, average,
         if format == 'joint':
             yield {**path, 'order': len(path['n'])}
         elif format == 'time':
-            yield from time_formatting(path)
+            yield from time_formatting(path, backend)

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -641,9 +641,13 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         if (self.format == 'joint') and (self.out_type == 'array'):
             # Skip zeroth order
             S = S[1:]
-            # Concatenate first and second order into a 4D tensor:
+            # Concatenate first and second orders into a 4D tensor:
             # (batch, n_jtfs, freq, time) where n_jtfs aggregates (n2, n_fr)
             return self.backend.concatenate([path['coef'] for path in S], dim=-3)
+        elif (self.format == "time") and (self.out_type == "array"):
+            # Concatenate zeroth, first, and second orders into a 3D tensor:
+            # (batch, n_jtfs, time) where n_jtfs aggregates (n1, n2, n_fr)
+            return self.backend.concatenate([path['coef'] for path in S], dim=-2)
         elif self.out_type == 'dict':
             return {path['n']: path['coef'] for path in S}
         elif self.out_type == 'list':

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -634,8 +634,8 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
                     path['coef'], self.ind_start[res], self.ind_end[res])
 
             # Reshape path to batch shape.
-            path['coef'] = self.backend.reshape_output(
-                path['coef'], batch_shape, n_kept_dims=2)
+            path['coef'] = self.backend.reshape_output(path['coef'],
+                batch_shape, n_kept_dims=(1 + (self.format == "joint")))
             S.append(path)
 
         if (self.format == 'joint') and (self.out_type == 'array'):

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -663,32 +663,33 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
             self.filters_fr[0], self.oversampling_fr, self.average_fr,
             self.out_type, self.format)
         S = sorted(list(S_gen), key=lambda path: (len(path['n']), path['n']))
-        meta = dict(order=np.array([len(path['n']) for path in S]))
-        meta['key'] = [path['n'] for path in S]
-        meta['n'] = []
-        meta['n_fr'] = []
+        meta = dict(key=[path['n'] for path in S], n=[], n_fr=[], order=[])
         for path in S:
             if len(path['n']) == 0:
                 # Zeroth order: no n1, no n_fr, no n2
                 meta['n'].append([np.nan, np.nan])
                 meta['n_fr'].append(np.nan)
+                meta['order'].append(0)
             else:
-                n1_range = range(0, path['n1_max'], path['n1_stride'])
                 if len(path['n']) == 1:
                     # First order and format='joint': n=(n_fr,)
+                    n1_range = range(0, path['n1_max'], path['n1_stride'])
                     meta['n'].append([n1_range, np.nan])
                 elif len(path['n']) == 2 and self.format == 'joint':
                     # Second order and format='joint': n=(n2, n_fr)
+                    n1_range = range(0, path['n1_max'], path['n1_stride'])
                     meta['n'].append([n1_range, path['n'][0]])
                 elif len(path['n']) == 2 and self.format == 'time':
                     # First order and format='time': n=(n1, n_fr)
                     meta['n'].append([path['n'][0], np.nan])
                 elif len(path['n']) == 3 and self.format == 'time':
                     # Second order and format='time': n=(n1, n2, n_fr)
-                    meta['n'].append([path['n'][2:]])
+                    meta['n'].append(path['n'][:2])
                 meta['n_fr'].append(path['n_fr'][0])
+                meta['order'].append(len(path['n']) - (self.format == 'time'))
         meta['n'] = np.array(meta['n'], dtype=object)
         meta['n_fr'] = np.array(meta['n_fr'])
+        meta['order'] = np.array(meta['order'])
         for key in ['xi', 'sigma', 'j']:
             meta[key] = np.zeros((meta['n_fr'].shape[0], 2)) * np.nan
             for order, filterbank in enumerate(filters[1:]):

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -19,12 +19,14 @@ ScatteringNumPy1D._document()
 
 class TimeFrequencyScatteringNumPy(
         ScatteringNumPy1D, TimeFrequencyScatteringBase):
-    def __init__(self, *, J, J_fr, shape, Q, T=None, oversampling=0, Q_fr=1,
-            F=None, oversampling_fr=0, out_type='array', backend='numpy'):
+    def __init__(self, *, J, J_fr, shape, Q, T=None, oversampling=0,
+            Q_fr=1, F=None, oversampling_fr=0,
+            out_type='array', format='joint', backend='numpy'):
         ScatteringNumPy.__init__(self)
         TimeFrequencyScatteringBase.__init__(self, J=J, J_fr=J_fr, shape=shape,
-            Q=Q, T=T, oversampling=oversampling, Q_fr=Q_fr, F=F,
-            oversampling_fr=oversampling_fr, out_type=out_type, backend=backend)
+            Q=Q, T=T, oversampling=oversampling,
+            Q_fr=Q_fr, F=F, oversampling_fr=oversampling_fr,
+            out_type=out_type, format=format, backend=backend)
         ScatteringBase1D._instantiate_backend(
             self, 'kymatio.scattering1d.backend.')
         TimeFrequencyScatteringBase.build(self)

--- a/tests/scattering1d/test_numpy_backend_1d.py
+++ b/tests/scattering1d/test_numpy_backend_1d.py
@@ -148,3 +148,14 @@ def test_unpad_frequency():
     x = np.arange(np.prod(shape)).reshape(shape) * 0.5
     x_unpadded = backend.unpad_frequency(x, n1_max=10, n1_stride=2)
     assert x_unpadded.shape == shape_unpadded
+
+
+def test_split_frequency_axis():
+    shape = (10, 20, 16, 3)
+    x = np.arange(np.prod(shape)).reshape(shape) * 0.5
+    X_split = backend.split_frequency_axis(x)
+    assert len(X_split) == x.shape[-2]
+    for i, x_split in enumerate(X_split):
+        assert x_split.shape[:-2] == x.shape[:-2]
+        assert x_split.shape[-1] == x.shape[-1]
+        assert np.allclose(x_split[..., 0, :], x[..., i, :])

--- a/tests/scattering1d/test_tensorflow_backend_1d.py
+++ b/tests/scattering1d/test_tensorflow_backend_1d.py
@@ -143,12 +143,14 @@ def test_swap_time_frequency_1d():
     assert x_T_T.shape == x.shape
     assert np.all(x == x_T_T)
 
+
 def test_unpad_frequency():
     shape = (10, 20, 16, 3)
     shape_unpadded = (10, 20, 6, 3)
     x = np.arange(np.prod(shape)).reshape(shape) * 0.5
     x_unpadded = backend.unpad_frequency(x, n1_max=10, n1_stride=2)
     assert x_unpadded.shape == shape_unpadded
+
 
 def test_split_frequency_axis():
     shape = (10, 20, 16, 3)

--- a/tests/scattering1d/test_tensorflow_backend_1d.py
+++ b/tests/scattering1d/test_tensorflow_backend_1d.py
@@ -149,3 +149,13 @@ def test_unpad_frequency():
     x = np.arange(np.prod(shape)).reshape(shape) * 0.5
     x_unpadded = backend.unpad_frequency(x, n1_max=10, n1_stride=2)
     assert x_unpadded.shape == shape_unpadded
+
+def test_split_frequency_axis():
+    shape = (10, 20, 16, 3)
+    x = tf.constant(np.arange(np.prod(shape)).reshape(shape) * 0.5)
+    X_split = backend.split_frequency_axis(x)
+    assert len(X_split) == x.shape[-2]
+    for i, x_split in enumerate(X_split):
+        assert x_split.shape[:-2] == x.shape[:-2]
+        assert x_split.shape[-1:] == x.shape[-1:]
+        assert np.allclose(x_split[..., 0, :], x[..., i, :])

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -461,6 +461,7 @@ def test_jtfs_numpy():
     # Dictionary output
     S = TimeFrequencyScatteringNumPy(out_type="dict", **kwargs)
     Sx = S(x)
+    assert all([isinstance(path, np.ndarray) for path in Sx.values()])
 
     # List output
     S = TimeFrequencyScatteringNumPy(out_type="list", T=0, F=0, **kwargs)
@@ -472,3 +473,13 @@ def test_jtfs_numpy():
     for key in ["xi", "sigma", "j", "xi_fr", "sigma_fr", "j_fr", "spin"]:
         assert key in meta.keys()
         assert len(meta[key]) == len(Sx)
+
+    # format='time'
+    S = TimeFrequencyScatteringNumPy(T=None, F=0, format="time", **kwargs)
+    Sx = S(x)
+    assert Sx.ndim == 2
+
+    # format='time' with global averaging
+    S = TimeFrequencyScatteringNumPy(T="global", F=0, format="time", **kwargs)
+    Sx = S(x)
+    assert Sx.ndim == 2

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -483,3 +483,7 @@ def test_jtfs_numpy():
     S = TimeFrequencyScatteringNumPy(T="global", F=0, format="time", **kwargs)
     Sx = S(x)
     assert Sx.ndim == 2
+
+    # format='time' meta()
+    meta = S.meta()
+    assert len(meta['key']) == Sx.shape[-2]

--- a/tests/scattering1d/test_torch_backend_1d.py
+++ b/tests/scattering1d/test_torch_backend_1d.py
@@ -246,10 +246,7 @@ def test_fft(backend, device):
     z_1 = backend.ifft(z)
     assert torch.allclose(x_r[..., 0], z_1[..., 0])
 
-    print(z.shape)
-
     z_2 = backend.irfft(z)
-    print(z_2.shape)
     assert not z_2.shape[-1] == 2
     assert torch.allclose(x_r, z_2)
     
@@ -315,3 +312,14 @@ def test_unpad_frequency():
     x = np.arange(np.prod(shape)).reshape(shape) * 0.5
     x_unpadded = backend.unpad_frequency(x, n1_max=10, n1_stride=2)
     assert x_unpadded.shape == shape_unpadded
+
+
+def test_split_frequency_axis():
+    shape = (10, 20, 16, 3)
+    x = torch.arange(np.prod(shape)).reshape(shape) * 0.5
+    X_split = backend.split_frequency_axis(x)
+    assert len(X_split) == x.shape[-3]
+    for i, x_split in enumerate(X_split):
+        assert x_split.shape[:-3] == x.shape[:-3]
+        assert x_split.shape[-2:] == x.shape[-2:]
+        assert torch.allclose(x_split[..., 0, :, :], x[..., i, :, :])


### PR DESCRIPTION
This was harder than expected
See new primitive `split_frequency_axis` and additional core method `time_formatting`
The switch logic in base frontend between orders, choice of out_type, and choice of format is quite subtle now. But i think i got it right without too much code (~70 lines of base frontend for both scattering sand meta)

Ready for review, tests included