### PR TITLE
Update cifar_small_sample.py to fix AttributeError

### DIFF
--- a/examples/2d/cifar_small_sample.py
+++ b/examples/2d/cifar_small_sample.py
@@ -9,7 +9,7 @@ Based on pytorch example for CIFAR10
 import torch.optim
 from torchvision import datasets, transforms
 import torch.nn.functional as F
-from kymatio import Scattering2D
+from kymatio.torch import Scattering2D
 import torch
 import argparse
 import kymatio.datasets as scattering_datasets


### PR DESCRIPTION
Fixed 
```
AttributeError: 'ScatteringNumPy2D' object has no attribute 'to'
```
kymatio by default imports numpy backend