### PR TITLE
ENH/FIX add format kwarg to TimeFrequencyScattering torch and tf frontends

### DIFF
--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -6,12 +6,23 @@ from .base_frontend import ScatteringBase1D, TimeFrequencyScatteringBase
 
 
 class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2, oversampling=0,
-            out_type='array', backend='tensorflow', name='Scattering1D'):
+    def __init__(
+        self,
+        J,
+        shape,
+        Q=1,
+        T=None,
+        max_order=2,
+        oversampling=0,
+        out_type="array",
+        backend="tensorflow",
+        name="Scattering1D",
+    ):
         ScatteringTensorFlow.__init__(self, name=name)
-        ScatteringBase1D.__init__(self, J, shape, Q, T, max_order,
-                oversampling, out_type, backend)
-        ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
+        ScatteringBase1D.__init__(
+            self, J, shape, Q, T, max_order, oversampling, out_type, backend
+        )
+        ScatteringBase1D._instantiate_backend(self, "kymatio.scattering1d.backend.")
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
 
@@ -20,22 +31,46 @@ ScatteringTensorFlow1D._document()
 
 
 class TimeFrequencyScatteringTensorFlow(
-        ScatteringTensorFlow, TimeFrequencyScatteringBase):
-    def __init__(self, *, J, J_fr, shape, Q, T=None, oversampling=0, Q_fr=1,
-            F=None, oversampling_fr=0, out_type='array', backend='tensorflow', name='TimeFrequencyScattering'):
-        ScatteringTensorFlow.__init__(self,name=name)
-        TimeFrequencyScatteringBase.__init__(self, J=J, J_fr=J_fr, shape=shape,
-            Q=Q, T=T, oversampling=oversampling, Q_fr=Q_fr, F=F,
-            oversampling_fr=oversampling_fr, out_type=out_type, backend=backend)
+    ScatteringTensorFlow, TimeFrequencyScatteringBase
+):
+    def __init__(
+        self,
+        *,
+        J,
+        J_fr,
+        shape,
+        Q,
+        T=None,
+        oversampling=0,
+        Q_fr=1,
+        F=None,
+        oversampling_fr=0,
+        out_type="array",
+        backend="tensorflow",
+        format="joint",
+        name="TimeFrequencyScattering"
+    ):
+        ScatteringTensorFlow.__init__(self, name=name)
+        TimeFrequencyScatteringBase.__init__(
+            self,
+            J=J,
+            J_fr=J_fr,
+            shape=shape,
+            Q=Q,
+            T=T,
+            oversampling=oversampling,
+            Q_fr=Q_fr,
+            F=F,
+            oversampling_fr=oversampling_fr,
+            out_type=out_type,
+            backend=backend,
+            format=format,
+        )
         TimeFrequencyScatteringBase._instantiate_backend(
-            self, 'kymatio.scattering1d.backend.')
+            self, "kymatio.scattering1d.backend."
+        )
         TimeFrequencyScatteringBase.build(self)
         TimeFrequencyScatteringBase.create_filters(self)
-    
 
 
-
-__all__ = ['ScatteringTensorFlow1D', 'TimeFrequencyScatteringTensorFlow']
-
-
-
+__all__ = ["ScatteringTensorFlow1D", "TimeFrequencyScatteringTensorFlow"]

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -6,58 +6,71 @@ from .base_frontend import ScatteringBase1D, TimeFrequencyScatteringBase
 
 
 class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2,
-            oversampling=0, out_type='array', backend='torch'):
+    def __init__(
+        self,
+        J,
+        shape,
+        Q=1,
+        T=None,
+        max_order=2,
+        oversampling=0,
+        out_type="array",
+        backend="torch",
+    ):
         ScatteringTorch.__init__(self)
-        ScatteringBase1D.__init__(self, J, shape, Q, T, max_order,
-                oversampling, out_type, backend)
-        ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
+        ScatteringBase1D.__init__(
+            self, J, shape, Q, T, max_order, oversampling, out_type, backend
+        )
+        ScatteringBase1D._instantiate_backend(self, "kymatio.scattering1d.backend.")
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
         self.register_filters()
 
     def register_filters(self):
-        """ This function run the filterbank function that
+        """This function run the filterbank function that
         will create the filters as numpy array, and then, it
         saves those arrays as module's buffers."""
         n = 0
         # prepare for pytorch
-        for level in range(len(self.phi_f['levels'])):
-            self.phi_f['levels'][level] = torch.from_numpy(
-                self.phi_f['levels'][level]).float().view(-1, 1)
-            self.register_buffer('tensor' + str(n), self.phi_f['levels'][level])
+        for level in range(len(self.phi_f["levels"])):
+            self.phi_f["levels"][level] = (
+                torch.from_numpy(self.phi_f["levels"][level]).float().view(-1, 1)
+            )
+            self.register_buffer("tensor" + str(n), self.phi_f["levels"][level])
             n += 1
         for psi_f in self.psi1_f:
-            for level in range(len(psi_f['levels'])):
-                psi_f['levels'][level] = torch.from_numpy(
-                    psi_f['levels'][level]).float().view(-1, 1)
-                self.register_buffer('tensor' + str(n), psi_f['levels'][level])
+            for level in range(len(psi_f["levels"])):
+                psi_f["levels"][level] = (
+                    torch.from_numpy(psi_f["levels"][level]).float().view(-1, 1)
+                )
+                self.register_buffer("tensor" + str(n), psi_f["levels"][level])
                 n += 1
         for psi_f in self.psi2_f:
-            for level in range(len(psi_f['levels'])):
-                psi_f['levels'][level] = torch.from_numpy(
-                    psi_f['levels'][level]).float().view(-1, 1)
-                self.register_buffer('tensor' + str(n), psi_f['levels'][level])
+            for level in range(len(psi_f["levels"])):
+                psi_f["levels"][level] = (
+                    torch.from_numpy(psi_f["levels"][level]).float().view(-1, 1)
+                )
+                self.register_buffer("tensor" + str(n), psi_f["levels"][level])
                 n += 1
         return n
 
     def load_filters(self):
-        """This function loads filters from the module's buffer """
+        """This function loads filters from the module's buffer"""
         buffer_dict = dict(self.named_buffers())
         n = 0
 
-        for level in range(len(self.phi_f['levels'])):
-            self.phi_f['levels'][level] = buffer_dict['tensor' + str(n)]
+        for level in range(len(self.phi_f["levels"])):
+            self.phi_f["levels"][level] = buffer_dict["tensor" + str(n)]
             n += 1
 
         for psi_f in self.psi1_f:
-            for level in range(len(psi_f['levels'])):
-                psi_f['levels'][level] = buffer_dict['tensor' + str(n)]
+            for level in range(len(psi_f["levels"])):
+                psi_f["levels"][level] = buffer_dict["tensor" + str(n)]
                 n += 1
 
         for psi_f in self.psi2_f:
-            for level in range(len(psi_f['levels'])):
-                psi_f['levels'][level] = buffer_dict['tensor' + str(n)]
+            for level in range(len(psi_f["levels"])):
+                psi_f["levels"][level] = buffer_dict["tensor" + str(n)]
                 n += 1
         return n
 
@@ -69,47 +82,74 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
 ScatteringTorch1D._document()
 
 
-class TimeFrequencyScatteringTorch(
-        ScatteringTorch1D, TimeFrequencyScatteringBase):
-    def __init__(self, *, J, J_fr, shape, Q, T=None, oversampling=0, Q_fr=1,
-            F=None, oversampling_fr=0, out_type='array', backend='torch'):
+class TimeFrequencyScatteringTorch(ScatteringTorch1D, TimeFrequencyScatteringBase):
+    def __init__(
+        self,
+        *,
+        J,
+        J_fr,
+        shape,
+        Q,
+        T=None,
+        oversampling=0,
+        Q_fr=1,
+        F=None,
+        oversampling_fr=0,
+        out_type="array",
+        format="joint",
+        backend="torch"
+    ):
         ScatteringTorch.__init__(self)
-        TimeFrequencyScatteringBase.__init__(self, J=J, J_fr=J_fr, shape=shape,
-            Q=Q, T=T, oversampling=oversampling, Q_fr=Q_fr, F=F,
-            oversampling_fr=oversampling_fr, out_type=out_type, backend=backend)
-        ScatteringBase1D._instantiate_backend(
-            self, 'kymatio.scattering1d.backend.')
+        TimeFrequencyScatteringBase.__init__(
+            self,
+            J=J,
+            J_fr=J_fr,
+            shape=shape,
+            Q=Q,
+            T=T,
+            oversampling=oversampling,
+            Q_fr=Q_fr,
+            F=F,
+            oversampling_fr=oversampling_fr,
+            out_type=out_type,
+            format=format,
+            backend=backend,
+        )
+        ScatteringBase1D._instantiate_backend(self, "kymatio.scattering1d.backend.")
         TimeFrequencyScatteringBase.build(self)
         TimeFrequencyScatteringBase.create_filters(self)
         self.register_filters()
 
     def register_filters(self):
         n = super(TimeFrequencyScatteringTorch, self).register_filters()
-        for level in range(len(self.filters_fr[0]['levels'])):
-            self.filters_fr[0]['levels'][level] = torch.from_numpy(
-                self.filters_fr[0]['levels'][level]).float().view(-1, 1)
-            self.register_buffer(
-                'tensor' + str(n), self.filters_fr[0]['levels'][level])
+        for level in range(len(self.filters_fr[0]["levels"])):
+            self.filters_fr[0]["levels"][level] = (
+                torch.from_numpy(self.filters_fr[0]["levels"][level])
+                .float()
+                .view(-1, 1)
+            )
+            self.register_buffer("tensor" + str(n), self.filters_fr[0]["levels"][level])
             n += 1
         for psi_f in self.filters_fr[1]:
-            for level in range(len(psi_f['levels'])):
-                psi_f['levels'][level] = torch.from_numpy(
-                    psi_f['levels'][level]).float().view(-1, 1)
-                self.register_buffer('tensor' + str(n), psi_f['levels'][level])
+            for level in range(len(psi_f["levels"])):
+                psi_f["levels"][level] = (
+                    torch.from_numpy(psi_f["levels"][level]).float().view(-1, 1)
+                )
+                self.register_buffer("tensor" + str(n), psi_f["levels"][level])
                 n += 1
 
     def load_filters(self):
         buffer_dict = dict(self.named_buffers())
         n = super(TimeFrequencyScatteringTorch, self).load_filters()
 
-        for level in range(len(self.filters_fr[0]['levels'])):
-            self.filters_fr[0]['levels'][level] = buffer_dict['tensor' + str(n)]
+        for level in range(len(self.filters_fr[0]["levels"])):
+            self.filters_fr[0]["levels"][level] = buffer_dict["tensor" + str(n)]
             n += 1
 
         for psi_f in self.filters_fr[1]:
-            for level in range(len(psi_f['levels'])):
-                psi_f['levels'][level] = buffer_dict['tensor' + str(n)]
+            for level in range(len(psi_f["levels"])):
+                psi_f["levels"][level] = buffer_dict["tensor" + str(n)]
                 n += 1
 
 
-__all__ = ['ScatteringTorch1D', 'TimeFrequencyScatteringTorch']
+__all__ = ["ScatteringTorch1D", "TimeFrequencyScatteringTorch"]

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -543,6 +543,11 @@ def test_jtfs_numpy_and_sklearn(frontend):
     Sx = S(x)
     assert Sx.ndim == 2
 
+    # format='joint'
+    S = TimeFrequencyScatteringNumPy(T=None, format="joint", **kwargs)
+    Sx = S(x)
+    assert Sx.ndim == 3
+
     # format='time' with global averaging
     S = TimeFrequencyScatteringNumPy(T="global", F=0, format="time", **kwargs)
     Sx = S(x)
@@ -562,12 +567,22 @@ frontends = ["torch", "tensorflow"]
 @pytest.mark.parametrize("frontend", frontends)
 def test_jtfs_torch_tf_frontends(frontend):
     # Test __init__
-    kwargs = {"J": 8, "J_fr": 3, "shape": (1024,), "Q": 3}
+    kwargs = {"J": 8, "J_fr": 3, "shape": (8192,), "Q": 3}
     x = torch.zeros(kwargs["shape"])
     x[kwargs["shape"][0] // 2] = 1
 
+    # format='time'
+    S = TimeFrequencyScattering(frontend="torch", T=None, F=0, format="time", **kwargs)
+    Sx = S(x)
+    assert Sx.ndim == 2
+
+    # format='time' with global averaging
+    S = TimeFrequencyScattering(frontend="torch", T="global", F=0, format="time", **kwargs)
+    Sx = S(x)
+    assert Sx.ndim == 2
+
     # Local averaging
-    S = TimeFrequencyScattering(frontend=frontend, **kwargs)
+    S = TimeFrequencyScattering(frontend=frontend, format="joint", **kwargs)
     assert S.F == (2**S.J_fr)
     Sx = S(x)
     assert isinstance(Sx, torch.Tensor) if frontend == "torch" else isinstance(Sx, tf.Tensor)


### PR DESCRIPTION
I have added the `format` kwarg for `TimeFrequencyScattering` torch and tf frontends. Upon testing, I have noticed a `RuntimeError` for `format="time"` in tensorflow