### PR TITLE
Jtfs docstrings

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,6 +4,7 @@ Content of this website:
 ------------------------
 
 .. toctree::
+   :maxdepth: 2
 
    userguide
    developerguide

--- a/kymatio/frontend/sklearn_frontend.py
+++ b/kymatio/frontend/sklearn_frontend.py
@@ -23,13 +23,12 @@ class ScatteringTransformerMixin(BaseEstimator, TransformerMixin):
 
     _doc_alias_call = '.predict({x}.flatten())'
 
-    _doc_frontend_paragraph = \
-        """
+    _doc_frontend_paragraph = r"""
+
         This class inherits from `BaseEstimator` and `TransformerMixin` in
         `sklearn.base`. As a result, it supports calculating the scattering
         transform by calling the `predict` and `transform` methods. By
-        extension, it can be included as part of a scikit-learn `Pipeline`.
-        """
+        extension, it can be included as part of a scikit-learn `Pipeline`."""
 
     _doc_sample = 'np.random.randn({shape})'
 

--- a/kymatio/frontend/tensorflow_frontend.py
+++ b/kymatio/frontend/tensorflow_frontend.py
@@ -17,11 +17,10 @@ class ScatteringTensorFlow(tf.Module):
 
     _doc_alias_call = ''
 
-    _doc_frontend_paragraph = \
-        """
+    _doc_frontend_paragraph = r"""
+
         This class inherits from `tf.Module`. As a result, it has all the
-        same capabilities as a standard TensorFlow `Module`.
-        """
+        same capabilities as a standard TensorFlow `Module`."""
 
     _doc_sample = 'np.random.randn({shape})'
 

--- a/kymatio/frontend/torch_frontend.py
+++ b/kymatio/frontend/torch_frontend.py
@@ -24,14 +24,13 @@ class ScatteringTorch(nn.Module):
 
     _doc_alias_call = '.forward({x})'
 
-    _doc_frontend_paragraph = \
-        """
+    _doc_frontend_paragraph = r"""
+
         This class inherits from `torch.nn.Module`. As a result, it has all
         the same capabilities, including transferring the object to the GPU
         using the `cuda` or `to` methods. This object would then take GPU
         tensors as input and output the scattering coefficients of those
-        tensors.
-        """
+        tensors."""
 
     _doc_sample = 'torch.randn({shape})'
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -568,9 +568,9 @@ class ScatteringBase1D(ScatteringBase):
 
 
 class TimeFrequencyScatteringBase(ScatteringBase1D):
-    def __init__(self, *, J, J_fr, shape, Q, T=None, stride=None,
+    def __init__(self, J, J_fr, Q, shape, T=None, stride=None,
             Q_fr=1, F=None, stride_fr=None,
-            out_type='array', format='joint', backend=None):
+            out_type='array', format='time', backend=None):
         max_order = 2
         oversampling = None
         super(TimeFrequencyScatteringBase, self).__init__(J, shape, Q, T,

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -182,7 +182,7 @@ class ScatteringBase1D(ScatteringBase):
                 the filters used at each order (padded with NaNs).
             - `'key'` : list
                 The tuples indexing the corresponding scattering coefficient
-                in the non-vectorized output.
+                for `out_type='list'`.
         """
         backend = self._DryBackend()
         filters = [self.phi_f, self.psi1_f, self.psi2_f][:(1+self.max_order)]
@@ -304,13 +304,12 @@ class ScatteringBase1D(ScatteringBase):
     _doc_instantiation_shape = {True: 'S = Scattering1D(J, N, Q)',
                                 False: 'S = Scattering1D(J, Q)'}
 
-    _doc_param_shape = \
-    r"""shape : int
-            The length of the input signals.
-        """
+    _doc_param_shape = r"""
+        shape : int
+            The length of the input signals."""
 
-    _doc_attrs_shape = \
-    r"""pad_left : int
+    _doc_attrs_shape = r"""
+        pad_left : int
             The amount of padding to the left of the signal.
         pad_right : int
             The amount of padding to the right of the signal.
@@ -326,61 +325,25 @@ class ScatteringBase1D(ScatteringBase):
             A dictionary containing all the second-order wavelet filters, each
             represented as a dictionary containing that filter at all
             resolutions. See `filter_bank.scattering_filter_factory` for an
-            exact description.
-        """
+            exact description."""
 
-    _doc_param_average = \
-    r"""average : boolean, optional
-            Determines whether the output is averaged in time or not. The
-            averaged output corresponds to the standard scattering transform,
-            while the un-averaged output skips the last convolution by
-            :math:`\phi_J(t)`.  This parameter may be modified after object
-            creation. Defaults to `True`. Deprecated in v0.3 in favour of `T`
-            and will  be removed in v0.4. Replace `average=False` by `T=0` and
-            set `T>1` or leave `T=None` for `average=True` (default).
-        """
-
-    _doc_attr_average = \
-    r"""average : boolean
-            Controls whether the output should be averaged (the standard
-            scattering transform) or not (resulting in wavelet modulus
-            coefficients). Note that to obtain unaveraged output, the
-            `vectorize` flag must be set to `False` or `out_type` must be set
-            to `'list'`. Deprecated in favor of `T`. For more details,
-            see the documentation for `scattering`.
-     """
-
-    _doc_param_vectorize = \
-    r"""vectorize : boolean, optional
-            Determines wheter to return a vectorized scattering transform
-            (that is, a large array containing the output) or a dictionary
-            (where each entry corresponds to a separate scattering
-            coefficient). This parameter may be modified after object
-            creation. Deprecated in favor of `out_type` (see below). Defaults
-            to True.
+    _doc_param_vectorize = r"""
         out_type : str, optional
             The format of the output of a scattering transform. If set to
             `'list'`, then the output is a list containing each individual
             scattering coefficient with meta information. Otherwise, if set to
             `'array'`, the output is a large array containing the
             concatenation of all scattering coefficients. Defaults to
-            `'array'`.
-        """
+            `'array'`."""
 
-    _doc_attr_vectorize = \
-    r"""vectorize : boolean
-            Controls whether the output should be vectorized into a single
-            Tensor or collected into a dictionary. Deprecated in favor of
-            `out_type`. For more details, see the documentation for
-            `scattering`.
+    _doc_attr_vectorize = r"""
         out_type : str
             Specifices the output format of the transform, which is currently
             one of `'array'` or `'list`'. If `'array'`, the output is a large
             array containing the scattering coefficients. If `'list`', the
             output is a list of dictionaries, each containing a scattering
             coefficient along with meta information. For more information, see
-            the documentation for `scattering`.
-        """
+            the documentation for `scattering`."""
 
     _doc_class = \
     r"""The 1D scattering transform
@@ -409,8 +372,8 @@ class ScatteringBase1D(ScatteringBase):
         While the wavelets are fixed, other parameters may be changed after
         the object is created, such as whether to compute all of
         :math:`S_J^{{(0)}} x`, $S_J^{{(1)}} x$, and $S_J^{{(2)}} x$ or just
-        $S_J^{{(0)}} x$ and $S_J^{{(1)}} x$.
-        {frontend_paragraph}
+        $S_J^{{(0)}} x$ and $S_J^{{(1)}} x$.{frontend_paragraph}
+
         Given an input `{array}` `x` of shape `(B, N)`, where `B` is the
         number of signals to transform (the batch size) and `N` is the length
         of the signal, we compute its scattering transform by passing it to
@@ -450,20 +413,24 @@ class ScatteringBase1D(ScatteringBase):
         ----------
         J : int
             The maximum log-scale of the scattering transform. In other words,
-            the maximum scale is given by :math:`2^J`.
-        {param_shape}Q : int or tuple
+            the maximum scale is given by :math:`2^J`.{param_shape}
+        Q : int or tuple
             By default, Q (int) is the number of wavelets per octave for the first
             order and that for the second order has one wavelet per octave. This
             default value can be modified by passing Q as a tuple with two values,
             i.e. Q = (Q1, Q2), where Q1 and Q2 are the number of wavelets per
             octave for the first and second order, respectively.
         T : int
-            temporal support of low-pass filter, controlling amount of imposed
-            time-shift invariance and maximum subsampling
+            The temporal support of low-pass filter, controlling amount of imposed
+            time-shift invariance and maximum subsampling.:
+        stride : int
+            The stride with which the scattering transform is sampled.
+            When set to `1`, no subsampling is performed. Must be a power of
+            two. Defaults to `2 ** J`.
         max_order : int, optional
             The maximum order of scattering coefficients to compute. Must be
             either `1` or `2`. Defaults to `2`.
-        {param_average}oversampling : integer >= 0, optional
+        oversampling : integer >= 0, optional
             Controls the oversampling factor relative to the default as a
             power of two. Since the convolving by wavelets (or lowpass
             filters) and taking the modulus reduces the high-frequency content
@@ -471,25 +438,26 @@ class ScatteringBase1D(ScatteringBase):
             performance. However, this may reduce precision in the
             calculation. If this is not desirable, `oversampling` can be set
             to a large value to prevent too much subsampling. This parameter
-            may be modified after object creation. Defaults to `0`.
-        {param_vectorize}
+            may be modified after object creation. Defaults to `0`. This
+            parameter is deprecated and will be removed in v0.5. Please use
+            `stride` instead.{param_vectorize}
+
         Attributes
         ----------
         J : int
             The maximum log-scale of the scattering transform. In other words,
-            the maximum scale is given by `2 ** J`.
-        {param_shape}Q : int
+            the maximum scale is given by `2 ** J`.{param_shape}
+        Q : int
             The number of first-order wavelets per octave (second-order
             wavelets are fixed to one wavelet per octave).
         T : int
             temporal support of low-pass filter, controlling amount of imposed
-            time-shift invariance and maximum subsampling
-        {attrs_shape}max_order : int
+            time-shift invariance and maximum subsampling{attrs_shape}
+        max_order : int
             The maximum scattering order of the transform.
-        {attr_average}oversampling : int
+        oversampling : int
             The number of powers of two to oversample the output compared to
-            the default subsampling rate determined from the filters.
-        {attr_vectorize}"""
+            the default subsampling rate determined from the filters.{attr_vectorize}"""
 
     _doc_scattering = \
     """Apply the scattering transform
@@ -497,30 +465,15 @@ class ScatteringBase1D(ScatteringBase):
        Given an input `{array}` of size `(B, N)`, where `B` is the batch
        size (it can be potentially an integer or a shape) and `N` is the length
        of the individual signals, this function computes its scattering
-       transform. If the `vectorize` flag is set to `True` (or if it is not
-       available in this frontend), the output is in the form of a `{array}`
-       or size `(B, C, N1)`, where `N1` is the signal length after subsampling
-       to the scale :math:`2^J` (with the appropriate oversampling factor to
-       reduce aliasing), and `C` is the number of scattering coefficients. If
-       `vectorize` is set `False`, however, the output is a dictionary
-       containing `C` keys, each a tuple whose length corresponds to the
-       scattering order and whose elements are the sequence of filter indices
-       used.
-
-       Note that the `vectorize` flag has been deprecated in favor of the
-       `out_type` parameter. If this is set to `'array'` (the default), the
-       `vectorize` flag is still respected, but if not, `out_type` takes
-       precedence. The two current output types are `'array'` and `'list'`.
-       The former gives the type of output described above. If set to
-       `'list'`, however, the output is a list of dictionaries, each
-       dictionary corresponding to a scattering coefficient and its associated
-       meta information. The coefficient is stored under the `'coef'` key,
-       while other keys contain additional information, such as `'j'` (the
-       scale of the filter used) and `'n`' (the filter index).
-
-       Furthermore, if the `average` flag is set to `False`, these outputs
-       are not averaged, but are simply the wavelet modulus coefficients of
-       the filters.
+       transform. If the `out_type` is set to `'array'`, the output is in the
+       form of a `{array}` of size `(B, C, N1)`, where `N1` is the signal length
+       after subsampling to the scale :math:`2^J` (with the appropriate oversampling
+       factor to reduce aliasing), and `C` is the number of scattering coefficients.
+       If `out_type` is set to `'list'`, however, the output is a list of
+       dictionaries, each dictionary corresponding to a scattering coefficient
+       and its associated meta information. The coefficient is stored under the
+       `'coef'` key, while other keys contain additional information, such as
+       `'j'` (the scale of the filter used) and `'n`' (the filter index).
 
        Parameters
        ----------
@@ -529,13 +482,10 @@ class ScatteringBase1D(ScatteringBase):
 
        Returns
        -------
-       S : tensor or dictionary
-           If `out_type` is `'array'` and the `vectorize` flag is `True`, the
-           output is a{n} `{array}` containing the scattering coefficients,
-           while if `vectorize` is `False`, it is a dictionary indexed by
-           tuples of filter indices. If `out_type` is `'list'`, the output is
-           a list of dictionaries as described above.
-    """
+       S : tensor or list
+           If `out_type` is `'array'` the output is a{n} `{array}` containing
+           the scattering coefficients, while if `out_type` is `'list'`, the
+           output is a list of dictionaries as described above."""
 
     @classmethod
     def _document(cls):
@@ -543,8 +493,6 @@ class ScatteringBase1D(ScatteringBase):
         param_shape = cls._doc_param_shape if cls._doc_has_shape else ''
         attrs_shape = cls._doc_attrs_shape if cls._doc_has_shape else ''
 
-        param_average = cls._doc_param_average if cls._doc_has_out_type else ''
-        attr_average = cls._doc_attr_average if cls._doc_has_out_type else ''
         param_vectorize = cls._doc_param_vectorize if cls._doc_has_out_type else ''
         attr_vectorize = cls._doc_attr_vectorize if cls._doc_has_out_type else ''
 
@@ -556,11 +504,17 @@ class ScatteringBase1D(ScatteringBase):
             instantiation=instantiation,
             param_shape=param_shape,
             attrs_shape=attrs_shape,
-            param_average=param_average,
-            attr_average=attr_average,
             param_vectorize=param_vectorize,
             attr_vectorize=attr_vectorize,
             sample=cls._doc_sample.format(shape=cls._doc_shape))
+        # Sphinx will not show docstrings for inherited methods, so we add a
+        # dummy method here that will just call the super.
+
+        if not "scattering" in cls.__dict__:
+            def _scattering(self, x):
+                return super(cls, self).scattering(x)
+
+            setattr(cls, "scattering", _scattering)
 
         cls.scattering.__doc__ = ScatteringBase1D._doc_scattering.format(
             array=cls._doc_array,

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -496,7 +496,7 @@ class ScatteringBase1D(ScatteringBase):
         param_vectorize = cls._doc_param_vectorize if cls._doc_has_out_type else ''
         attr_vectorize = cls._doc_attr_vectorize if cls._doc_has_out_type else ''
 
-        cls.__doc__ = ScatteringBase1D._doc_class.format(
+        cls.__doc__ = cls._doc_class.format(
             array=cls._doc_array,
             frontend_paragraph=cls._doc_frontend_paragraph,
             alias_name=cls._doc_alias_name,
@@ -516,7 +516,7 @@ class ScatteringBase1D(ScatteringBase):
 
             setattr(cls, "scattering", _scattering)
 
-        cls.scattering.__doc__ = ScatteringBase1D._doc_scattering.format(
+        cls.scattering.__doc__ = cls._doc_scattering.format(
             array=cls._doc_array,
             n=cls._doc_array_n)
 

--- a/kymatio/scattering1d/frontend/jax_frontend.py
+++ b/kymatio/scattering1d/frontend/jax_frontend.py
@@ -46,18 +46,17 @@ class TimeFrequencyScatteringJax(ScatteringJax, TimeFrequencyScatteringNumPy):
 
     def __init__(
         self,
-        *,
         J,
         J_fr,
-        shape,
         Q,
+        shape,
         T=None,
         stride=None,
         Q_fr=1,
         F=None,
         stride_fr=None,
         out_type="array",
-        format="joint",
+        format="time",
         backend="jax"
     ):
 
@@ -66,8 +65,8 @@ class TimeFrequencyScatteringJax(ScatteringJax, TimeFrequencyScatteringNumPy):
             self,
             J=J,
             J_fr=J_fr,
-            shape=shape,
             Q=Q,
+            shape=shape,
             T=T,
             stride=stride,
             Q_fr=Q_fr,

--- a/kymatio/scattering1d/frontend/numpy_frontend.py
+++ b/kymatio/scattering1d/frontend/numpy_frontend.py
@@ -19,9 +19,9 @@ ScatteringNumPy1D._document()
 
 class TimeFrequencyScatteringNumPy(
         ScatteringNumPy1D, TimeFrequencyScatteringBase):
-    def __init__(self, *, J, J_fr, shape, Q, T=None, stride=None,
+    def __init__(self, J, J_fr, Q, shape, T=None, stride=None,
             Q_fr=1, F=None, stride_fr=None,
-            out_type='array', format='joint', backend='numpy'):
+            out_type='array', format='time', backend='numpy'):
         ScatteringNumPy.__init__(self)
         TimeFrequencyScatteringBase.__init__(self, J=J, J_fr=J_fr, shape=shape,
             Q=Q, T=T, stride=stride,

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -73,4 +73,7 @@ class TimeFrequencyScatteringTensorFlow(
         TimeFrequencyScatteringBase.create_filters(self)
 
 
+TimeFrequencyScatteringTensorFlow._document()
+
+
 __all__ = ["ScatteringTensorFlow1D", "TimeFrequencyScatteringTensorFlow"]

--- a/kymatio/scattering1d/frontend/tensorflow_frontend.py
+++ b/kymatio/scattering1d/frontend/tensorflow_frontend.py
@@ -36,11 +36,10 @@ class TimeFrequencyScatteringTensorFlow(
 ):
     def __init__(
         self,
-        *,
         J,
         J_fr,
-        shape,
         Q,
+        shape,
         T=None,
         stride=None,
         Q_fr=1,
@@ -48,7 +47,7 @@ class TimeFrequencyScatteringTensorFlow(
         stride_fr=None,
         out_type="array",
         backend="tensorflow",
-        format="joint",
+        format="time",
         name="TimeFrequencyScattering"
     ):
         ScatteringTensorFlow.__init__(self, name=name)
@@ -56,8 +55,8 @@ class TimeFrequencyScatteringTensorFlow(
             self,
             J=J,
             J_fr=J_fr,
-            shape=shape,
             Q=Q,
+            shape=shape,
             T=T,
             stride=stride,
             Q_fr=Q_fr,

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -86,18 +86,17 @@ ScatteringTorch1D._document()
 class TimeFrequencyScatteringTorch(ScatteringTorch1D, TimeFrequencyScatteringBase):
     def __init__(
         self,
-        *,
         J,
         J_fr,
-        shape,
         Q,
+        shape,
         T=None,
         stride=None,
         Q_fr=1,
         F=None,
         stride_fr=None,
         out_type="array",
-        format="joint",
+        format="time",
         backend="torch"
     ):
         ScatteringTorch.__init__(self)
@@ -105,8 +104,8 @@ class TimeFrequencyScatteringTorch(ScatteringTorch1D, TimeFrequencyScatteringBas
             self,
             J=J,
             J_fr=J_fr,
-            shape=shape,
             Q=Q,
+            shape=shape,
             T=T,
             stride=stride,
             Q_fr=Q_fr,

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -152,4 +152,7 @@ class TimeFrequencyScatteringTorch(ScatteringTorch1D, TimeFrequencyScatteringBas
                 n += 1
 
 
+TimeFrequencyScatteringTorch._document()
+
+
 __all__ = ["ScatteringTorch1D", "TimeFrequencyScatteringTorch"]

--- a/kymatio/scattering2d/frontend/base_frontend.py
+++ b/kymatio/scattering2d/frontend/base_frontend.py
@@ -56,37 +56,34 @@ class ScatteringBase2D(ScatteringBase):
     _doc_instantiation_shape = {True: 'S = Scattering2D(J, (M, N))',
                                 False: 'S = Scattering2D(J)'}
 
-    _doc_param_shape = \
-    r"""shape : tuple of ints
-            Spatial support (M, N) of the input
-        """
+    _doc_param_shape = r"""
+        shape : tuple of ints
+            Spatial support (M, N) of the input."""
 
-    _doc_attrs_shape = \
-    r"""Psi : dictionary
+    _doc_attrs_shape = r"""
+        Psi : dictionary
             Contains the wavelets filters at all resolutions. See
             `filter_bank.filter_bank` for an exact description.
         Phi : dictionary
             Contains the low-pass filters at all resolutions. See
             `filter_bank.filter_bank` for an exact description.
         M_padded, N_padded : int
-             Spatial support of the padded input.
-        """
+             Spatial support of the padded input."""
 
-    _doc_param_out_type = \
-    r"""out_type : str, optional
+    _doc_param_out_type = r"""
+        out_type : str, optional
             The format of the output of a scattering transform. If set to
             `'list'`, then the output is a list containing each individual
             scattering path with meta information. Otherwise, if set to
             `'array'`, the output is a large array containing the
             concatenation of all scattering coefficients. Defaults to
-            `'array'`.
-        """
+            `'array'`."""
 
-    _doc_attr_out_type = \
-    r"""out_type : str
+    _doc_attr_out_type = r"""
+        out_type : str
             The format of the scattering output. See documentation for
-            `out_type` parameter above and the documentation for `scattering`.
-        """
+            `out_type` parameter above and the documentation for
+            `scattering`."""
 
     _doc_class = \
     r"""The 2D scattering transform
@@ -109,8 +106,8 @@ class ScatteringBase2D(ScatteringBase):
         lowpass filter, $\psi^{{(1)}}_\lambda$ is a family of bandpass filters
         and $\psi^{{(2)}}_\mu$ is another family of bandpass filters. Only
         Morlet filters are used in this implementation. Convolutions are
-        efficiently performed in the Fourier domain.
-        {frontend_paragraph}
+        efficiently performed in the Fourier domain.{frontend_paragraph}
+
         Example
         -------
         ::
@@ -134,8 +131,8 @@ class ScatteringBase2D(ScatteringBase):
         Parameters
         ----------
         J : int
-            Log-2 of the scattering scale.
-        {param_shape}L : int, optional
+            Log-2 of the scattering scale.{param_shape}
+        L : int, optional
             Number of angles used for the wavelet transform. Defaults to `8`.
         max_order : int, optional
             The maximum order of scattering coefficients to compute. Must be
@@ -145,13 +142,13 @@ class ScatteringBase2D(ScatteringBase):
             applied on the signal. If set to True, the software will assume
             the signal was padded externally. Defaults to `False`.
         backend : object, optional
-            Controls the backend which is combined with the frontend.
-        {param_out_type}
+            Controls the backend which is combined with the frontend.{param_out_type}
+
         Attributes
         ----------
         J : int
-            Log-2 of the scattering scale.
-        {param_shape}L : int, optional
+            Log-2 of the scattering scale.{param_shape}
+        L : int, optional
             Number of angles used for the wavelet transform.
         max_order : int, optional
             The maximum order of scattering coefficients to compute.
@@ -159,15 +156,14 @@ class ScatteringBase2D(ScatteringBase):
         pre_pad : boolean
             Controls the padding: if set to False, a symmetric padding is
             applied on the signal. If set to True, the software will assume
-            the signal was padded externally.
-        {attrs_shape}{attr_out_type}
+            the signal was padded externally.{attrs_shape}{attr_out_type}
+
         Notes
         -----
         The design of the filters is optimized for the value `L = 8`.
 
         The `pre_pad` flag is particularly useful when cropping bigger images
-        because this does not introduce border effects inherent to padding.
-        """
+        because this does not introduce border effects inherent to padding."""
 
     _doc_scattering = \
     """Apply the scattering transform
@@ -222,6 +218,15 @@ class ScatteringBase2D(ScatteringBase):
             param_out_type=param_out_type,
             attr_out_type=attr_out_type,
             sample=cls._doc_sample.format(shape=cls._doc_shape))
+
+        # Sphinx will not show docstrings for inherited methods, so we add a
+        # dummy method here that will just call the super.
+        if not "scattering" in cls.__dict__:
+            def _scattering(self, x):
+                return super(cls, self).scattering(x)
+
+            setattr(cls, "scattering", _scattering)
+
 
         cls.scattering.__doc__ = ScatteringBase2D._doc_scattering.format(
             array=cls._doc_array,

--- a/kymatio/scattering3d/frontend/base_frontend.py
+++ b/kymatio/scattering3d/frontend/base_frontend.py
@@ -39,8 +39,7 @@ class ScatteringBase3D(ScatteringBase):
     r"""The 3D solid harmonic scattering transform
 
         This class implements solid harmonic scattering on a 3D input image.
-        For details see https://arxiv.org/abs/1805.00571.
-        {frontend_paragraph}
+        For details see https://arxiv.org/abs/1805.00571.{frontend_paragraph}
 
         Example
         -------
@@ -118,6 +117,14 @@ class ScatteringBase3D(ScatteringBase):
             alias_name=cls._doc_alias_name,
             alias_call=cls._doc_alias_call.format(x="x"),
             sample=cls._doc_sample.format(shape=cls._doc_shape))
+
+        # Sphinx will not show docstrings for inherited methods, so we add a
+        # dummy method here that will just call the super.
+        if not "scattering" in cls.__dict__:
+            def _scattering(self, x):
+                return super(cls, self).scattering(x)
+
+            setattr(cls, "scattering", _scattering)
 
         cls.scattering.__doc__ = ScatteringBase3D._doc_scattering.format(
             array=cls._doc_array,

--- a/tests/scattering1d/test_timefrequency_scattering.py
+++ b/tests/scattering1d/test_timefrequency_scattering.py
@@ -505,12 +505,12 @@ def test_jtfs_numpy_and_sklearn(frontend):
     assert S.F == (2**S.J_fr)
     Sx = S(x)
     assert isinstance(Sx, np.ndarray)
-    assert Sx.ndim == 3
+    assert Sx.ndim == 2
 
     # Global averaging
     S = TimeFrequencyScattering(frontend=frontend, T="global", **kwargs)
     Sx = S(x)
-    assert Sx.ndim == 3
+    assert Sx.ndim == 2
     assert Sx.shape[-1] == 1
 
     # Dictionary output
@@ -521,7 +521,7 @@ def test_jtfs_numpy_and_sklearn(frontend):
     # List output
     S = TimeFrequencyScattering(frontend=frontend, out_type="list", T=0, F=0, **kwargs)
     Sx = S(x)
-    assert all([path["coef"].ndim == 2 for path in Sx if path["order"] > 0])
+    assert all([path["coef"].ndim == 1 for path in Sx if path["order"] > 0])
 
     # meta()
     meta = S.meta()


### PR DESCRIPTION
Builds on #1041.

Integrates JTFS into the docstring machinery. Modifies the `Scattering1D` docstring template to fit with JTFS.

Results can be viewed at https://people.kth.se/~janden/jtfs_docs/codereference.html.