### PR TITLE
TST Fix Tensorflow pip package in Jenkins

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -32,5 +32,5 @@ RUN python3 -m pip install \
       jax \
       scikit-cuda \
       cupy \
-      'tensorflow-gpu>=2.0.0a0' \
+      tensorflow \
       scikit-learn


### PR DESCRIPTION
Replace `tensorflow-gpu` package with `tensorflow` as the former has been deprecated.