### PR TITLE
DOC Fix 1d dataset examples

### DIFF
--- a/examples/1d/plot_real_signal.py
+++ b/examples/1d/plot_real_signal.py
@@ -1,9 +1,9 @@
 """
 Compute the scattering transform of a speech recording
 ======================================================
-This script loads a speech signal from the free spoken digit dataset (FSDD)
-of a man pronouncing the word "zero," computes its scattering transform, and
-displays the zeroth-, first-, and second-order scattering coefficients.
+This script loads a speech signal consisting of an excerpt from a recording of
+*Sense and Sensibility*. We then compute its scattering transform, and display
+the zeroth-, first-, and second-order scattering coefficients.
 """
 
 ###############################################################################
@@ -11,11 +11,11 @@ displays the zeroth-, first-, and second-order scattering coefficients.
 # -------------
 #
 ###############################################################################
-# To handle audio file I/O, we import `os` and `scipy.io.wavfile`.
+# To manipulate the audio signal, we first import NumPy. We also import
+# `librosa`, which allows us to automatically download the example signal.
 
 import numpy as np
-import os
-import scipy.io.wavfile
+import librosa
 
 ###############################################################################
 # We import `matplotlib` to plot the calculated scattering coefficients.
@@ -23,24 +23,19 @@ import scipy.io.wavfile
 import matplotlib.pyplot as plt
 
 ###############################################################################
-# Finally, we import the `Scattering1D` class from the `scattering` package and
-# the `fetch_fsdd` function from `scattering.datasets`. The `Scattering1D`
-# class is what lets us calculate the scattering transform, while the
-# `fetch_fsdd` function downloads the FSDD, if needed.
+# Finally, we import the `Scattering1D` class from the `scattering` package.
+# The `Scattering1D` class is what lets us calculate the scattering transform
 
 from kymatio.numpy import Scattering1D
-from ...datasets import fetch_fsdd
 
 ###############################################################################
 # Scattering setup
 # ----------------
-# First, we download the FSDD (if not already downloaded) and read in the
-# recording `0_jackson_0.wav` of a man pronouncing the word "zero".
+# First, we download the signal and extract the second second of it (the first
+# second is mostly silence).
 
-info_dataset = fetch_fsdd(verbose=True)
-
-file_path = os.path.join(info_dataset['path_dataset'], sorted(info_dataset['files'])[0])
-_, x = scipy.io.wavfile.read(file_path)
+x, sr = librosa.load(librosa.example("libri3"))
+x = x[sr:2 * sr]
 
 ###############################################################################
 # Once the recording is in memory, we normalize it.
@@ -93,23 +88,24 @@ order2 = np.where(meta['order'] == 2)
 plt.figure(figsize=(8, 2))
 plt.plot(x)
 plt.title('Original signal')
+plt.show()
 
 ###############################################################################
 # We now plot the zeroth-order scattering coefficient, which is simply an
 # average of the original signal at the scale `2**J`.
 
 plt.figure(figsize=(8, 8))
-plt.subplot(3, 1, 1)
 plt.plot(Sx[order0][0])
 plt.title('Zeroth-order scattering')
+plt.show()
 
 ###############################################################################
 # We then plot the first-order coefficients, which are arranged along time
 # and log-frequency.
 
-plt.subplot(3, 1, 2)
 plt.imshow(Sx[order1], aspect='auto')
 plt.title('First-order scattering')
+plt.show()
 
 ###############################################################################
 # Finally, we plot the second-order scattering coefficients. These are also
@@ -117,11 +113,6 @@ plt.title('First-order scattering')
 # frequency and one second-order frequency. Here, both indices are mixed along
 # the vertical axis.
 
-plt.subplot(3, 1, 3)
 plt.imshow(Sx[order2], aspect='auto')
 plt.title('Second-order scattering')
-###############################################################################
-# Display the plots!
-
-plt.tight_layout()
 plt.show()

--- a/examples/datasets.py
+++ b/examples/datasets.py
@@ -84,59 +84,6 @@ def _download(url, filename):
         raise
 
 
-
-
-
-
-fsdd_url= "https://github.com/Jakobovski/free-spoken-digit-dataset.git"
-def fetch_fsdd(verbose=False):
-    """
-    Fetches the Free Spoken Digit Dataset (FSDD).
-    If the dataset is not present in the caching directory named "fsdd", it
-    is downloaded via git.
-
-    Arguments
-    ---------
-    base_dir: string, optional
-        Name of the base directory for the caching. Will be rooted at the root
-        dataset directory given by functions in caching.py. Defaults to 'fsdd'
-    url: string, optional
-        url for the github repository containing the dataset.
-        Defaults to
-        "https://github.com/Jakobovski/free-spoken-digit-dataset.git"
-    verbose: boolean, optional
-        Whether to display indications of the operations undertaken.
-        Defaults to False
-
-    Returns
-    -------
-    dictionary: dictionary
-        A dictionary containing the keys 'path_dataset', with value the
-        absolute path to the recordings
-        (should be base_dir/free-spoken-digit-dataset/recordings),
-        and 'files', with value the list of the files in path_dataset
-        ending with .wav
-    """
-    path = get_dataset_dir("fsdd")
-    # check if there is already the free sound dataset within this directory
-    name_git = 'free-spoken-digit-dataset'
-    downloaded = name_git in os.listdir(path)
-    # download the git if not existing:
-    if not(downloaded):
-        if verbose:
-            print('Cloning git repository at ', fsdd_url)
-        instruction = "git clone " + fsdd_url + ' ' + str(
-            os.path.join(path, name_git))
-        status, msg = subprocess.getstatusoutput(instruction)
-        if status != 0:
-            raise RuntimeError(msg)
-    # now that it is downloaded, look at the recordings
-    repo = os.path.join(path, name_git, 'recordings')
-    files = [f for f in os.listdir(repo) if f.endswith('.wav')]
-    dictionary = {'path_dataset': repo, 'files': files}
-    return dictionary
-
-
 atom_charges=dict(H=1, C=6, O=8, N=7, S=16)
 
 def read_xyz(filename):

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -7,3 +7,4 @@ matplotlib
 scikit-learn
 texext
 m2r2
+librosa

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -8,3 +8,4 @@ scikit-learn
 texext
 m2r2
 librosa
+deeplake[audio]


### PR DESCRIPTION
Since `datasets.fetch_fsdd` is no longer available as part of the main `kymatio` package, we can't access it from the examples when run using `sphinx-gallery`. To solve this, we instead switch to a `librosa` example for `plot_real_signal` (`librivox3`) and use `deeplake` to download FSDD in the classification examples.