### PR TITLE
make swap_time_frequency output contiguous

### DIFF
--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -183,7 +183,7 @@ class TorchBackend1D(TorchBackend):
             if complex: (batch, time, frequency, real/imag)
             else: (batch, time, frequency, 1)
         """
-        return torch.transpose(x, dim0=-2, dim1=-3)
+        return torch.transpose(x, dim0=-2, dim1=-3).contiguous()
 
     @staticmethod
     def unpad_frequency(x, n1_max, n1_stride):

--- a/tests/scattering1d/test_torch_backend_1d.py
+++ b/tests/scattering1d/test_torch_backend_1d.py
@@ -287,11 +287,13 @@ def test_swap_time_frequency_1d(device, backend, random_state=42):
     x = torch.arange(np.prod(shape)).reshape(shape) * 0.5
     x_T = backend.swap_time_frequency(x)
     assert tuple(x_T.shape) == shape_T
+    assert x_T.is_contiguous()
 
     x_T_T = backend.swap_time_frequency(x_T)
     assert tuple(x_T_T.shape) == shape
     assert x_T_T.shape == x.shape
     assert torch.all(x == x_T_T)
+    assert x_T_T.is_contiguous()
 
     shape = (10, 20, 3, 5, 2)
     shape_T = (10, 20, 5, 3, 2)


### PR DESCRIPTION
* `swap_time_frequency` backend primitive explicitly returns contiguous tensor
* add contiguity test