### PR TITLE
MAINT Unpin sphinx

### DIFF
--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,5 +1,5 @@
 pytest
-sphinx<3.0
+sphinx
 sphinxcontrib-bibtex
 sphinx-gallery
 pillow


### PR DESCRIPTION
There was an issue a while back with sphinx-3.0 being incompatible with
the latest version of m2r (see f92b5077), but this now seems to have
been remedied.