### PR TITLE
MAINT use lr_scheduler instead of resetting optimizer

### DIFF
--- a/examples/2d/cifar_resnet_torch.py
+++ b/examples/2d/cifar_resnet_torch.py
@@ -193,11 +193,12 @@ if __name__ == '__main__':
 
     # Optimizer
     lr = 0.1
-    for epoch in range(0, 90):
-        if epoch%20==0:
-            optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
+    optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
                                         weight_decay=0.0005)
-            lr*=0.2
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=20,
+            gamma=0.2)
 
+    for epoch in range(0, 90):
         train(model, device, train_loader, optimizer, epoch+1, scattering)
+        scheduler.step()
         test(model, device, test_loader, scattering)

--- a/examples/2d/cifar_small_sample.py
+++ b/examples/2d/cifar_small_sample.py
@@ -229,7 +229,7 @@ def main():
                                         weight_decay=0.0005)
     M = args.learning_schedule_multi
     drops = [60*M,120*M,160*M]
-    scheduler = torch.optim.MultiStepLR(optimizer, drops, gamma=0.2)
+    scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer, drops, gamma=0.2)
     for epoch in range(0, 200*M):
         train(model, device, train_loader, optimizer, epoch+1, scattering)
         scheduler.step()

--- a/examples/2d/cifar_small_sample.py
+++ b/examples/2d/cifar_small_sample.py
@@ -228,7 +228,7 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
                                         weight_decay=0.0005)
     M = args.learning_schedule_multi
-    drops = [0, 60*M,120*M,160*M]
+    drops = [60*M,120*M,160*M]
     scheduler = torch.optim.MultiStepLR(optimizer, drops, gamma=0.2)
     for epoch in range(0, 200*M):
         train(model, device, train_loader, optimizer, epoch+1, scattering)

--- a/examples/2d/cifar_small_sample.py
+++ b/examples/2d/cifar_small_sample.py
@@ -228,13 +228,11 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
                                         weight_decay=0.0005)
     M = args.learning_schedule_multi
-    drops = [60*M,120*M,160*M]
+    drops = [0, 60*M,120*M,160*M]
+    scheduler = torch.optim.MultiStepLR(optimizer, drops, gamma=0.2)
     for epoch in range(0, 200*M):
-        if epoch in drops or epoch==0:
-            for param_group in optimizer.param_groups:
-                param_group['lr'] *= 0.2
-
         train(model, device, train_loader, optimizer, epoch+1, scattering)
+        scheduler.step()
         if epoch%10==0:
             test(model, device, test_loader, scattering)
 

--- a/examples/2d/cifar_small_sample.py
+++ b/examples/2d/cifar_small_sample.py
@@ -225,13 +225,14 @@ def main():
 
     # Optimizer
     lr = 0.1
+    optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
+                                        weight_decay=0.0005)
     M = args.learning_schedule_multi
     drops = [60*M,120*M,160*M]
     for epoch in range(0, 200*M):
         if epoch in drops or epoch==0:
-            optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
-                                        weight_decay=0.0005)
-            lr*=0.2
+            for param_group in optimizer.param_groups:
+                param_group['lr'] *= 0.2
 
         train(model, device, train_loader, optimizer, epoch+1, scattering)
         if epoch%10==0:

--- a/examples/2d/cifar_torch.py
+++ b/examples/2d/cifar_torch.py
@@ -165,11 +165,12 @@ if __name__ == '__main__':
 
     # Optimizer
     lr = 0.1
+    optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
+                                        weight_decay=0.0005)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=20, gamma=0.2)
     for epoch in range(0, 90):
         if epoch%20==0:
-            optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
-                                        weight_decay=0.0005)
-            lr*=0.2
+            scheduler.step()
 
         train(model, device, train_loader, optimizer, epoch+1, scattering)
         test(model, device, test_loader, scattering)

--- a/examples/2d/cifar_torch.py
+++ b/examples/2d/cifar_torch.py
@@ -168,9 +168,8 @@ if __name__ == '__main__':
     optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9,
                                         weight_decay=0.0005)
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=20, gamma=0.2)
-    for epoch in range(0, 90):
-        if epoch%20==0:
-            scheduler.step()
 
+    for epoch in range(0, 90):
         train(model, device, train_loader, optimizer, epoch+1, scattering)
+        scheduler.step()
         test(model, device, test_loader, scattering)


### PR DESCRIPTION
Instead of redefining the optimizer every 20 epochs during training to decrease the learning rate, I initialized it before the training loop starts along with a StepLR scheduler that will decrease the learning rate by a factor of 0.2 every 20 epochs. 

I changed this for one of the three CIFAR10 2d example scripts, and I will change the other two if everyone agrees.

This resolves issue #1021  