### PR TITLE
TST Upgrade CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -15,6 +15,8 @@ jobs:
                 include:
                   - python-version: '3.7'
                     pytorch-version: '1.13'
+                  - python-version: '3.11'
+                    pytorch-version: '2.0'
 
         env:
             CONDA_ENV: test-env-py${{ matrix.python-version }}-torch${{ matrix.pytorch-version }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,8 +10,11 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.7', '3.8', '3.9', '3.10']
-                pytorch-version: ['1.10', '1.11']
+                python-version: ['3.8', '3.9', '3.10']
+                pytorch-version: ['1.13', '2.0']
+                include:
+                  - python-version: '3.7'
+                    pytorch-version: '1.13'
 
         env:
             CONDA_ENV: test-env-py${{ matrix.python-version }}-torch${{ matrix.pytorch-version }}

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -15,7 +15,8 @@ jobs:
                 include:
                   - python-version: '3.7'
                     pytorch-version: '1.13'
-
+                  - python-version: '3.11'
+                    pytorch-version: '2.0'
         steps:
             - uses: actions/checkout@v1
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -10,11 +10,11 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.7', '3.8', '3.9']
-                pytorch-version: ['1.10', '1.11']
+                python-version: ['3.8', '3.9', '3.10']
+                pytorch-version: ['1.13', '2.0']
                 include:
-                    - python-version: '3.10'
-                      pytorch-version: '1.11'
+                  - python-version: '3.7'
+                    pytorch-version: '1.13'
 
         steps:
             - uses: actions/checkout@v1
@@ -27,14 +27,14 @@ jobs:
                   python3 -m pip install --upgrade pip
                   python3 -m pip install pytest pytest-cov
 
-                  if [ ${{ matrix.pytorch-version }} == '1.10' ]; then
-                      pip install torch==1.10.1+cpu \
-                                  torchvision==0.11.2+cpu \
-                                  -f https://download.pytorch.org/whl/torch_stable.html
-                  elif [ ${{ matrix.pytorch-version }} == '1.11' ]; then
-                      pip install torch==1.11.0+cpu \
-                                  torchvision==0.12.0+cpu \
-                                  -f https://download.pytorch.org/whl/torch_stable.html
+                  if [ ${{ matrix.pytorch-version }} == '1.13' ]; then
+                      pip install torch==1.13.1+cpu \
+                                  torchvision==0.14.1+cpu \
+                                  --extra-index-url https://download.pytorch.org/whl/cpu
+                  elif [ ${{ matrix.pytorch-version }} == '2.0' ]; then
+                      pip install torch==2.0.0+cpu \
+                                  torchvision==0.15.1+cpu \
+                                  --index-url https://download.pytorch.org/whl/cpu
                   fi
                   python3 -m pip install "tensorflow>=2.0.0a"
                   python3 -m pip install scikit-learn

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.2-devel-ubuntu20.04
+FROM nvidia/cuda:11.7.1-devel-ubuntu20.04
 
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 
@@ -26,7 +26,7 @@ RUN python3 -m pip install \
       'numpy>=1.16' \
       scipy \
       configparser \
-      'torchvision==0.8.2' \
+      torchvision \
       torch \
       jaxlib \
       jax \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,7 +1,5 @@
 FROM nvidia/cuda:11.7.1-devel-ubuntu20.04
 
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
       libcudnn8 \


### PR DESCRIPTION
Include `torch==2.0` for GHA as well as Jenkins (which will now install the latest version available) and update the Jenkins image to CUDA 11.7. Finally, we add testing for Python 3.11.