### PR TITLE
MAINT `oversampling` --> `stride`, immutable `Q` and `T`

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -241,17 +241,6 @@ class ScatteringBase1D(ScatteringBase):
         return parse_T(self._T, self.J, self.shape[0], T_alias='T')[1]
 
     @property
-    def oversampling(self):
-        warn("The attribute oversampling is deprecated and will be removed in v0.5. "
-        "Pass stride = 2**(J-oversampling) or stride = 2**(log2(T)-oversampling) "
-        "to retain current behavior.", DeprecationWarning)
-        return self._oversampling
-
-    @property
-    def average(self):
-        return parse_T(self._T, self.J, self.shape[0], T_alias='T')[1]
-
-    @property
     def filterbank(self):
         filterbank_kwargs = {
             "alpha": self.alpha, "r_psi": self.r_psi, "sigma0": self.sigma0}

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -14,17 +14,19 @@ from ..utils import compute_border_indices, compute_padding, parse_T
 
 
 class ScatteringBase1D(ScatteringBase):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2,
+    def __init__(self, J, shape, Q=1, T=None, stride=None, max_order=2,
                  oversampling=0, out_type='array', backend=None):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
         self.Q = Q
         self.T = T
+        self.stride = stride
         self.max_order = max_order
-        self.oversampling = oversampling
         self.out_type = out_type
         self.backend = backend
+
+        self._oversampling = oversampling
         self._reduction = np.mean
 
     def build(self):
@@ -95,12 +97,12 @@ class ScatteringBase1D(ScatteringBase):
             self._N_padded, self.J, self.Q, self.T, self.filterbank, self._reduction)
         ScatteringBase._check_filterbanks(self.psi1_f, self.psi2_f)
 
-    def scattering(self, x, stride=None):
-        ScatteringBase1D._check_runtime_args(self, stride)
+    def scattering(self, x):
+        ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
 
-        if stride is None:
-            oversampling = self.oversampling
+        if self.stride is None:
+            oversampling = self._oversampling
         else:
             oversampling = self.log2_T - int(math.floor(math.log2(stride)))
 
@@ -184,7 +186,7 @@ class ScatteringBase1D(ScatteringBase):
         backend = self._DryBackend()
         filters = [self.phi_f, self.psi1_f, self.psi2_f][:(1+self.max_order)]
         S_gen = scattering1d(
-            None, backend, filters, self.oversampling, average_local=False)
+            None, backend, filters, self._oversampling, average_local=False)
         S = sorted(list(S_gen), key=lambda path: (len(path['n']), path['n']))
         meta = dict(order=np.array([len(path['n']) for path in S]))
         meta['key'] = [path['n'] for path in S]
@@ -217,30 +219,31 @@ class ScatteringBase1D(ScatteringBase):
             return tuple(Counter(self.meta()['order']).values())
         return len(self.meta()['key'])
 
-    def _check_runtime_args(self, stride):
+    def _check_runtime_args(self):
         # check oversampling (NB: this will be removed in v0.5)
-        if self.oversampling < 0:
+        if self._oversampling < 0:
             raise ValueError("oversampling must be nonnegative. Got: {}".format(
-                self.oversampling))
-        if not isinstance(self.oversampling, numbers.Integral):
+                self._oversampling))
+        if not isinstance(self._oversampling, numbers.Integral):
             raise ValueError("oversampling must be integer. Got: {}".format(
-                self.oversampling))
-        if self.oversampling > 0:
+                self._oversampling))
+        if self._oversampling > 0:
             warn("oversampling is deprecated in v0.4 and will be removed"
                 " in v0.5. Pass stride = 2**(J-oversampling) or "
                 "stride = 2**(log2(T)-oversampling) "
                 "to retain current behavior.", DeprecationWarning)
-            if not stride is None:
+            if not self.stride is None:
                 raise ValueError("stride={} is incompatible with "
-                    "oversampling={}".format(stride, self.oversampling))
+                    "oversampling={}".format(self.stride, self._oversampling))
 
-        if not stride is None:
-            if not isinstance(stride, numbers.Integral):
+        if not self.stride is None:
+            if not isinstance(self.stride, numbers.Integral):
                 raise ValueError("stride must be integer. Got: {}".format(
-                    stride))
-            if math.floor(math.log2(x)) != math.ceil(math.log2(x)):
+                    self.stride))
+            log2_stride = math.log2(self.stride)
+            if math.floor(log2_stride) != math.ceil(log2_stride):
                 raise ValueError("stride must be a power of two. Got: {}".format(
-                    stride))
+                    self.stride))
 
         if (self.T==0) or (self.T=="global"):
             raise ValueError("stride={} is incompatible with T={}.".format(
@@ -536,12 +539,12 @@ class ScatteringBase1D(ScatteringBase):
 
 
 class TimeFrequencyScatteringBase(ScatteringBase1D):
-    def __init__(self, *, J, J_fr, shape, Q, T=None, oversampling=0,
-            Q_fr=1, F=None, oversampling_fr=0,
+    def __init__(self, *, J, J_fr, shape, Q, T=None, stride=None,
+            oversampling=0, Q_fr=1, F=None, oversampling_fr=0,
             out_type='array', format='joint', backend=None):
         max_order = 2
         super(TimeFrequencyScatteringBase, self).__init__(J, shape, Q, T,
-            max_order, oversampling, out_type, backend)
+            stride, max_order, oversampling, out_type, backend)
         self.J_fr = J_fr
         self.Q_fr = Q_fr
         self.F = F
@@ -597,7 +600,7 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         assert all((abs(psi1["xi"]) < 0.5/(2**psi1["j"])) for psi1 in psis_fr_f)
 
     def scattering(self, x, stride=None):
-        TimeFrequencyScatteringBase._check_runtime_args(self, stride)
+        TimeFrequencyScatteringBase._check_runtime_args(self)
         TimeFrequencyScatteringBase._check_input(self, x)
 
         x_shape = self.backend.shape(x)
@@ -608,11 +611,11 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
 
         filters = [self.phi_f, self.psi1_f, self.psi2_f]
         U_gen = joint_timefrequency_scattering(U_0, self.backend,
-            filters, self.oversampling, (self.average=='local'),
+            filters, self._oversampling, (self.average=='local'),
             self.filters_fr, self.oversampling_fr, (self.average_fr=='local'))
 
         S_gen = jtfs_average_and_format(U_gen, self.backend,
-            self.phi_f, self.oversampling, self.average,
+            self.phi_f, self._oversampling, self.average,
             self.filters_fr[0], self.oversampling_fr, self.average_fr,
             self.out_type, self.format)
 
@@ -639,10 +642,10 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
             if not self.average == 'global':
                 if not self.average and len(path['n']) > 1:
                     # Case 3b.
-                    res = max(path['j'][-1] - self.oversampling, 0)
+                    res = max(path['j'][-1] - self._oversampling, 0)
                 else:
                     # Cases 2a, 2b, and 3a.
-                    res = max(self.log2_T - self.oversampling, 0)
+                    res = max(self.log2_T - self._oversampling, 0)
                 # Cases 2a, 2b, 3a, and 3b.
                 path['coef'] = self.backend.unpad(
                     path['coef'], self.ind_start[res], self.ind_end[res])
@@ -670,10 +673,10 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
     def meta(self):
         filters = [self.phi_f, self.psi1_f, self.psi2_f]
         U_gen = joint_timefrequency_scattering(None, self._DryBackend(),
-            filters, self.oversampling, self.average=='local',
+            filters, self._oversampling, self.average=='local',
             self.filters_fr, self.oversampling_fr, self.average_fr=='local')
         S_gen = jtfs_average_and_format(U_gen, self._DryBackend(),
-            self.phi_f, self.oversampling, self.average,
+            self.phi_f, self._oversampling, self.average,
             self.filters_fr[0], self.oversampling_fr, self.average_fr,
             self.out_type, self.format)
         S = sorted(list(S_gen), key=lambda path: (len(path['n']), path['n']))
@@ -717,8 +720,8 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         meta['spin'] = np.sign(meta['xi_fr'])
         return meta
 
-    def _check_runtime_args(self, stride):
-        super(TimeFrequencyScatteringBase, self)._check_runtime_args(stride)
+    def _check_runtime_args(self):
+        super(TimeFrequencyScatteringBase, self)._check_runtime_args()
 
         if self.format == 'joint':
             if (not self.average_fr) and (self.out_type == 'array'):

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -237,20 +237,6 @@ class ScatteringBase1D(ScatteringBase):
                     len(x.shape)))
 
     @property
-    def J_pad(self):
-        warn("The attribute J_pad is deprecated and will be removed in v0.4. "
-        "Measure len(self.phi_f[0]) for the padded length (previously 2**J_pad) "
-        "or access shape[0] for the unpadded length (previously N).", DeprecationWarning)
-        return int(np.log2(self._N_padded))
-
-    @property
-    def N(self):
-        warn("The attribute N is deprecated and will be removed in v0.4. "
-        "Measure len(self.phi_f[0]) for the padded length (previously 2**J_pad) "
-        "or access shape[0] for the unpadded length (previously N).", DeprecationWarning)
-        return int(self.shape[0])
-
-    @property
     def filterbank(self):
         filterbank_kwargs = {
             "alpha": self.alpha, "r_psi": self.r_psi, "sigma0": self.sigma0}

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -19,9 +19,9 @@ class ScatteringBase1D(ScatteringBase):
         super(ScatteringBase1D, self).__init__()
         self.J = J
         self.shape = shape
-        self.Q = Q
-        self.T = T
-        self.stride = stride
+        self._Q = Q
+        self._T = T
+        self._stride = stride
         self.max_order = max_order
         self.out_type = out_type
         self.backend = backend
@@ -42,36 +42,35 @@ class ScatteringBase1D(ScatteringBase):
         self.sigma0 = 0.1
         self.alpha = 5.
 
-        # check the number of filters per octave
-        if np.any(np.array(self.Q) < 1):
-            raise ValueError('Q must always be >= 1, got {}'.format(self.Q))
-
-        if isinstance(self.Q, int):
-            self.Q = (self.Q, 1)
-        elif isinstance(self.Q, tuple):
-            if len(self.Q) == 1:
-                self.Q = self.Q + (1, )
-            elif len(self.Q) < 1 or len(self.Q) > 2:
-                raise NotImplementedError("Q must be an integer, 1-tuple or "
-                                          "2-tuple. Scattering transforms "
-                                          "beyond order 2 are not implemented.")
-        else:
-            raise ValueError("Q must be an integer or a tuple")
-
         # check input length
         if isinstance(self.shape, numbers.Integral):
             self.shape = (self.shape,)
         elif isinstance(self.shape, tuple):
             if len(self.shape) > 1:
                 raise ValueError("If shape is specified as a tuple, it must "
-                                 "have exactly one element")
+                    "have exactly one element. Got: {}".format(self.shape))
+            self.shape = self.shape
         else:
-            raise ValueError("shape must be an integer or a 1-tuple")
+            raise ValueError("shape must be an integer or a 1-tuple. "
+                "Got: {}".format(self.shape))
         N_input = self.shape[0]
 
-        # check T or set default
-        self.T, self.average = parse_T(self.T, self.J, N_input)
-        self.log2_T = math.floor(math.log2(self.T))
+        # check oversampling (NB: this will be removed in v0.5)
+        if self._oversampling < 0:
+            raise ValueError("oversampling must be nonnegative. Got: {}".format(
+                self._oversampling))
+        if not isinstance(self._oversampling, numbers.Integral):
+            raise ValueError("oversampling must be integer. Got: {}".format(
+                self._oversampling))
+        if self._oversampling > 0:
+            warn("oversampling is deprecated in and will be removed in v0.5."
+                "Pass stride = 2**(J-oversampling) or "
+                "stride = 2**(log2(T)-oversampling) "
+                "to retain current behavior.", DeprecationWarning)
+            if not self._stride in [None, 2**(self.log2_T-self._oversampling-1)]:
+                raise ValueError("oversampling={} and stride={}"
+                    "are incompatible".format(self._oversampling, self._stride))
+            self._stride = 2 ** (self.log2_T-self._oversampling)
 
         # Compute the minimum support to pad (ideally)
         phi_f = gauss_1d(N_input, self.sigma0/self.T)
@@ -101,11 +100,6 @@ class ScatteringBase1D(ScatteringBase):
         ScatteringBase1D._check_runtime_args(self)
         ScatteringBase1D._check_input(self, x)
 
-        if self.stride is None:
-            oversampling = self._oversampling
-        else:
-            oversampling = self.log2_T - int(math.floor(math.log2(stride)))
-
         x_shape = self.backend.shape(x)
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
         x = self.backend.reshape_input(x, signal_shape)
@@ -114,7 +108,7 @@ class ScatteringBase1D(ScatteringBase):
 
         filters = [self.phi_f, self.psi1_f, self.psi2_f][:(1+self.max_order)]
         S_gen = scattering1d(U_0, self.backend, filters,
-            oversampling, (self.average=='local'))
+            self.log2_stride, (self.average=='local'))
 
         if self.out_type in ['array', 'list']:
             S = list()
@@ -124,9 +118,9 @@ class ScatteringBase1D(ScatteringBase):
         for path in S_gen:
             path['order'] = len(path['n'])
             if self.average == 'local':
-                res = max(self.log2_T - oversampling, 0)
+                res = self.log2_stride
             elif path['order']>0:
-                res = max(path['j'][-1] - oversampling, 0)
+                res = max(path['j'][-1] - self._oversampling, 0)
             else:
                 res = 0
 
@@ -186,7 +180,7 @@ class ScatteringBase1D(ScatteringBase):
         backend = self._DryBackend()
         filters = [self.phi_f, self.psi1_f, self.psi2_f][:(1+self.max_order)]
         S_gen = scattering1d(
-            None, backend, filters, self._oversampling, average_local=False)
+            None, backend, filters, self.log2_stride, average_local=False)
         S = sorted(list(S_gen), key=lambda path: (len(path['n']), path['n']))
         meta = dict(order=np.array([len(path['n']) for path in S]))
         meta['key'] = [path['n'] for path in S]
@@ -220,35 +214,6 @@ class ScatteringBase1D(ScatteringBase):
         return len(self.meta()['key'])
 
     def _check_runtime_args(self):
-        # check oversampling (NB: this will be removed in v0.5)
-        if self._oversampling < 0:
-            raise ValueError("oversampling must be nonnegative. Got: {}".format(
-                self._oversampling))
-        if not isinstance(self._oversampling, numbers.Integral):
-            raise ValueError("oversampling must be integer. Got: {}".format(
-                self._oversampling))
-        if self._oversampling > 0:
-            warn("oversampling is deprecated in v0.4 and will be removed"
-                " in v0.5. Pass stride = 2**(J-oversampling) or "
-                "stride = 2**(log2(T)-oversampling) "
-                "to retain current behavior.", DeprecationWarning)
-            if not self.stride is None:
-                raise ValueError("stride={} is incompatible with "
-                    "oversampling={}".format(self.stride, self._oversampling))
-
-        if not self.stride is None:
-            if not isinstance(self.stride, numbers.Integral):
-                raise ValueError("stride must be integer. Got: {}".format(
-                    self.stride))
-            log2_stride = math.log2(self.stride)
-            if math.floor(log2_stride) != math.ceil(log2_stride):
-                raise ValueError("stride must be a power of two. Got: {}".format(
-                    self.stride))
-
-        if (self.T==0) or (self.T=="global"):
-            raise ValueError("stride={} is incompatible with T={}.".format(
-                stride, self.T))
-
         if not self.out_type in ('array', 'dict', 'list'):
             raise ValueError("out_type must be one of 'array', 'dict'"
                              ", or 'list'. Got: {}".format(self.out_type))
@@ -265,10 +230,67 @@ class ScatteringBase1D(ScatteringBase):
                     len(x.shape)))
 
     @property
+    def oversampling(self):
+        warn("The attribute oversampling is deprecated and will be removed in v0.5. "
+        "Pass stride = 2**(J-oversampling) or stride = 2**(log2(T)-oversampling) "
+        "to retain current behavior.", DeprecationWarning)
+        return self._oversampling
+
+    @property
+    def average(self):
+        return parse_T(self._T, self.J, self.shape[0], T_alias='T')[1]
+
+    @property
     def filterbank(self):
         filterbank_kwargs = {
             "alpha": self.alpha, "r_psi": self.r_psi, "sigma0": self.sigma0}
         return (anden_generator, filterbank_kwargs)
+
+    @property
+    def log2_stride(self):
+        if self._stride is None:
+            return self.log2_T
+        if not isinstance(self._stride, numbers.Integral):
+            raise ValueError("stride must be integer. Got: {}".format(
+                self._stride))
+        log2_stride = math.log2(self._stride)
+        if math.floor(log2_stride) != math.ceil(log2_stride):
+            raise ValueError("stride must be a power of two. Got: {}".format(
+                self._stride))
+        if self.average in [False, "global"]:
+            raise ValueError("stride={} is incompatible with T={}.".format(
+                self._stride, self._T))
+        return int(log2_stride)
+
+    @property
+    def log2_T(self):
+        return int(math.floor(math.log2(self.T)))
+
+    @property
+    def Q(self):
+        if np.any(np.array(self._Q) < 1):
+            raise ValueError('Q must always be >= 1, got {}'.format(self._Q))
+        if isinstance(self._Q, int):
+            return (self._Q, 1)
+        elif isinstance(self._Q, tuple):
+            if len(self._Q) == 1:
+                return (self._Q + (1,))
+            elif len(self._Q) == 2:
+                return self._Q
+            raise NotImplementedError("Q must be an integer, 1-tuple or "
+                "2-tuple. Scattering transforms beyond order 2 are not "
+                "implemented. Got: {}".format(self._Q))
+        else:
+            raise ValueError("Q must be an integer or a tuple")
+
+    @property
+    def stride(self):
+        return (2**self.log2_stride)
+
+    @property
+    def T(self):
+        return parse_T(self._T, self.J, self.shape[0], T_alias='T')[0]
+
 
     _doc_shape = 'N'
 
@@ -611,18 +633,18 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
 
         filters = [self.phi_f, self.psi1_f, self.psi2_f]
         U_gen = joint_timefrequency_scattering(U_0, self.backend,
-            filters, self._oversampling, (self.average=='local'),
+            filters, self.log2_stride, (self.average=='local'),
             self.filters_fr, self.oversampling_fr, (self.average_fr=='local'))
 
         S_gen = jtfs_average_and_format(U_gen, self.backend,
-            self.phi_f, self._oversampling, self.average,
+            self.phi_f, self.log2_stride, self.average,
             self.filters_fr[0], self.oversampling_fr, self.average_fr,
             self.out_type, self.format)
 
         # Zeroth order
         path = next(S_gen)
         if not self.average == 'global':
-            res = self.log2_T if self.average else 0
+            res = self.log2_stride if self.average else 0
             path['coef'] = self.backend.unpad(
                 path['coef'], self.ind_start[res], self.ind_end[res])
         path['coef'] = self.backend.reshape_output(
@@ -642,10 +664,10 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
             if not self.average == 'global':
                 if not self.average and len(path['n']) > 1:
                     # Case 3b.
-                    res = max(path['j'][-1] - self._oversampling, 0)
+                    res = max(path['j'][-1], 0)
                 else:
                     # Cases 2a, 2b, and 3a.
-                    res = max(self.log2_T - self._oversampling, 0)
+                    res = max(self.log2_stride, 0)
                 # Cases 2a, 2b, 3a, and 3b.
                 path['coef'] = self.backend.unpad(
                     path['coef'], self.ind_start[res], self.ind_end[res])
@@ -673,10 +695,10 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
     def meta(self):
         filters = [self.phi_f, self.psi1_f, self.psi2_f]
         U_gen = joint_timefrequency_scattering(None, self._DryBackend(),
-            filters, self._oversampling, self.average=='local',
+            filters, self.log2_stride, self.average=='local',
             self.filters_fr, self.oversampling_fr, self.average_fr=='local')
         S_gen = jtfs_average_and_format(U_gen, self._DryBackend(),
-            self.phi_f, self._oversampling, self.average,
+            self.phi_f, self.log2_stride, self.average,
             self.filters_fr[0], self.oversampling_fr, self.average_fr,
             self.out_type, self.format)
         S = sorted(list(S_gen), key=lambda path: (len(path['n']), path['n']))

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -10,7 +10,7 @@ from ..core.timefrequency_scattering import (joint_timefrequency_scattering,
     jtfs_average_and_format)
 from ..filter_bank import (compute_temporal_support, gauss_1d,
     anden_generator, scattering_filter_factory, spin)
-from ..utils import compute_border_indices, compute_padding, parse_T
+from ..utils import compute_border_indices, compute_padding, ispow2, parse_T
 
 
 class ScatteringBase1D(ScatteringBase):
@@ -95,9 +95,14 @@ class ScatteringBase1D(ScatteringBase):
             self._N_padded, self.J, self.Q, self.T, self.filterbank, self._reduction)
         ScatteringBase._check_filterbanks(self.psi1_f, self.psi2_f)
 
-    def scattering(self, x):
-        ScatteringBase1D._check_runtime_args(self)
+    def scattering(self, x, stride=None):
+        ScatteringBase1D._check_runtime_args(self, stride)
         ScatteringBase1D._check_input(self, x)
+
+        if stride is None:
+            oversampling = self.oversampling
+        else:
+            oversampling = self.log2_T - int(math.floor(math.log2(stride)))
 
         x_shape = self.backend.shape(x)
         batch_shape, signal_shape = x_shape[:-1], x_shape[-1:]
@@ -107,7 +112,7 @@ class ScatteringBase1D(ScatteringBase):
 
         filters = [self.phi_f, self.psi1_f, self.psi2_f][:(1+self.max_order)]
         S_gen = scattering1d(U_0, self.backend, filters,
-            self.oversampling, (self.average=='local'))
+            oversampling, (self.average=='local'))
 
         if self.out_type in ['array', 'list']:
             S = list()
@@ -117,9 +122,9 @@ class ScatteringBase1D(ScatteringBase):
         for path in S_gen:
             path['order'] = len(path['n'])
             if self.average == 'local':
-                res = max(self.log2_T - self.oversampling, 0)
+                res = max(self.log2_T - oversampling, 0)
             elif path['order']>0:
-                res = max(path['j'][-1] - self.oversampling, 0)
+                res = max(path['j'][-1] - oversampling, 0)
             else:
                 res = 0
 
@@ -212,7 +217,35 @@ class ScatteringBase1D(ScatteringBase):
             return tuple(Counter(self.meta()['order']).values())
         return len(self.meta()['key'])
 
-    def _check_runtime_args(self):
+    def _check_runtime_args(self, stride):
+        # check oversampling (NB: this will be removed in v0.5)
+        if self.oversampling < 0:
+            raise ValueError("oversampling must be nonnegative. Got: {}".format(
+                self.oversampling))
+        if not isinstance(self.oversampling, numbers.Integral):
+            raise ValueError("oversampling must be integer. Got: {}".format(
+                self.oversampling))
+        if self.oversampling > 0:
+            warn("oversampling is deprecated in v0.4 and will be removed"
+                " in v0.5. Pass stride = 2**(J-oversampling) or "
+                "stride = 2**(log2(T)-oversampling) "
+                "to retain current behavior.", DeprecationWarning)
+            if not stride is None:
+                raise ValueError("stride={} is incompatible with "
+                    "oversampling={}".format(stride, self.oversampling))
+
+        if not stride is None:
+            if not isinstance(stride, numbers.Integral):
+                raise ValueError("stride must be integer. Got: {}".format(
+                    stride))
+            if not ispow2(stride):
+                raise ValueError("stride must be a power of two. Got: {}".format(
+                    stride))
+
+        if (self.T==0) or (self.T=="global"):
+            raise ValueError("stride={} is incompatible with T={}.".format(
+                stride, self.T))
+
         if not self.out_type in ('array', 'dict', 'list'):
             raise ValueError("out_type must be one of 'array', 'dict'"
                              ", or 'list'. Got: {}".format(self.out_type))
@@ -220,14 +253,6 @@ class ScatteringBase1D(ScatteringBase):
         if not self.average and self.out_type == 'array':
             raise ValueError("Cannot convert to out_type='array' with "
                              "T=0. Please set out_type to 'dict' or 'list'.")
-
-        if self.oversampling < 0:
-            raise ValueError("oversampling must be nonnegative. Got: {}".format(
-                self.oversampling))
-
-        if not isinstance(self.oversampling, numbers.Integral):
-            raise ValueError("oversampling must be integer. Got: {}".format(
-                self.oversampling))
 
     def _check_input(self, x):
         # basic checking, should be improved
@@ -571,8 +596,8 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         # Check for absence of aliasing
         assert all((abs(psi1["xi"]) < 0.5/(2**psi1["j"])) for psi1 in psis_fr_f)
 
-    def scattering(self, x):
-        TimeFrequencyScatteringBase._check_runtime_args(self)
+    def scattering(self, x, stride=None):
+        TimeFrequencyScatteringBase._check_runtime_args(self, stride)
         TimeFrequencyScatteringBase._check_input(self, x)
 
         x_shape = self.backend.shape(x)
@@ -692,8 +717,8 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         meta['spin'] = np.sign(meta['xi_fr'])
         return meta
 
-    def _check_runtime_args(self):
-        super(TimeFrequencyScatteringBase, self)._check_runtime_args()
+    def _check_runtime_args(self, stride):
+        super(TimeFrequencyScatteringBase, self)._check_runtime_args(stride)
 
         if self.format == 'joint':
             if (not self.average_fr) and (self.out_type == 'array'):

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -10,7 +10,7 @@ from ..core.timefrequency_scattering import (joint_timefrequency_scattering,
     jtfs_average_and_format)
 from ..filter_bank import (compute_temporal_support, gauss_1d,
     anden_generator, scattering_filter_factory, spin)
-from ..utils import compute_border_indices, compute_padding, ispow2, parse_T
+from ..utils import compute_border_indices, compute_padding, parse_T
 
 
 class ScatteringBase1D(ScatteringBase):
@@ -238,7 +238,7 @@ class ScatteringBase1D(ScatteringBase):
             if not isinstance(stride, numbers.Integral):
                 raise ValueError("stride must be integer. Got: {}".format(
                     stride))
-            if not ispow2(stride):
+            if math.floor(math.log2(x)) != math.ceil(math.log2(x)):
                 raise ValueError("stride must be a power of two. Got: {}".format(
                     stride))
 

--- a/kymatio/scattering1d/frontend/jax_frontend.py
+++ b/kymatio/scattering1d/frontend/jax_frontend.py
@@ -11,11 +11,11 @@ class ScatteringJax1D(ScatteringJax, ScatteringNumPy1D):
     # be loaded
 
 
-    def __init__(self, J, shape, Q=1, T=None, max_order=2,
+    def __init__(self, J, shape, Q=1, T=None, stride=None, max_order=2,
             oversampling=0, out_type='array', backend='jax'):
 
         ScatteringJax.__init__(self)
-        ScatteringBase1D.__init__(self, J, shape, Q, T, max_order,
+        ScatteringBase1D.__init__(self, J, shape, Q, T, stride, max_order,
                 oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -9,15 +9,19 @@ from tensorflow.python.framework import tensor_shape
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, T=None, max_order=2, oversampling=0):
         ScatteringKeras.__init__(self)
-        ScatteringBase1D.__init__(self, J, shape=None, Q=Q, T=T, stride=None,
-            max_order=max_order, oversampling=oversampling,
-            out_type='array', backend=None)
+        self.J = J
+        self._Q = Q
+        self._T = T
+        self._max_order = 2
+        self._oversampling = 0
+        self.out_type = 'array'
+        self.backend = None
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
         self.S = ScatteringTensorFlow1D(J=self.J, shape=shape,
-                                        Q=self.Q, max_order=self.max_order,
-                                        oversampling=self._oversampling, T=self.T)
+            Q=self._Q, T=self._T, max_order=self._max_order,
+            oversampling=self._oversampling)
         ScatteringKeras.build(self, input_shape)
 
     def compute_output_shape(self, input_shape):

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -9,20 +9,21 @@ from tensorflow.python.framework import tensor_shape
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, T=None, max_order=2, oversampling=0):
         ScatteringKeras.__init__(self)
-        ScatteringBase1D.__init__(self, J, shape=None, Q=Q, T=T, max_order=max_order,
-            oversampling=oversampling, out_type='array', backend=None)
+        ScatteringBase1D.__init__(self, J, shape=None, Q=Q, T=T, stride=None,
+            max_order=max_order, oversampling=oversampling,
+            out_type='array', backend=None)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
         self.S = ScatteringTensorFlow1D(J=self.J, shape=shape,
                                         Q=self.Q, max_order=self.max_order,
-                                        oversampling=self.oversampling, T=self.T)
+                                        oversampling=self._oversampling, T=self.T)
         ScatteringKeras.build(self, input_shape)
 
     def compute_output_shape(self, input_shape):
         input_shape = tensor_shape.TensorShape(input_shape).as_list()
         nc = self.S.output_size()
-        k0 = max(self.J - self.oversampling, 0)
+        k0 = max(self.J - self._oversampling, 0)
         ln = self.S.ind_end[k0] - self.S.ind_start[k0]
         output_shape = [input_shape[0], nc, ln]
         return tensor_shape.TensorShape(output_shape)

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -5,11 +5,11 @@ from .base_frontend import ScatteringBase1D, TimeFrequencyScatteringBase
 
 
 class ScatteringNumPy1D(ScatteringNumPy, ScatteringBase1D):
-    def __init__(self, J, shape, Q=1, T=None, max_order=2,
+    def __init__(self, J, shape, Q=1, T=None, stride=None, max_order=2,
             oversampling=0, out_type='array', backend='numpy'):
         ScatteringNumPy.__init__(self)
-        ScatteringBase1D.__init__(self, J, shape, Q, T, max_order,
-                oversampling, out_type, backend)
+        ScatteringBase1D.__init__(self, J, shape, Q, T, stride, max_order,
+            oversampling, out_type, backend)
         ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
@@ -19,12 +19,12 @@ ScatteringNumPy1D._document()
 
 class TimeFrequencyScatteringNumPy(
         ScatteringNumPy1D, TimeFrequencyScatteringBase):
-    def __init__(self, *, J, J_fr, shape, Q, T=None, oversampling=0,
-            Q_fr=1, F=None, oversampling_fr=0,
+    def __init__(self, *, J, J_fr, shape, Q, T=None, stride=None,
+            oversampling=0, Q_fr=1, F=None, oversampling_fr=0,
             out_type='array', format='joint', backend='numpy'):
         ScatteringNumPy.__init__(self)
         TimeFrequencyScatteringBase.__init__(self, J=J, J_fr=J_fr, shape=shape,
-            Q=Q, T=T, oversampling=oversampling,
+            Q=Q, T=T, stride=stride, oversampling=oversampling,
             Q_fr=Q_fr, F=F, oversampling_fr=oversampling_fr,
             out_type=out_type, format=format, backend=backend)
         ScatteringBase1D._instantiate_backend(

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -12,6 +12,7 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
         shape,
         Q=1,
         T=None,
+        stride=None,
         max_order=2,
         oversampling=0,
         out_type="array",
@@ -20,7 +21,7 @@ class ScatteringTensorFlow1D(ScatteringTensorFlow, ScatteringBase1D):
     ):
         ScatteringTensorFlow.__init__(self, name=name)
         ScatteringBase1D.__init__(
-            self, J, shape, Q, T, max_order, oversampling, out_type, backend
+            self, J, shape, Q, T, stride, max_order, oversampling, out_type, backend
         )
         ScatteringBase1D._instantiate_backend(self, "kymatio.scattering1d.backend.")
         ScatteringBase1D.build(self)
@@ -41,6 +42,7 @@ class TimeFrequencyScatteringTensorFlow(
         shape,
         Q,
         T=None,
+        stride=None,
         oversampling=0,
         Q_fr=1,
         F=None,
@@ -58,6 +60,7 @@ class TimeFrequencyScatteringTensorFlow(
             shape=shape,
             Q=Q,
             T=T,
+            stride=stride,
             oversampling=oversampling,
             Q_fr=Q_fr,
             F=F,

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -12,6 +12,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
         shape,
         Q=1,
         T=None,
+        stride=None,
         max_order=2,
         oversampling=0,
         out_type="array",
@@ -19,7 +20,7 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
     ):
         ScatteringTorch.__init__(self)
         ScatteringBase1D.__init__(
-            self, J, shape, Q, T, max_order, oversampling, out_type, backend
+            self, J, shape, Q, T, stride, max_order, oversampling, out_type, backend
         )
         ScatteringBase1D._instantiate_backend(self, "kymatio.scattering1d.backend.")
         ScatteringBase1D.build(self)
@@ -91,6 +92,7 @@ class TimeFrequencyScatteringTorch(ScatteringTorch1D, TimeFrequencyScatteringBas
         shape,
         Q,
         T=None,
+        stride=None,
         oversampling=0,
         Q_fr=1,
         F=None,
@@ -107,6 +109,7 @@ class TimeFrequencyScatteringTorch(ScatteringTorch1D, TimeFrequencyScatteringBas
             shape=shape,
             Q=Q,
             T=T,
+            stride=stride,
             oversampling=oversampling,
             Q_fr=Q_fr,
             F=F,

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -68,6 +68,21 @@ def compute_padding(N, N_input):
     return pad_left, pad_right
 
 
+def ispow2(x):
+    """
+    Checks if a positive number is a power of two.
+
+    Parameters
+    ----------
+    x : int
+
+    Returns
+    -------
+    b : boolean
+    """
+    return math.floor(math.log2(x)) == math.ceil(math.log2(x))
+
+
 def parse_T(T, J, N_input, T_alias='T'):
     """
     Parses T in Scattering1D base frontend.

--- a/kymatio/scattering1d/utils.py
+++ b/kymatio/scattering1d/utils.py
@@ -68,21 +68,6 @@ def compute_padding(N, N_input):
     return pad_left, pad_right
 
 
-def ispow2(x):
-    """
-    Checks if a positive number is a power of two.
-
-    Parameters
-    ----------
-    x : int
-
-    Returns
-    -------
-    b : boolean
-    """
-    return math.floor(math.log2(x)) == math.ceil(math.log2(x))
-
-
 def parse_T(T, J, N_input, T_alias='T'):
     """
     Parses T in Scattering1D base frontend.

--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -22,8 +22,8 @@ def test_Scattering1D():
     Sx0 = data['Sx']
     # default
     inputs0 = Input(shape=(x.shape[-1]))
-    scat0 = Scattering1D(J=J, Q=Q)(inputs0)
-    model0 = Model(inputs0, scat0)
+    sc0 = Scattering1D(J=J, Q=Q)(inputs0)
+    model0 = Model(inputs0, sc0)
     model0.compile(optimizer='adam',
                   loss='sparse_categorical_crossentropy',
                   metrics=['accuracy'])
@@ -33,13 +33,14 @@ def test_Scattering1D():
     sigma_low_scale_factor = 2
     T = 2**(J-sigma_low_scale_factor)
     inputs1 = Input(shape=(x.shape[-1]))
-    scat1 = Scattering1D(J=J, Q=Q, T=T)(inputs1)
-    model1 = Model(inputs1, scat1)
+    sc1 = Scattering1D(J=J, Q=Q, T=T)(inputs1)
+    model1 = Model(inputs1, sc1)
     model1.compile(optimizer='adam',
                   loss='sparse_categorical_crossentropy',
                   metrics=['accuracy'])
     Sg1 = model1.predict(x)
-    assert Sg1.shape == (Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**(sigma_low_scale_factor))
+    assert Sg1.shape == (
+        Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**(sigma_low_scale_factor))
 
     save_stdout = sys.stdout
     result = io.StringIO()
@@ -48,6 +49,10 @@ def test_Scattering1D():
     sys.stdout = save_stdout
     assert 'scattering1d' in result.getvalue()
   
+    sc0 = Scattering1D(J=J, Q=Q)
+    sc0.build(inputs0.shape)
+    print(sc0.compute_output_shape(inputs0.shape))
+
 def test_Q():
     J = 3
     length = 1024
@@ -55,11 +60,13 @@ def test_Q():
 
     # test different cases for Q
     with pytest.raises(ValueError) as ve:
-        _ = Scattering1D(J=J, Q=0.9)(inputs)
+        S = Scattering1D(J=J, Q=0.9)(inputs)
+        Q = S.Q
     assert "Q must always be >= 1" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
-        _ = Scattering1D(J=J, Q=[8])(inputs)
+        S = Scattering1D(J=J, Q=[8])(inputs)
+        Q = S.Q
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
     Sc_int = Scattering1D(J=J, Q=(8, ))(inputs)
@@ -82,4 +89,3 @@ def test_Q():
     Sc_tuple_out = model1.predict(x)
 
     assert Sc_int_out.shape == (Sc_tuple_out.shape[0], Sc_tuple_out.shape[1], Sc_tuple_out.shape[2])
-    assert np.allclose(Sc_int_out, Sc_tuple_out)

--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -51,7 +51,7 @@ def test_Scattering1D():
   
     sc0 = Scattering1D(J=J, Q=Q)
     sc0.build(inputs0.shape)
-    print(sc0.compute_output_shape(inputs0.shape))
+    assert sc0.compute_output_shape(inputs0.shape)[-1] == 8
 
 def test_Q():
     J = 3

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -32,6 +32,8 @@ class TestScattering1DNumpy:
         Sx = scattering(x)
         assert Sx.shape == Sx0.shape
         assert np.allclose(Sx, Sx0)
+        assert scattering.oversampling==0
+        assert scattering.N == scattering.shape[0]
 
     def test_Scattering1D_T(self, backend):
         """

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -137,11 +137,13 @@ def test_Q(backend, frontend):
 
     # test different cases for Q
     with pytest.raises(ValueError) as ve:
-        _ = Scattering1D(J, shape, Q=0.9, backend=backend, frontend=frontend)
+        S = Scattering1D(J, shape, Q=0.9, backend=backend, frontend=frontend)
+        Q = S.Q
     assert "Q must always be >= 1" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
-        _ = Scattering1D(J, shape, Q=[8], backend=backend, frontend=frontend)
+        S = Scattering1D(J, shape, Q=[8], backend=backend, frontend=frontend)
+        Q = S.Q
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
     Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend=frontend)

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -146,6 +146,11 @@ def test_Q(backend, frontend):
         Q = S.Q
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
+    with pytest.raises(NotImplementedError) as ve:
+        S = Scattering1D(J, shape, Q=(1, 1, 1), backend=backend, frontend=frontend)
+        Q = S.Q
+    assert "Scattering transforms beyond order 2 are not implemented" in ve.value.args[0]
+
     Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend=frontend)
     Sc_tuple = Scattering1D(J, shape, Q=(8, 1), backend=backend, frontend=frontend)
 

--- a/tests/scattering1d/test_numpy_scattering1d.py
+++ b/tests/scattering1d/test_numpy_scattering1d.py
@@ -33,7 +33,6 @@ class TestScattering1DNumpy:
         assert Sx.shape == Sx0.shape
         assert np.allclose(Sx, Sx0)
         assert scattering.oversampling==0
-        assert scattering.N == scattering.shape[0]
 
     def test_Scattering1D_T(self, backend):
         """

--- a/tests/scattering1d/test_tensorflow_scattering1d.py
+++ b/tests/scattering1d/test_tensorflow_scattering1d.py
@@ -42,13 +42,15 @@ def test_Q(backend):
 
     # test different cases for Q
     with pytest.raises(ValueError) as ve:
-        _ = Scattering1D(
+        S = Scattering1D(
             J, shape, Q=0.9, backend=backend, frontend='tensorflow')
+        Q = S.Q
     assert "Q must always be >= 1" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
-        _ = Scattering1D(
+        S = Scattering1D(
             J, shape, Q=[8], backend=backend, frontend='tensorflow')
+        Q = S.Q
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
     Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='tensorflow')

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -75,54 +75,54 @@ def test_check_runtime_args():
     kwargs = dict(J=10, J_fr=3, shape=4096, Q=8)
     S = TimeFrequencyScatteringBase(**kwargs)
     S.build()
-    assert S._check_runtime_args() is None
+    assert S._check_runtime_args(stride=None) is None
 
     with pytest.raises(ValueError) as ve:
         S = TimeFrequencyScatteringBase(out_type="doesnotexist", **kwargs)
         S.build()
-        S._check_runtime_args()
+        S._check_runtime_args(stride=None)
     assert "out_type must be one of" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
         S = TimeFrequencyScatteringBase(T=0, **kwargs)
         S.build()
-        S._check_runtime_args()
+        S._check_runtime_args(stride=None)
     assert "Cannot convert" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
         S = TimeFrequencyScatteringBase(oversampling=-1, **kwargs)
         S.build()
-        S._check_runtime_args()
+        S._check_runtime_args(stride=None)
     assert "nonnegative" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
         S = TimeFrequencyScatteringBase(oversampling=0.5, **kwargs)
         S.build()
-        S._check_runtime_args()
+        S._check_runtime_args(stride=None)
     assert "integer" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
         S = TimeFrequencyScatteringBase(F=0, out_type="array", format="joint", **kwargs)
         S.build()
-        S._check_runtime_args()
+        S._check_runtime_args(stride=None)
     assert "Cannot convert" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
         S = TimeFrequencyScatteringBase(oversampling_fr=-1, **kwargs)
         S.build()
-        S._check_runtime_args()
+        S._check_runtime_args(stride=None)
     assert "nonnegative" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
         S = TimeFrequencyScatteringBase(oversampling_fr=0.5, **kwargs)
         S.build()
-        S._check_runtime_args()
+        S._check_runtime_args(stride=None)
     assert "integer" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
         S = TimeFrequencyScatteringBase(format="doesnotexist", **kwargs)
         S.build()
-        S._check_runtime_args()
+        S._check_runtime_args(stride=None)
     assert "format must be" in ve.value.args[0]
 
 

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -506,6 +506,17 @@ def test_check_runtime_args(device, backend):
         S(x)
     assert "integer" in ve.value.args[0]
 
+    with pytest.raises(ValueError) as ve:
+        S = Scattering1D(J, shape, stride="noninteger",
+            backend=backend, frontend='torch').to(device)
+        S(x)
+    assert "integer" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        S = Scattering1D(J, shape, stride=17,
+            backend=backend, frontend='torch').to(device)
+        S(x)
+    assert "power of two" in ve.value.args[0]
 
 def test_Scattering1D_average_global():
     """

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -518,6 +518,24 @@ def test_check_runtime_args(device, backend):
         S(x)
     assert "power of two" in ve.value.args[0]
 
+    with pytest.raises(ValueError) as ve:
+        S = Scattering1D(J, shape, T=0, stride=16, out_type="list",
+            backend=backend, frontend='torch').to(device)
+        S(x)
+    assert "incompatible" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        S = Scattering1D(J, shape, T="global", stride=16,
+            backend=backend, frontend='torch').to(device)
+        S(x)
+    assert "incompatible" in ve.value.args[0]
+
+    with pytest.raises(ValueError) as ve:
+        S = Scattering1D(J, shape, stride=16, oversampling=1,
+            backend=backend, frontend='torch').to(device)
+        S(x)
+    assert "incompatible" in ve.value.args[0]
+
 def test_Scattering1D_average_global():
     """
     Tests global averaging.

--- a/tests/scattering1d/test_torch_scattering1d.py
+++ b/tests/scattering1d/test_torch_scattering1d.py
@@ -443,13 +443,15 @@ def test_Q(device, backend):
 
     # test different cases for Q
     with pytest.raises(ValueError) as ve:
-        _ = Scattering1D(
+        S = Scattering1D(
             J, shape, Q=0.9, backend=backend, frontend='torch')
+        Q = S.Q
     assert "Q must always be >= 1" in ve.value.args[0]
 
     with pytest.raises(ValueError) as ve:
-        _ = Scattering1D(
+        S = Scattering1D(
             J, shape, Q=[8], backend=backend, frontend='torch')
+        Q = S.Q
     assert "Q must be an integer or a tuple" in ve.value.args[0]
 
     Sc_int = Scattering1D(J, shape, Q=(8, ), backend=backend, frontend='torch').to(device)

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -32,5 +32,5 @@ RUN python3 -m pip install \
       jax \
       scikit-cuda \
       cupy \
-      'tensorflow-gpu>=2.0.0a0' \
+      tensorflow \
       scikit-learn


### PR DESCRIPTION
Fixes #937 

I have written the smallest PR possible
In a separate PR i will rewrite core 1D in terms of log2_stride instead of oversampling. But that's not necessary right now.

~~Note that stride is passed at runtime, not in the constructor. This allows to change stride between inputs without recomputing the filters.~~  actually no because this causes problem in autodiff

Should be reviewed and merged before v0.4

I will also make a PR about `stride_fr` later