### PR TITLE
FIX include level `k2=log2_T` of `psi2_f`

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -377,8 +377,8 @@ def scattering_filter_factory(N, J, Q, T, filterbank):
             j = get_max_dyadic_subsampling(xi, sigma, **filterbank_kwargs)
 
             # Resample to smaller resolutions if necessary (beyond 1st layer)
-            # The idiom min(previous_J, j, log2_T) implements "j1 < j2"
-            for level in range(1, min(previous_J, j, log2_T)):
+            # The idiom min(previous_J, j, 1+log2_T) implements "j1 < j2"
+            for level in range(1, min(previous_J, j, 1+log2_T)):
                 psi_level = psi_levels[0].reshape(2 ** level, -1).mean(axis=0)
                 psi_levels.append(psi_level)
             psi_f.append({'levels': psi_levels, 'xi': xi, 'sigma': sigma, 'j': j})

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -114,6 +114,16 @@ class TestScattering1DNumpy:
         Sx = sc(x)
         assert Sx.shape[-1] == 1
 
+    def test_981(self, backend):
+        """
+        Tests against bug #981, in which some low values of T triggered an
+        `IndexError` in second-order backend.cdgmm
+        """
+        N = 1024
+        x = np.zeros(N)
+        sc = Scattering1D(J=8, shape=(N,), T=2)
+        Sx = sc(x)
+        assert Sx.shape[-1] == N/sc.T
 
 
 frontends = ['numpy', 'sklearn']


### PR DESCRIPTION
fixes #981
tests included

it was an off-by-one error in `scattering_filter_factory`


```python
    # Loop over scattering layers
    for Q_layer in Q:
        psi_f = []

        # Loop over center frequencies xi and bandwidths sigma in the filterbank
        for xi, sigma in filterbank_fn(J, Q_layer, **filterbank_kwargs):

            # Construct filter at full resolution
            psi_levels = [morlet_1d(N, xi, sigma)]
            j = get_max_dyadic_subsampling(xi, sigma, **filterbank_kwargs)

            # Resample to smaller resolutions if necessary (beyond 1st layer)
            # The idiom min(previous_J, j, 1+log2_T) implements "j1 < j2"
            for level in range(1, min(previous_J, j, 1+log2_T)):
                psi_level = psi_levels[0].reshape(2 ** level, -1).mean(axis=0)
                psi_levels.append(psi_level)
            psi_f.append({'levels': psi_levels, 'xi': xi, 'sigma': sigma, 'j': j})
            max_j = max(j, max_j)

        # Keep score of how many resolutions will be needed in the next layer
        previous_J = max_j
        psis_f.append(psi_f)
```

the `range(1, min(previous_J, j, 1+log2_T)` was `range(1, min(previous_J, j, log2_T)` before