### PR TITLE
FIX #978 omit order0 from JTFS meta when `format="joint"`

### DIFF
--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -373,7 +373,7 @@ def frequency_averaging(U_2, backend, phi_fr_f, oversampling_fr, average_fr):
             S_2_T = backend.average_global(U_2_T)
             n1_stride = U_2['n1_max']
         elif average_fr == 'local':
-            k_in = U_2['j_fr'][-1]
+            k_in = min(U_2['j_fr'][-1], log2_F)
             k_J = max(log2_F - k_in - oversampling_fr, 0)
             U_hat = backend.rfft(U_2_T)
             S_c = backend.cdgmm(U_hat, phi_fr_f['levels'][k_in])

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -666,10 +666,12 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         meta = dict(key=[path['n'] for path in S], n=[], n_fr=[], order=[])
         for path in S:
             if len(path['n']) == 0:
-                # Zeroth order: no n1, no n_fr, no n2
-                meta['n'].append([np.nan, np.nan])
-                meta['n_fr'].append(np.nan)
-                meta['order'].append(0)
+                # If format='joint' and out_type='array' skip zeroth order
+                if not (self.format == 'joint' and self.out_type == 'array'):
+                    # Zeroth order: no n1, no n_fr, no n2
+                    meta['n'].append([np.nan, np.nan])
+                    meta['n_fr'].append(np.nan)
+                    meta['order'].append(0)
             else:
                 if len(path['n']) == 1:
                     # First order and format='joint': n=(n_fr,)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -602,7 +602,7 @@ def test_F(frontend):
     # default F
     jtfs0 = TimeFrequencyScattering(frontend="torch", format="joint", **kwargs)
 
-    # explict F
+    # explicit F
     jtfs1 = TimeFrequencyScattering(frontend="torch", format="joint", F=2**kwargs['J_fr'], **kwargs)
 
     Sx0 = jtfs0(x)
@@ -610,7 +610,9 @@ def test_F(frontend):
     assert torch.equal(Sx0, Sx1)
     assert Sx0.shape == Sx1.shape
 
-    # non-default F smaller than 2**J_fr
+    """ non-default F smaller than 2**J_fr. This checks that the subsampling
+        index does not exceed log2_F and cause an IndexError at runtime (#976).
+    """
     jtfs2 = TimeFrequencyScattering(frontend="torch", format="joint", F=2**kwargs['J_fr'] // 4, **kwargs)
     Sx2 = jtfs2(x)
     assert Sx0.shape[0] == Sx2.shape[0] and Sx0.shape[2] == Sx2.shape[2] and Sx0.shape[1] < Sx2.shape[1]

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -548,6 +548,10 @@ def test_jtfs_numpy_and_sklearn(frontend):
     Sx = S(x)
     assert Sx.ndim == 3
 
+    # format='joint' meta()
+    meta = S.meta()
+    assert len(meta["order"]) == Sx.shape[-3]
+
     # format='time' with global averaging
     S = TimeFrequencyScatteringNumPy(T="global", F=0, format="time", **kwargs)
     Sx = S(x)

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 import pytest
 import torch, tensorflow as tf


### PR DESCRIPTION
Fixes #978

Added minimal test to check that `meta['order']` has same number of elements as Sx paths