### PR TITLE
Fixes TypeError, Value Error in tests.

### DIFF
--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -21,7 +21,7 @@ def test_Scattering1D():
     Q = int(data['Q'])
     Sx0 = data['Sx']
     # default
-    inputs0 = Input(shape=(x.shape[-1]))
+    inputs0 = Input(shape=(x.shape[-1], ))
     sc0 = Scattering1D(J=J, Q=Q)(inputs0)
     model0 = Model(inputs0, sc0)
     model0.compile(optimizer='adam',
@@ -32,7 +32,7 @@ def test_Scattering1D():
     # adjust T
     sigma_low_scale_factor = 2
     T = 2**(J-sigma_low_scale_factor)
-    inputs1 = Input(shape=(x.shape[-1]))
+    inputs1 = Input(shape=(x.shape[-1], ))
     sc1 = Scattering1D(J=J, Q=Q, T=T)(inputs1)
     model1 = Model(inputs1, sc1)
     model1.compile(optimizer='adam',

--- a/tests/scattering3d/test_utils_scattering3d.py
+++ b/tests/scattering3d/test_utils_scattering3d.py
@@ -1,5 +1,6 @@
 from kymatio.scattering3d.utils import sqrt
 import pytest
+import warnings
 import numpy as np
 
 def test_utils():
@@ -20,7 +21,7 @@ def test_utils():
     assert "Negative" in record[0].message.args[0]
 
     # ...unless they are complex numbers!
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         x = np.array([-1, 0, 1], dtype='complex64')
         y = sqrt(x)
-    assert not record.list
+    assert len(record) == 0


### PR DESCRIPTION
This PR updates one of our tests to not use deprecated pytest code for checking if no warnings were thrown on complex input. 

Another test is also updated to convert shape inputs of type `int` to type `tuple`.

Should Solve #1045 