### PR TITLE
FIX `_reduction=np.sum` (vs default `np.mean`) in JTFS sc filter factory

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -25,6 +25,7 @@ class ScatteringBase1D(ScatteringBase):
         self.oversampling = oversampling
         self.out_type = out_type
         self.backend = backend
+        self._reduction = np.mean
 
     def build(self):
         """Set up padding and filters
@@ -38,7 +39,6 @@ class ScatteringBase1D(ScatteringBase):
         self.r_psi = math.sqrt(0.5)
         self.sigma0 = 0.1
         self.alpha = 5.
-        self._reduction = np.mean
 
         # check the number of filters per octave
         if np.any(np.array(self.Q) < 1):

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -38,6 +38,7 @@ class ScatteringBase1D(ScatteringBase):
         self.r_psi = math.sqrt(0.5)
         self.sigma0 = 0.1
         self.alpha = 5.
+        self._reduction = np.mean
 
         # check the number of filters per octave
         if np.any(np.array(self.Q) < 1):
@@ -91,7 +92,7 @@ class ScatteringBase1D(ScatteringBase):
     def create_filters(self):
         # Create the filters
         self.phi_f, self.psi1_f, self.psi2_f = scattering_filter_factory(
-            self._N_padded, self.J, self.Q, self.T, self.filterbank)
+            self._N_padded, self.J, self.Q, self.T, self.filterbank, self._reduction)
         ScatteringBase._check_filterbanks(self.psi1_f, self.psi2_f)
 
     def scattering(self, x):
@@ -535,6 +536,7 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         self.F = F
         self.oversampling_fr = oversampling_fr
         self.format = format
+        self._reduction = np.sum
 
     def build(self):
         super(TimeFrequencyScatteringBase, self).build()
@@ -574,9 +576,10 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
 
     def create_filters(self):
         phi0_fr_f,= scattering_filter_factory(self._N_padded_fr,
-            self.J_fr, (), self.F, self.filterbank_fr)
+            self.J_fr, (), self.F, self.filterbank_fr, self._reduction)
         phi1_fr_f, psis_fr_f = scattering_filter_factory(self._N_padded_fr,
-            self.J_fr, self.Q_fr, 2**self.J_fr, self.filterbank_fr)
+            self.J_fr, self.Q_fr, 2**self.J_fr, self.filterbank_fr,
+            self._reduction)
         self.filters_fr = (phi0_fr_f, [phi1_fr_f] + psis_fr_f)
 
         # Check for absence of aliasing


### PR DESCRIPTION
Fixes #984 

With @cyrusvahidi we have spotted an issue in scattering filter factory, while working on JTFS


```python
# Resample to smaller resolutions if necessary (beyond 1st layer)
# The idiom min(previous_J, j, log2_T) implements "j1 < j2"
for level in range(1, min(previous_J, j, log2_T)):
    psi_level = psi_levels[0].reshape(2 ** level, -1).mean(axis=0)
    psi_levels.append(psi_level)
psi_f.append({'levels': psi_levels, 'xi': xi, 'sigma': sigma, 'j': j})
max_j = max(j, max_j)
```

This `.mean(axis=0)` should be a `sum` instead so as to preserve L1 norm across resolution levels.
The same problem arises in the construction of phi_levels:

```python
# Same with low-pass filter phi
sigma_low = filterbank_kwargs["sigma0"] / T
phi_levels = [gauss_1d(N, sigma_low)]
for level in range(1, max(previous_J, 1+log2_T)):
    phi_level = phi_levels[0].reshape(2 ** level, -1).mean(axis=0)
    phi_levels.append(phi_level)
phi_f = {'levels': phi_levels, 'xi': 0, 'sigma': sigma_low, 'j': log2_T,
    'N': N}
```

This is not so much of a big deal for `Scattering1D` (it causes discrepancies of the order of `2**k1` at the first order, and `2**(k1+k2)` at the second order) but it becomes a huge problem for JTFS because it introduces discontinuities at octave boundaries (when those octave boundaries correspond to changes in resolution level).

@cyrusvahidi has made several examples with Diracs and exponential chirps, demonstrating the issue.

This PR provide a backwards compatible fix to the issue. It introduces a temporary attribute `self._reduction`, which defaults to `np.mean` for the time being. We are setting it to `np.sum` for JTFS. Here is the new code

```python
# Resample to smaller resolutions if necessary (beyond 1st layer)
# The idiom min(previous_J, j, log2_T) implements "j1 < j2"
for level in range(1, min(previous_J, j, log2_T)):
    psi_level_reshaped = psi_levels[0].reshape(2**level, -1)
    psi_level = _reduction(psi_level_reshaped, axis=0)
    psi_levels.append(psi_level)
psi_f.append({'levels': psi_levels, 'xi': xi, 'sigma': sigma, 'j': j})
max_j = max(j, max_j)

```

Long term i think that all reductions should be `np.sum` and that we should remove the `_reduction` argument. But i'm introducing it here so that all regression tests still pass and we can merge this quickly (it's really urgent given an impending JTFS paper deadline) without rushing into big API decisions.