### PR TITLE
remove J_pad and N from ScatteringBase1D

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -237,20 +237,6 @@ class ScatteringBase1D(ScatteringBase):
                     len(x.shape)))
 
     @property
-    def J_pad(self):
-        warn("The attribute J_pad is deprecated and will be removed in v0.4. "
-        "Measure len(self.phi_f[0]) for the padded length (previously 2**J_pad) "
-        "or access shape[0] for the unpadded length (previously N).", DeprecationWarning)
-        return int(np.log2(self._N_padded))
-
-    @property
-    def N(self):
-        warn("The attribute N is deprecated and will be removed in v0.4. "
-        "Measure len(self.phi_f[0]) for the padded length (previously 2**J_pad) "
-        "or access shape[0] for the unpadded length (previously N).", DeprecationWarning)
-        return int(self.shape[0])
-
-    @property
     def filterbank(self):
         filterbank_kwargs = {
             "alpha": self.alpha, "r_psi": self.r_psi, "sigma0": self.sigma0}


### PR DESCRIPTION
after v0.3 deprecation cycle
(segue of #857)

for v0.4