### PR TITLE
ENH JTFS jax module export 

### DIFF
--- a/kymatio/jax.py
+++ b/kymatio/jax.py
@@ -17,4 +17,4 @@ HarmonicScattering3D.__name__ = "HarmonicScattering3D"
 TimeFrequencyScattering.__module__ = "kymatio.jax"
 TimeFrequencyScattering.__name__ = "TimeFrequencyScattering"
 
-__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D", TimeFrequencyScattering]
+__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D", "TimeFrequencyScattering"]

--- a/kymatio/jax.py
+++ b/kymatio/jax.py
@@ -1,4 +1,4 @@
-from .scattering1d.frontend.jax_frontend import ScatteringJax1D as Scattering1D
+from .scattering1d.frontend.jax_frontend import ScatteringJax1D as Scattering1D, TimeFrequencyScatteringJax as TimeFrequencyScattering
 from .scattering2d.frontend.jax_frontend import ScatteringJax2D as Scattering2D
 from .scattering3d.frontend.jax_frontend import (
     HarmonicScatteringJax3D as HarmonicScattering3D,
@@ -13,4 +13,8 @@ Scattering2D.__name__ = "Scattering2D"
 HarmonicScattering3D.__module__ = "kymatio.jax"
 HarmonicScattering3D.__name__ = "HarmonicScattering3D"
 
-__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D"]
+
+TimeFrequencyScattering.__module__ = "kymatio.jax"
+TimeFrequencyScattering.__name__ = "TimeFrequencyScattering"
+
+__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D", TimeFrequencyScattering]

--- a/kymatio/scattering1d/frontend/entry.py
+++ b/kymatio/scattering1d/frontend/entry.py
@@ -7,6 +7,6 @@ class ScatteringEntry1D(ScatteringEntry):
 class TimeFrequencyScatteringEntry(ScatteringEntry):
     def __init__(self, *args, **kwargs):
         super().__init__(
-            name='JTFS', class_name='scattering1d', *args, **kwargs)
+            name='JTFS', class_name='timefrequencyscattering', *args, **kwargs)
 
 __all__ = ['ScatteringEntry1D', 'TimeFrequencyScatteringEntry']

--- a/kymatio/scattering1d/frontend/entry.py
+++ b/kymatio/scattering1d/frontend/entry.py
@@ -7,6 +7,6 @@ class ScatteringEntry1D(ScatteringEntry):
 class TimeFrequencyScatteringEntry(ScatteringEntry):
     def __init__(self, *args, **kwargs):
         super().__init__(
-            name='JTFS', class_name='timefrequencyscattering', *args, **kwargs)
+            name='JTFS', class_name='scattering1d', *args, **kwargs)
 
 __all__ = ['ScatteringEntry1D', 'TimeFrequencyScatteringEntry']

--- a/kymatio/sklearn.py
+++ b/kymatio/sklearn.py
@@ -23,4 +23,4 @@ Scattering2D.__name__ = "Scattering2D"
 HarmonicScattering3D.__module__ = "kymatio.sklearn"
 HarmonicScattering3D.__name__ = "HarmonicScattering3D"
 
-__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D"]
+__all__ = ["Scattering1D", "Scattering2D", "HarmonicScattering3D", "TimeFrequencyScattering"]

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -584,7 +584,7 @@ def test_jtfs_torch_tf_frontends(frontend):
     assert Sx.ndim == 3
 
 
-def test_jtfs_jax_frontend(frontend):
+def test_jtfs_jax_frontend():
     # Test __init__
     kwargs = {"J": 8, "J_fr": 3, "shape": (8192,), "Q": 3}
     x = np.zeros(kwargs["shape"])
@@ -592,7 +592,7 @@ def test_jtfs_jax_frontend(frontend):
     x = device_put(jnp.asarray(x))
 
     # Local averaging
-    S = TimeFrequencyScatteringJax(frontend=frontend, format="joint", **kwargs)
+    S = TimeFrequencyScatteringJax(format="joint", **kwargs)
     assert S.F == (2**S.J_fr)
     Sx = S(x)
     assert Sx.ndim == 3

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -18,6 +18,7 @@ from kymatio.scattering1d.core.timefrequency_scattering import (
 from kymatio.scattering1d.frontend.base_frontend import TimeFrequencyScatteringBase
 from kymatio.scattering1d.frontend.torch_frontend import TimeFrequencyScatteringTorch
 from kymatio.scattering1d.frontend.numpy_frontend import TimeFrequencyScatteringNumPy
+from kymatio.jax import TimeFrequencyScattering as TimeFrequencyScatteringJax
 
 
 backends = ["numpy", "torch", "tensorflow", "jax", "sklearn"]
@@ -583,8 +584,6 @@ def test_jtfs_torch_tf_frontends(frontend):
     assert Sx.ndim == 3
 
 
-frontends = ["jax"]
-@pytest.mark.parametrize("frontend", frontends)
 def test_jtfs_jax_frontend(frontend):
     # Test __init__
     kwargs = {"J": 8, "J_fr": 3, "shape": (8192,), "Q": 3}
@@ -593,7 +592,7 @@ def test_jtfs_jax_frontend(frontend):
     x = device_put(jnp.asarray(x))
 
     # Local averaging
-    S = TimeFrequencyScattering(frontend=frontend, format="joint", **kwargs)
+    S = TimeFrequencyScatteringJax(frontend=frontend, format="joint", **kwargs)
     assert S.F == (2**S.J_fr)
     Sx = S(x)
     assert Sx.ndim == 3


### PR DESCRIPTION
Following #1001 I have exported JTFS from the JAX frontend such that one can import as: from kymatio.jax import TimeFrequencyScattering

I noticed that this was also missing in sklearn.