### PR TITLE
FIX `get_max_dyadic_subsampling` for negative `xi` in JTFS frequency filterbank construction

### DIFF
--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -214,7 +214,7 @@ def get_max_dyadic_subsampling(xi, sigma, alpha, **unused_kwargs):
     Parameters
     ----------
     xi : float
-        frequency of the filter in [-1, 1]
+        frequency of the filter in [-0.5, 0.5]
     sigma : float
         frequential width of the filter
     alpha : float, optional

--- a/kymatio/scattering1d/filter_bank.py
+++ b/kymatio/scattering1d/filter_bank.py
@@ -204,7 +204,7 @@ def get_max_dyadic_subsampling(xi, sigma, alpha, **unused_kwargs):
     Finds the maximal integer j such that:
     omega_0 < 2^{-(j + 1)}
     where omega_0 is the boundary of the filter, defined as
-    omega_0 = xi + alpha * sigma
+    omega_0 = abs(xi) + alpha * sigma
 
     This ensures that the filter can be subsampled by a factor 2^j without
     aliasing.
@@ -214,7 +214,7 @@ def get_max_dyadic_subsampling(xi, sigma, alpha, **unused_kwargs):
     Parameters
     ----------
     xi : float
-        frequency of the filter in [0, 1]
+        frequency of the filter in [-1, 1]
     sigma : float
         frequential width of the filter
     alpha : float, optional
@@ -227,7 +227,7 @@ def get_max_dyadic_subsampling(xi, sigma, alpha, **unused_kwargs):
         integer such that 2^j is the maximal subsampling accepted by the
         Gabor filter without aliasing.
     """
-    upper_bound = min(xi + alpha * sigma, 0.5)
+    upper_bound = min(abs(xi) + alpha * sigma, 0.5)
     j = math.floor(-math.log2(upper_bound)) - 1
     j = int(j)
     return j

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -633,8 +633,8 @@ def test_986(backend):
     jtfs.create_filters()
 
     psis = jtfs.filters_fr[1]
-    positive_spins = sorted(psis[1:][: J_fr + 1], key=lambda x: x["xi"], reverse=True)
-    negative_spins = sorted(psis[1:][J_fr + 1 :], key=lambda x: x["xi"])
+    positive_spins = sorted([psi for psi in psis[1:] if np.sign(psi['xi']) > 0], key=lambda x: x["xi"], reverse=True)
+    negative_spins = sorted([psi for psi in psis[1:] if np.sign(psi['xi']) < 0], key=lambda x: x["xi"])
     assert all(
         [
             (psi_pos["j"] == psi_neg["j"])

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -620,3 +620,24 @@ def test_F(frontend):
     jtfs2 = TimeFrequencyScattering(frontend="torch", format="joint", F=2**kwargs['J_fr'] // 4, **kwargs)
     Sx2 = jtfs2(x)
     assert Sx0.shape[0] == Sx2.shape[0] and Sx0.shape[2] == Sx2.shape[2] and Sx0.shape[1] < Sx2.shape[1]
+
+
+backends = ["numpy", "torch", "tensorflow", "jax", "sklearn"]
+@pytest.mark.parametrize("backend", backends)
+def test_986(backend):
+    J_fr = 6
+    jtfs = TimeFrequencyScatteringBase(
+        J=8, J_fr=J_fr, shape=4096, Q=8, backend=backend
+    )
+    jtfs.build()
+    jtfs.create_filters()
+
+    psis = jtfs.filters_fr[1]
+    positive_spins = sorted(psis[1:][: J_fr + 1], key=lambda x: x["xi"], reverse=True)
+    negative_spins = sorted(psis[1:][J_fr + 1 :], key=lambda x: x["xi"])
+    assert all(
+        [
+            (psi_pos["j"] == psi_neg["j"])
+            for psi_pos, psi_neg in zip(positive_spins, negative_spins)
+        ]
+    )


### PR DESCRIPTION
fixes #986 

The new unit test failed without the introduction of `abs(xi)` in `get_max_dyadic_subsampling`. I test that `j` is mirrored for positive and negative spinned filters. This ensures that we subsample correctly for negative spin filters.