### PR TITLE
FIX export JTFS from jax + sklearn module

### DIFF
--- a/kymatio/jax.py
+++ b/kymatio/jax.py
@@ -1,4 +1,4 @@
-from .scattering1d.frontend.jax_frontend import ScatteringJax1D as Scattering1D
+from .scattering1d.frontend.jax_frontend import ScatteringJax1D as Scattering1D, TimeFrequencyScatteringJax as TimeFrequencyScattering
 from .scattering2d.frontend.jax_frontend import ScatteringJax2D as Scattering2D
 from .scattering3d.frontend.jax_frontend import (
     HarmonicScatteringJax3D as HarmonicScattering3D,
@@ -13,4 +13,8 @@ Scattering2D.__name__ = "Scattering2D"
 HarmonicScattering3D.__module__ = "kymatio.jax"
 HarmonicScattering3D.__name__ = "HarmonicScattering3D"
 
-__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D"]
+
+TimeFrequencyScattering.__module__ = "kymatio.jax"
+TimeFrequencyScattering.__name__ = "TimeFrequencyScattering"
+
+__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D", TimeFrequencyScattering]

--- a/kymatio/scattering1d/frontend/entry.py
+++ b/kymatio/scattering1d/frontend/entry.py
@@ -7,6 +7,6 @@ class ScatteringEntry1D(ScatteringEntry):
 class TimeFrequencyScatteringEntry(ScatteringEntry):
     def __init__(self, *args, **kwargs):
         super().__init__(
-            name='JTFS', class_name='scattering1d', *args, **kwargs)
+            name='JTFS', class_name='timefrequencyscattering', *args, **kwargs)
 
 __all__ = ['ScatteringEntry1D', 'TimeFrequencyScatteringEntry']

--- a/kymatio/scattering1d/frontend/entry.py
+++ b/kymatio/scattering1d/frontend/entry.py
@@ -7,6 +7,6 @@ class ScatteringEntry1D(ScatteringEntry):
 class TimeFrequencyScatteringEntry(ScatteringEntry):
     def __init__(self, *args, **kwargs):
         super().__init__(
-            name='JTFS', class_name='timefrequencyscattering', *args, **kwargs)
+            name='JTFS', class_name='scattering1d', *args, **kwargs)
 
 __all__ = ['ScatteringEntry1D', 'TimeFrequencyScatteringEntry']

--- a/kymatio/scattering1d/frontend/jax_frontend.py
+++ b/kymatio/scattering1d/frontend/jax_frontend.py
@@ -1,6 +1,7 @@
 from ...frontend.jax_frontend import ScatteringJax
-from .numpy_frontend import ScatteringNumPy1D
-from .base_frontend import ScatteringBase1D
+from .numpy_frontend import ScatteringNumPy1D, TimeFrequencyScatteringNumPy
+from .base_frontend import ScatteringBase1D, TimeFrequencyScatteringBase
+
 
 class ScatteringJax1D(ScatteringJax, ScatteringNumPy1D):
     # This class inherits the attribute "frontend" from ScatteringJax
@@ -10,15 +11,77 @@ class ScatteringJax1D(ScatteringJax, ScatteringNumPy1D):
     # Through ScatteringBase1D._instantiate_backend the jax backend will
     # be loaded
 
-
-    def __init__(self, J, shape, Q=1, T=None, stride=None, max_order=2,
-            oversampling=0, out_type='array', backend='jax'):
+    def __init__(
+        self,
+        J,
+        shape,
+        Q=1,
+        T=None,
+        stride=None,
+        max_order=2,
+        oversampling=0,
+        out_type="array",
+        backend="jax",
+    ):
 
         ScatteringJax.__init__(self)
-        ScatteringBase1D.__init__(self, J, shape, Q, T, stride, max_order,
-                oversampling, out_type, backend)
-        ScatteringBase1D._instantiate_backend(self, 'kymatio.scattering1d.backend.')
+        ScatteringBase1D.__init__(
+            self, J, shape, Q, T, stride, max_order, oversampling, out_type, backend
+        )
+        ScatteringBase1D._instantiate_backend(self, "kymatio.scattering1d.backend.")
         ScatteringBase1D.build(self)
         ScatteringBase1D.create_filters(self)
 
+
 ScatteringJax1D._document()
+
+
+class TimeFrequencyScatteringJax(ScatteringJax, TimeFrequencyScatteringNumPy):
+    # This class inherits the attribute "frontend" from ScatteringJax
+    # It overrides the __init__ function present in TimeFrequencyScatteringNumPy
+    # in order to add the default argument for backend and call the
+    # ScatteringJax.__init__
+    # Through TimeFrequencyScatteringBase._instantiate_backend the jax backend will
+    # be loaded
+
+    def __init__(
+        self,
+        *,
+        J,
+        J_fr,
+        shape,
+        Q,
+        T=None,
+        stride=None,
+        Q_fr=1,
+        F=None,
+        stride_fr=None,
+        out_type="array",
+        format="joint",
+        backend="jax"
+    ):
+
+        ScatteringJax.__init__(self)
+        TimeFrequencyScatteringBase.__init__(
+            self,
+            J=J,
+            J_fr=J_fr,
+            shape=shape,
+            Q=Q,
+            T=T,
+            stride=stride,
+            Q_fr=Q_fr,
+            F=F,
+            stride_fr=stride_fr,
+            out_type=out_type,
+            format=format,
+            backend=backend,
+        )
+        ScatteringBase1D._instantiate_backend(self, "kymatio.scattering1d.backend.")
+        TimeFrequencyScatteringBase.build(self)
+        TimeFrequencyScatteringBase.create_filters(self)
+
+
+TimeFrequencyScatteringJax._document()
+
+__all__ = ["ScatteringJax1D", "TimeFrequencyScatteringJax"]

--- a/kymatio/sklearn.py
+++ b/kymatio/sklearn.py
@@ -23,4 +23,4 @@ Scattering2D.__name__ = "Scattering2D"
 HarmonicScattering3D.__module__ = "kymatio.sklearn"
 HarmonicScattering3D.__name__ = "HarmonicScattering3D"
 
-__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D"]
+__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D", "TimeFrequencyScattering"]

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -130,14 +130,14 @@ def test_jtfs_create_filters(backend):
     )
 
 
-frontends = ["numpy", "torch", "tensorflow", "sklearn"]
+frontends = ["numpy", "torch", "tensorflow", "sklearn", "jax"]
 @pytest.mark.parametrize("frontend", frontends)
 def test_time_scattering_widthfirst(frontend):
     """Checks that width-first and depth-first algorithms have same output."""
     J = 5
     shape = (1024,)
     S = kymatio.Scattering1D(J, shape, frontend=frontend)
-    x = torch.zeros(shape)
+    x = torch.zeros(shape) if frontend == "torch" else np.zeros(shape)
     x[shape[0] // 2] = 1
     x_shape = S.backend.shape(x)
     _, signal_shape = x_shape[:-1], x_shape[-1:]
@@ -163,7 +163,7 @@ def test_time_scattering_widthfirst(frontend):
     S1_depth = S.backend.stack(
         [S1_depth[key] for key in sorted(S1_depth.keys()) if len(key) == 1]
     )
-    if frontend not in ["numpy", "sklearn"]:
+    if frontend not in ["numpy", "sklearn", "jax"]:
         S1_width = S1_width.numpy()
         S1_depth = S1_depth.numpy()
     assert np.allclose(S1_width, S1_depth)


### PR DESCRIPTION
Following #1001 I have exported JTFS from the JAX frontend such that one can import as: `from kymatio.jax import TimeFrequencyScattering` 

I noticed that this was also missing in `sklearn`. 