### PR TITLE
MAINT remove `_reduction` from JTFS self

### DIFF
--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -615,10 +615,10 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
 
     def create_filters(self):
         phi0_fr_f,= scattering_filter_factory(self._N_padded_fr,
-            self.J_fr, (), self.F, self.filterbank_fr, _reduction=np.mean)
+            self.J_fr, (), self.F, self.filterbank_fr, _reduction=np.sum)
         phi1_fr_f, psis_fr_f = scattering_filter_factory(self._N_padded_fr,
             self.J_fr, self.Q_fr, 2**self.J_fr, self.filterbank_fr,
-            _reduction=np.mean)
+            _reduction=np.sum)
         self.filters_fr = (phi0_fr_f, [phi1_fr_f] + psis_fr_f)
 
         # Check for absence of aliasing

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -581,7 +581,6 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
         self.oversampling_fr = 0
         self._stride_fr = stride_fr
         self.format = format
-        self._reduction = np.sum
 
     def build(self):
         super(TimeFrequencyScatteringBase, self).build()
@@ -616,10 +615,10 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
 
     def create_filters(self):
         phi0_fr_f,= scattering_filter_factory(self._N_padded_fr,
-            self.J_fr, (), self.F, self.filterbank_fr, self._reduction)
+            self.J_fr, (), self.F, self.filterbank_fr, _reduction=np.mean)
         phi1_fr_f, psis_fr_f = scattering_filter_factory(self._N_padded_fr,
             self.J_fr, self.Q_fr, 2**self.J_fr, self.filterbank_fr,
-            self._reduction)
+            _reduction=np.mean)
         self.filters_fr = (phi0_fr_f, [phi1_fr_f] + psis_fr_f)
 
         # Check for absence of aliasing


### PR DESCRIPTION
segue from #1005 
in the case of JTFS, there is no backwards compatibility to be had, so we might as well remove the `_reduction` attribute from the JTFS object and pass `_reduction=np.mean` to filterbank constructors.