### PR TITLE
API adding barebones keras timefreqscatter. 

### DIFF
--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -3,4 +3,6 @@ What's New
 
 .. include:: whats_new/_preamble.rst
 
+.. include:: whats_new/v0.4.rst
+
 .. include:: whats_new/v0.3.rst

--- a/doc/source/whats_new/v0.4.rst
+++ b/doc/source/whats_new/v0.4.rst
@@ -1,0 +1,9 @@
+.. include:: _preamble.rst
+
+Version 0.4.0
+=============
+
+**Changelog**
+
+- |Feature| Add a Keras frontend for ``TimeFrequencyScattering``, completing joint time-frequency scattering (JTFS) support across the NumPy, scikit-learn, PyTorch, TensorFlow, Keras and Jax frontends. :pr:`1059` by :user:`Muawiz Chaudhary <MuawizChaudhary>`
+- |Documentation| Add a joint time-frequency scattering example to the 1D gallery. :pr:`1059`

--- a/examples/1d/plot_time_frequency_scattering.py
+++ b/examples/1d/plot_time_frequency_scattering.py
@@ -1,0 +1,99 @@
+"""
+Joint time-frequency scattering of a synthetic signal
+=====================================================
+The joint time-frequency scattering transform (JTFS) extends the 1D scattering
+transform by applying a second, *two-dimensional* wavelet transform jointly
+over time and log-frequency. This makes it sensitive to the **direction** of
+frequency modulation, which ordinary time scattering discards. In this example
+we build a signal containing an ascending chirp followed by a descending chirp
+and inspect its JTFS coefficients in both output formats.
+"""
+
+###############################################################################
+# Import the necessary packages
+# -----------------------------
+from kymatio.numpy import TimeFrequencyScattering
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+###############################################################################
+# Generate a signal with two chirps of opposite direction
+# --------------------------------------------------------
+# JTFS responds differently to upward and downward frequency sweeps, so we
+# build a signal whose first half sweeps upward in frequency and whose second
+# half sweeps downward.
+N = 2 ** 13
+t = np.arange(N) / N
+
+
+def chirp(f0, f1, time):
+    """A linear frequency sweep from ``f0`` to ``f1`` (normalized frequency)."""
+    instantaneous = f0 * time + 0.5 * (f1 - f0) * time ** 2
+    return np.cos(2 * np.pi * instantaneous * N)
+
+
+x = np.zeros(N, dtype='float32')
+half = N // 2
+x[:half] = chirp(0.02, 0.2, t[:half])        # ascending sweep
+x[half:] = chirp(0.2, 0.02, t[:N - half])    # descending sweep
+x *= np.hanning(N).astype('float32')
+
+plt.figure(figsize=(8, 2))
+plt.plot(x)
+plt.title("Signal: an ascending chirp followed by a descending chirp")
+
+###############################################################################
+# Spectrogram
+# -----------
+# The spectrogram shows the two opposite frequency sweeps.
+plt.figure(figsize=(8, 4))
+plt.specgram(x, Fs=N)
+plt.title("Spectrogram")
+
+###############################################################################
+# Time-format JTFS
+# ----------------
+# With ``format='time'`` the output is a 3D array
+# ``(batch, n_coefficients, time)`` in which every joint path is flattened
+# onto the coefficient axis. We add a leading batch axis to the signal.
+J = 8
+Q = 8
+J_fr = 3
+
+jtfs_time = TimeFrequencyScattering(J=J, J_fr=J_fr, Q=Q, shape=(N,),
+                                    format='time')
+Sx_time = jtfs_time(x[None, :])
+print("format='time' output shape:", Sx_time.shape)
+
+plt.figure(figsize=(8, 4))
+plt.imshow(Sx_time[0], aspect='auto')
+plt.title("JTFS coefficients (format='time')")
+plt.xlabel("Time")
+plt.ylabel("Joint path")
+
+###############################################################################
+# Joint-format JTFS
+# -----------------
+# With ``format='joint'`` the frequency axis is kept explicit, giving a 4D
+# array ``(batch, n_jtfs, n_freq, time)``. Each of the ``n_jtfs`` slices is a
+# localized time-frequency image; the ``meta()`` dictionary records the
+# parameters (including the *spin* ``s = +1``/``-1`` that distinguishes upward
+# from downward modulation) of every slice.
+jtfs_joint = TimeFrequencyScattering(J=J, J_fr=J_fr, Q=Q, shape=(N,),
+                                     format='joint')
+Sx_joint = jtfs_joint(x[None, :])
+print("format='joint' output shape:", Sx_joint.shape)
+
+###############################################################################
+# We display a handful of second-order joint slices as time-frequency images.
+n_show = 6
+fig, axes = plt.subplots(1, n_show, figsize=(2 * n_show, 3))
+for i, ax in enumerate(axes):
+    ax.imshow(Sx_joint[0, i], aspect='auto')
+    ax.set_title("path {}".format(i))
+    ax.set_xticks([])
+    ax.set_yticks([])
+fig.suptitle("JTFS joint slices, each (n_freq x time)  -  format='joint'")
+plt.tight_layout()
+plt.show()

--- a/kymatio/keras.py
+++ b/kymatio/keras.py
@@ -1,10 +1,15 @@
 from .scattering1d.frontend.keras_frontend import ScatteringKeras1D as Scattering1D
+from .scattering1d.frontend.keras_frontend import TimeFrequencyScatteringKeras as TimeFrequencyScattering
 from .scattering2d.frontend.keras_frontend import ScatteringKeras2D as Scattering2D
 
 Scattering1D.__module__ = "kymatio.keras"
 Scattering1D.__name__ = "Scattering1D"
 
+TimeFrequencyScattering.__module__ = "kymatio.keras"
+TimeFrequencyScattering.__name__ = "TimeFrequencyScattering"
+
+
 Scattering2D.__module__ = "kymatio.keras"
 Scattering2D.__name__ = "Scattering2D"
 
-__all__ = ["Scattering1D", "Scattering2D"]
+__all__ = ["Scattering1D", "TimeFrequencyScattering", "Scattering2D"]

--- a/kymatio/keras.py
+++ b/kymatio/keras.py
@@ -8,7 +8,6 @@ Scattering1D.__name__ = "Scattering1D"
 TimeFrequencyScattering.__module__ = "kymatio.keras"
 TimeFrequencyScattering.__name__ = "TimeFrequencyScattering"
 
-
 Scattering2D.__module__ = "kymatio.keras"
 Scattering2D.__name__ = "Scattering2D"
 

--- a/kymatio/scattering1d/frontend/base_frontend.py
+++ b/kymatio/scattering1d/frontend/base_frontend.py
@@ -526,7 +526,7 @@ class TimeFrequencyScatteringBase(ScatteringBase1D):
             Q_fr=1, F=None, stride_fr=None,
             out_type='array', format='time', backend=None):
         max_order = 2
-        oversampling = None
+        oversampling = 0
         super(TimeFrequencyScatteringBase, self).__init__(J, shape, Q, T,
             stride, max_order, oversampling, out_type, backend)
         self.J_fr = J_fr

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -2,8 +2,8 @@ from ...frontend.keras_frontend import ScatteringKeras
 from ...scattering1d.frontend.base_frontend import ScatteringBase1D, TimeFrequencyScatteringBase
 
 from kymatio.tensorflow import Scattering1D as ScatteringTensorFlow1D
-
 from kymatio.tensorflow import TimeFrequencyScattering as TimeFrequencyScatteringTensorFlow
+
 from tensorflow.python.framework import tensor_shape
 
 
@@ -43,41 +43,45 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         J,
         J_fr,
         Q,
-        shape,
+        #shape,
         T=None,
         stride=None,
         Q_fr=1,
         F=None,
         stride_fr=None,
         out_type="array",
+        format="time",
         backend="tensorflow",):
 
         ScatteringKeras.__init__(self)
 
-        self.J=J,
-        self.J_fr=J_fr,
-        self.Q=Q,
-        self.shape=shape,
-        self.T=T,
-        self.stride=stride,
-        self.Q_fr=Q_fr,
-        self.F=F,
-        self.stride_fr=stride_fr,
-        self.out_type=out_type,
-        self.backend=backend,
+        self.J=J
+        self.J_fr=J_fr
+        self._Q=Q
+        #self.shape=shape,
+        self._T=T
+        self._stride=stride
+        self._Q_fr=Q_fr
+        self._F=F
+        self._stride_fr=stride_fr
+        self.out_type=out_type
+        self.format = format
+        #WHAT SHOULD THIS BE? 
+        self._oversampling = 0
+        self.backend=backend
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
         self.S = TimeFrequencyScatteringTensorFlow(
         J=self.J,
         J_fr=self.J_fr,
-        Q=self.Q,
-        shape=self.shape,
-        T=self.T,
-        stride=self.stride,
-        Q_fr=self.Q_fr,
-        F=self.F,
-        stride_fr=self.stride_fr)
+        Q=self._Q,
+        shape=shape,
+        T=self._T,
+        stride=self._stride,
+        Q_fr=self._Q_fr,
+        F=self._F,
+        stride_fr=self._stride_fr)
         ScatteringKeras.build(self, input_shape)
 
     #TODO: how do we implement this without #839 implemented?
@@ -87,7 +91,7 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
             meta = self.meta()
             S1_meta = meta['n'][0]
             N_freq = len(S1_meta[0])
-            N_jtfs = len(meta[’n’])
+            N_jtfs = len(meta['n'])
             k0 = max(self.J - self._oversampling, 0)
             N_time = self.S.ind_end[k0] - self.S.ind_start[k0]
             output_shape = [input_shape[0], N_jtfs, N_freq, N_time]

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -83,11 +83,20 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
     #TODO: how do we implement this without #839 implemented?
     #right now uses ScatteringKeras1D calculation
     def compute_output_shape(self, input_shape):
-        input_shape = tensor_shape.TensorShape(input_shape).as_list()
-        nc = self.S.output_size()
-        k0 = max(self.J - self._oversampling, 0)
-        ln = self.S.ind_end[k0] - self.S.ind_start[k0]
-        output_shape = [input_shape[0], nc, ln]
+        if self.format == 'joint':
+            meta = self.meta()
+            S1_meta = meta['n'][0]
+            N_freq = len(S1_meta[0])
+            N_jtfs = len(meta[’n’])
+            k0 = max(self.J - self._oversampling, 0)
+            N_time = self.S.ind_end[k0] - self.S.ind_start[k0]
+            output_shape = [input_shape[0], N_jtfs, N_freq, N_time]
+        else:
+            input_shape = tensor_shape.TensorShape(input_shape).as_list()
+            nc = self.S.output_size()
+            k0 = max(self.J - self._oversampling, 0)
+            ln = self.S.ind_end[k0] - self.S.ind_start[k0]
+            output_shape = [input_shape[0], nc, ln]
         return tensor_shape.TensorShape(output_shape)
 
     def get_config(self):

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -10,7 +10,8 @@ from tensorflow.python.framework import tensor_shape
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, T=None, max_order=2, oversampling=0):
         ScatteringKeras.__init__(self)
-        ScatteringBase1D.__init__(self, J, None, Q=Q, T=T, max_order=2, oversampling=0, out_type='array')
+        ScatteringBase1D.__init__(self, J, None, Q=Q, T=T, max_order=max_order,
+            oversampling=oversampling, out_type='array')
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
@@ -33,59 +34,56 @@ class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
 
 
 class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase):
-    def __init__(self, 
-        J,
-        J_fr,
-        Q,
-        T=None,
-        stride=None,
-        Q_fr=1,
-        F=None,
-        stride_fr=None,
-        format="time"):
-
+    def __init__(self, J, J_fr, Q, T=None, stride=None, Q_fr=1, F=None,
+            stride_fr=None, format='time'):
         ScatteringKeras.__init__(self)
         TimeFrequencyScatteringBase.__init__(self, J, J_fr, Q, None, T, stride,
-                Q_fr, F, stride_fr, 'array', format)
+            Q_fr, F, stride_fr, 'array', format)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
-        self.shape = shape
-        super(TimeFrequencyScatteringBase, self).build()
-        super(TimeFrequencyScatteringBase, self).create_filters()
-        self.S = TimeFrequencyScatteringTensorFlow(
-        J=self.J,
-        J_fr=self.J_fr,
-        Q=self._Q,
-        shape=shape,
-        T=self._T,
-        stride=self._stride,
-        Q_fr=self.Q_fr,
-        F=self._F,
-        stride_fr=self._stride_fr)
+        # The inner TensorFlow transform builds every (time and frequency)
+        # filterbank itself, so the Keras layer only stores configuration and
+        # delegates the heavy lifting to ``self.S`` -- mirroring
+        # ScatteringKeras1D/2D. ``format`` must be forwarded, otherwise a
+        # ``format='joint'`` layer would silently build a ``'time'`` transform.
+        self.S = TimeFrequencyScatteringTensorFlow(J=self.J, J_fr=self.J_fr,
+            Q=self._Q, shape=shape, T=self._T, stride=self._stride,
+            Q_fr=self.Q_fr, F=self._F, stride_fr=self._stride_fr,
+            format=self.format)
         ScatteringKeras.build(self, input_shape)
 
     def compute_output_shape(self, input_shape):
-        if self.format == 'joint':
-            meta = self.S.meta()
-            
-            S1_meta = meta['n']
-            N_freq = len(S1_meta[0])
-            N_jtfs = len(meta['n'])
-            k0 = max(self.J - self._oversampling, 0)
-            N_time = self.S.ind_end[k0] - self.S.ind_start[k0]
-            output_shape = [input_shape[0], N_jtfs, N_freq, N_time]
+        input_shape = tensor_shape.TensorShape(input_shape).as_list()
+        # The time axis is subsampled by 2 ** log2_stride (= log2(T)), not by
+        # 2 ** J; global averaging collapses it to a single sample.
+        if self.S.average == 'global':
+            n_time = 1
         else:
-            input_shape = tensor_shape.TensorShape(input_shape).as_list()
-            nc = self.S.output_size()
-            k0 = max(self.J - self._oversampling, 0)
-            ln = self.S.ind_end[k0] - self.S.ind_start[k0]
-            output_shape = [input_shape[0], nc, ln]
+            k = max(self.S.log2_stride, 0)
+            n_time = self.S.ind_end[k] - self.S.ind_start[k]
+        if self.format == 'joint':
+            # (batch, n_jtfs, n_freq, time). ``meta()['n']`` already excludes
+            # the zeroth-order path that joint + 'array' output does not emit,
+            # so its length is the number of stacked joint coefficients. Every
+            # joint path shares the same (averaged/subsampled) frequency axis.
+            n_jtfs = len(self.S.meta()['n'])
+            n_freq = self.S._N_padded_fr // 2 ** max(self.S.log2_stride_fr, 0)
+            output_shape = [input_shape[0], n_jtfs, n_freq, n_time]
+        else:
+            # (batch, n_coefficients, time).
+            output_shape = [input_shape[0], self.S.output_size(), n_time]
         return tensor_shape.TensorShape(output_shape)
 
     def get_config(self):
-        keys = ["J", "J_fr", "Q", "max_order", "Q_fr"]
-        return {key: getattr(self, key) for key in keys}
+        # Only "static" parameters that determine the filterbank are
+        # serialized; T, stride, F and stride_fr are dynamic (see gh-1053).
+        # ``self._Q`` (not the ``Q`` property, which returns a tuple) is used so
+        # that ``from_config(get_config())`` round-trips faithfully.
+        keys = ["J", "J_fr", "Q_fr", "format"]
+        config = {key: getattr(self, key) for key in keys}
+        config["Q"] = self._Q
+        return config
 
 
 ScatteringKeras1D._document()

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -10,18 +10,12 @@ from tensorflow.python.framework import tensor_shape
 class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
     def __init__(self, J, Q=1, T=None, max_order=2, oversampling=0):
         ScatteringKeras.__init__(self)
-        self.J = J
-        self._Q = Q
-        self._T = T
-        self._max_order = 2
-        self._oversampling = 0
-        self.out_type = 'array'
-        self.backend = None
+        ScatteringBase1D.__init__(self, J, None, Q=Q, T=T, max_order=2, oversampling=0, out_type='array')
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
         self.S = ScatteringTensorFlow1D(J=self.J, shape=shape,
-            Q=self._Q, T=self._T, max_order=self._max_order,
+            Q=self._Q, T=self._T, max_order=self.max_order,
             oversampling=self._oversampling)
         ScatteringKeras.build(self, input_shape)
 
@@ -49,12 +43,13 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         Q_fr=1,
         F=None,
         stride_fr=None,
-        out_type="array",
-        format="time",
-        backend="tensorflow",):
+        #out_type="array",
+        format="time"):
+        #backend="tensorflow",):
 
         ScatteringKeras.__init__(self)
-
+        #TimeFrequencyScatteringBase()
+        #replace the below code with the above function. 
         self.J=J
         self.J_fr=J_fr
         self._Q=Q
@@ -64,11 +59,12 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         self._Q_fr=Q_fr
         self._F=F
         self._stride_fr=stride_fr
-        self.out_type=out_type
+        self.out_type="array"
         self.format = format
         #WHAT SHOULD THIS BE? 
         self._oversampling = 0
-        self.backend=backend
+        self.max_order = 2
+        #self.backend=backend
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -1,8 +1,9 @@
 from ...frontend.keras_frontend import ScatteringKeras
-from ...scattering1d.frontend.base_frontend import ScatteringBase1D
+from ...scattering1d.frontend.base_frontend import ScatteringBase1D, TimeFrequencyScatteringBase
 
 from kymatio.tensorflow import Scattering1D as ScatteringTensorFlow1D
 
+from kymatio.tensorflow import TimeFrequencyScattering as TimeFrequencyScatteringTensorFlow
 from tensorflow.python.framework import tensor_shape
 
 
@@ -36,4 +37,63 @@ class ScatteringKeras1D(ScatteringKeras, ScatteringBase1D):
         keys = ["J", "Q", "max_order", "oversampling"]
         return {key: getattr(self, key) for key in keys}
 
+
+class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase):
+    def __init__(self, 
+        J,
+        J_fr,
+        Q,
+        shape,
+        T=None,
+        stride=None,
+        Q_fr=1,
+        F=None,
+        stride_fr=None,
+        out_type="array",
+        backend="tensorflow",):
+
+        ScatteringKeras.__init__(self)
+
+        self.J=J,
+        self.J_fr=J_fr,
+        self.Q=Q,
+        self.shape=shape,
+        self.T=T,
+        self.stride=stride,
+        self.Q_fr=Q_fr,
+        self.F=F,
+        self.stride_fr=stride_fr,
+        self.out_type=out_type,
+        self.backend=backend,
+
+    def build(self, input_shape):
+        shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
+        self.S = TimeFrequencyScatteringTensorFlow(
+        J=self.J,
+        J_fr=self.J_fr,
+        Q=self.Q,
+        shape=self.shape,
+        T=self.T,
+        stride=self.stride,
+        Q_fr=self.Q_fr,
+        F=self.F,
+        stride_fr=self.stride_fr)
+        ScatteringKeras.build(self, input_shape)
+
+    #TODO: how do we implement this without #839 implemented?
+    #right now uses ScatteringKeras1D calculation
+    def compute_output_shape(self, input_shape):
+        input_shape = tensor_shape.TensorShape(input_shape).as_list()
+        nc = self.S.output_size()
+        k0 = max(self.J - self._oversampling, 0)
+        ln = self.S.ind_end[k0] - self.S.ind_start[k0]
+        output_shape = [input_shape[0], nc, ln]
+        return tensor_shape.TensorShape(output_shape)
+
+    def get_config(self):
+        keys = ["J", "J_fr", "Q", "max_order", "Q_fr"]
+        return {key: getattr(self, key) for key in keys}
+
+
 ScatteringKeras1D._document()
+TimeFrequencyScatteringKeras._document()

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -48,23 +48,24 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         #backend="tensorflow",):
 
         ScatteringKeras.__init__(self)
-        #TimeFrequencyScatteringBase()
-        #replace the below code with the above function. 
-        self.J=J
-        self.J_fr=J_fr
-        self._Q=Q
-        #self.shape=shape,
-        self._T=T
-        self._stride=stride
-        self._Q_fr=Q_fr
-        self._F=F
-        self._stride_fr=stride_fr
-        self.out_type="array"
-        self.format = format
-        #WHAT SHOULD THIS BE? 
-        self._oversampling = 0
-        self.max_order = 2
-        #self.backend=backend
+        TimeFrequencyScatteringBase.__init__(self, J, J_fr, Q, None, T, stride,
+                Q_fr, F, stride_fr, 'array', format)
+#        self._oversampling = 0
+#        #replace the below code with the above function. 
+#        self.J=J
+#        self.J_fr=J_fr
+#        self._Q=Q
+#        #self.shape=shape,
+#        self._T=T
+#        self._stride=stride
+#        self._Q_fr=Q_fr
+#        self._F=F
+#        self._stride_fr=stride_fr
+#        self.out_type="array"
+#        self.format = format
+#        #WHAT SHOULD THIS BE? 
+#        self.max_order = 2
+#        #self.backend=backend
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
@@ -75,7 +76,7 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         shape=shape,
         T=self._T,
         stride=self._stride,
-        Q_fr=self._Q_fr,
+        Q_fr=self.Q_fr,
         F=self._F,
         stride_fr=self._stride_fr)
         ScatteringKeras.build(self, input_shape)
@@ -94,6 +95,8 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         else:
             input_shape = tensor_shape.TensorShape(input_shape).as_list()
             nc = self.S.output_size()
+            print(self._oversampling)
+            print(self.J, self.oversampling)
             k0 = max(self.J - self._oversampling, 0)
             ln = self.S.ind_end[k0] - self.S.ind_start[k0]
             output_shape = [input_shape[0], nc, ln]

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -37,35 +37,16 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         J,
         J_fr,
         Q,
-        #shape,
         T=None,
         stride=None,
         Q_fr=1,
         F=None,
         stride_fr=None,
-        #out_type="array",
         format="time"):
-        #backend="tensorflow",):
 
         ScatteringKeras.__init__(self)
         TimeFrequencyScatteringBase.__init__(self, J, J_fr, Q, None, T, stride,
                 Q_fr, F, stride_fr, 'array', format)
-#        self._oversampling = 0
-#        #replace the below code with the above function. 
-#        self.J=J
-#        self.J_fr=J_fr
-#        self._Q=Q
-#        #self.shape=shape,
-#        self._T=T
-#        self._stride=stride
-#        self._Q_fr=Q_fr
-#        self._F=F
-#        self._stride_fr=stride_fr
-#        self.out_type="array"
-#        self.format = format
-#        #WHAT SHOULD THIS BE? 
-#        self.max_order = 2
-#        #self.backend=backend
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
@@ -84,16 +65,11 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         stride_fr=self._stride_fr)
         ScatteringKeras.build(self, input_shape)
 
-    #TODO: how do we implement this without #839 implemented?
-    #right now uses ScatteringKeras1D calculation
     def compute_output_shape(self, input_shape):
         if self.format == 'joint':
             meta = self.S.meta()
             
-            S1_meta = meta['n']#[0]
-            print(meta['n'])
-            print(meta['n'][0])
-            #print(
+            S1_meta = meta['n']
             N_freq = len(S1_meta[0])
             N_jtfs = len(meta['n'])
             k0 = max(self.J - self._oversampling, 0)
@@ -102,8 +78,6 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
         else:
             input_shape = tensor_shape.TensorShape(input_shape).as_list()
             nc = self.S.output_size()
-            print(self._oversampling)
-            print(self.J, self.oversampling)
             k0 = max(self.J - self._oversampling, 0)
             ln = self.S.ind_end[k0] - self.S.ind_start[k0]
             output_shape = [input_shape[0], nc, ln]

--- a/kymatio/scattering1d/frontend/keras_frontend.py
+++ b/kymatio/scattering1d/frontend/keras_frontend.py
@@ -69,6 +69,9 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
 
     def build(self, input_shape):
         shape = tuple(tensor_shape.TensorShape(input_shape).as_list()[-1:])
+        self.shape = shape
+        super(TimeFrequencyScatteringBase, self).build()
+        super(TimeFrequencyScatteringBase, self).create_filters()
         self.S = TimeFrequencyScatteringTensorFlow(
         J=self.J,
         J_fr=self.J_fr,
@@ -85,8 +88,12 @@ class TimeFrequencyScatteringKeras(ScatteringKeras, TimeFrequencyScatteringBase)
     #right now uses ScatteringKeras1D calculation
     def compute_output_shape(self, input_shape):
         if self.format == 'joint':
-            meta = self.meta()
-            S1_meta = meta['n'][0]
+            meta = self.S.meta()
+            
+            S1_meta = meta['n']#[0]
+            print(meta['n'])
+            print(meta['n'][0])
+            #print(
             N_freq = len(S1_meta[0])
             N_jtfs = len(meta['n'])
             k0 = max(self.J - self._oversampling, 0)

--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -6,7 +6,6 @@ import os
 import numpy as np
 import io
 import sys
-import tensorflow as tf
 
 def test_Scattering1D():
     """
@@ -49,7 +48,7 @@ def test_Scattering1D():
     model1.summary()
     sys.stdout = save_stdout
     assert 'scattering1d' in result.getvalue()
-  
+
     sc0 = Scattering1D(J=J, Q=Q)
     sc0.build(inputs0.shape)
     assert sc0.compute_output_shape(inputs0.shape)[-1] == 8
@@ -89,107 +88,105 @@ def test_Q():
                   metrics=['accuracy'])
     Sc_tuple_out = model1.predict(x)
 
-    assert Sc_int_out.shape == (Sc_tuple_out.shape[0], Sc_tuple_out.shape[1], Sc_tuple_out.shape[2])
+    assert Sc_int_out.shape == (Sc_int_out.shape[0], Sc_tuple_out.shape[1], Sc_tuple_out.shape[2])
+
+
+def _jtfs_model(x, **kwargs):
+    """Build and compile a Keras model wrapping a TimeFrequencyScattering
+    layer, returning the model and its prediction on ``x``."""
+    inputs = Input(shape=(x.shape[-1], ))
+    out = TimeFrequencyScattering(**kwargs)(inputs)
+    model = Model(inputs, out)
+    model.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    return model, model.predict(x)
+
+
+def _assert_output_shape_matches(x, **kwargs):
+    """compute_output_shape (static inference) must agree with the realized
+    transform on every non-batch axis."""
+    _, Sx = _jtfs_model(x, **kwargs)
+    layer = TimeFrequencyScattering(**kwargs)
+    layer.build((None, x.shape[-1]))
+    inferred = layer.compute_output_shape((None, x.shape[-1])).as_list()
+    assert tuple(inferred[1:]) == tuple(Sx.shape[1:])
+    return Sx
 
 
 def test_TimeFrequencyScattering():
-    """
-    Applies scattering on a stored signal to make sure its output agrees with
-    a previously calculated version.
-    """
+    """format='time': output is (batch, n_coefficients, time) and
+    compute_output_shape tracks the realized shape under default, explicit and
+    global temporal averaging."""
     test_data_dir = os.path.dirname(__file__)
     with open(os.path.join(test_data_dir, 'test_data_1d.npz'), 'rb') as f:
         buffer = io.BytesIO(f.read())
         data = np.load(buffer)
     x = data['x']
-    J = data['J']
+    J = int(data['J'])
     Q = int(data['Q'])
-    Sx0 = data['Sx']
-    # default
-    inputs0 = Input(shape=(x.shape[-1], ))
-    sc0 = TimeFrequencyScattering(J=J, J_fr=1, Q=Q)(inputs0)
-    model0 = Model(inputs0, sc0)
-    model0.compile(optimizer='adam',
-                  loss='sparse_categorical_crossentropy',
-                  metrics=['accuracy'])
-    Sg0 = model0.predict(x)
-    assert np.allclose(Sg0, Sx0, atol=1e-06)
-    # adjust T
-    sigma_low_scale_factor = 2
-    T = 2**(J-sigma_low_scale_factor)
-    inputs1 = Input(shape=(x.shape[-1], ))
-    sc1 = TimeFrequencyScattering(J=J, J_fr=0, Q=Q, T=T)(inputs1)
-    model1 = Model(inputs1, sc1)
-    model1.compile(optimizer='adam',
-                  loss='sparse_categorical_crossentropy',
-                  metrics=['accuracy'])
-    Sg1 = model1.predict(x)
-    assert Sg1.shape == (
-        Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**(sigma_low_scale_factor))
 
+    # default temporal averaging (T = 2 ** J)
+    model0, Sg0 = _jtfs_model(x, J=J, J_fr=1, Q=Q)
+    assert Sg0.ndim == 3
+    Sg0_check = _assert_output_shape_matches(x, J=J, J_fr=1, Q=Q)
+    assert Sg0_check.shape == Sg0.shape
+
+    # explicit T < 2 ** J reduces temporal subsampling, lengthening the time
+    # axis by 2 ** sigma_low_scale_factor while keeping the coefficient count.
+    sigma_low_scale_factor = 2
+    T = 2 ** (J - sigma_low_scale_factor)
+    Sg1 = _assert_output_shape_matches(x, J=J, J_fr=1, Q=Q, T=T)
+    assert Sg1.shape[:2] == Sg0.shape[:2]
+    assert Sg1.shape[-1] == Sg0.shape[-1] * 2 ** sigma_low_scale_factor
+
+    # global averaging collapses the time axis to a single sample
+    Sg2 = _assert_output_shape_matches(x, J=J, J_fr=1, Q=Q, T='global')
+    assert Sg2.shape[-1] == 1
+
+    # the layer is named after the transform in the model summary
     save_stdout = sys.stdout
     result = io.StringIO()
     sys.stdout = result
-    model1.summary()
+    model0.summary()
     sys.stdout = save_stdout
-    assert 'timefrequencyscattering' in result.getvalue()
-  
-    sc0 = TimeFrequencyScattering(J=J, J_fr=0, Q=Q)
-    sc0.build(inputs0.shape)
-    assert sc0.compute_output_shape(inputs0.shape)[-1] == 8
+    assert 'scattering' in result.getvalue().lower()
 
 
-from kymatio.scattering1d.frontend.tensorflow_frontend import TimeFrequencyScatteringTensorFlow
-from kymatio.scattering1d.frontend.tensorflow_frontend import ScatteringTensorFlow1D
-import torch
+def test_TimeFrequencyScattering_time_largeJ():
+    """format='time' with a larger transform and no frequency averaging
+    (F=0), including global averaging."""
+    J, J_fr, Q, N = 8, 3, 3, 8192
+    x = np.zeros((2, N), dtype='float32')
+    x[:, N // 2] = 1.0
 
-def test_jtfs_torch_tf_frontends():
-    # Test __init__
-    kwargs = {"J": 8, "J_fr": 3, "Q": 3}
-    shape = (8192,)
-    x = np.zeros((1, 8192,))
-    x[:, shape[0] // 2] = 1
-    print(type(x))
-    tf.compat.v1.enable_eager_execution()  # Fixes eager execution
-    x = tf.convert_to_tensor(x)
-    inputs0 = Input(shape=(x.shape[-1], ))
-    # format='time'
-    S = TimeFrequencyScattering(T=None, F=0, format="time", **kwargs)(inputs0)
-    model0 = Model(inputs0, S)
-    model0.compile(optimizer='adam',
-                  loss='sparse_categorical_crossentropy',
-                  metrics=['accuracy'])
-    Sx = model0.predict(x)
-    print(Sx.shape)
-    print(type(Sx))
+    Sx = _assert_output_shape_matches(x, J=J, J_fr=J_fr, Q=Q, F=0, format='time')
     assert Sx.ndim == 3
 
-    # format='time' with global averaging
-    inputs1 = Input(shape=(x.shape[-1], ))
-    S = TimeFrequencyScattering(T="global", F=0, format="time", **kwargs)(inputs1)
-    model1 = Model(inputs1, S)
-    model1.compile(optimizer='adam',
-                  loss='sparse_categorical_crossentropy',
-                  metrics=['accuracy'])
-    Sx = model1.predict(x)
-    print(Sx.shape)
-    print(type(Sx))
-    assert Sx.ndim == 3
+    Sx_global = _assert_output_shape_matches(
+        x, J=J, J_fr=J_fr, Q=Q, T='global', F=0, format='time')
+    assert Sx_global.ndim == 3
+    assert Sx_global.shape[-1] == 1
 
-    # Local averaging
-    inputs2 = Input(shape=(x.shape[-1], ))
-    S = TimeFrequencyScattering(format="joint", **kwargs)(inputs2)
-    model2 = Model(inputs2, S)
-    model2.compile(optimizer='adam',
-                  loss='sparse_categorical_crossentropy',
-                  metrics=['accuracy'])
-    Sx = model1.predict(x)
 
-    assert S.F == (2**S.J_fr)
-    print(Sx.shape)
-    print(type(Sx))
-    Sx = S(x)
-    assert isinstance(Sx, torch.Tensor) if frontend == "torch" else isinstance(Sx, tf.Tensor)
+def test_TimeFrequencyScattering_joint():
+    """format='joint': output is (batch, n_jtfs, n_freq, time) and
+    compute_output_shape matches the realized 4D shape."""
+    J, J_fr, Q, N = 8, 3, 3, 8192
+    x = np.zeros((2, N), dtype='float32')
+    x[:, N // 2] = 1.0
+
+    Sx = _assert_output_shape_matches(x, J=J, J_fr=J_fr, Q=Q, format='joint')
     assert Sx.ndim == 4
 
 
+def test_TimeFrequencyScattering_get_config():
+    """get_config serializes only the static (filterbank-determining)
+    parameters and round-trips through from_config."""
+    sc = TimeFrequencyScattering(J=8, J_fr=3, Q=3, Q_fr=1, format='joint')
+    config = sc.get_config()
+    assert set(config) == {'J', 'J_fr', 'Q', 'Q_fr', 'format'}
+    assert config['Q'] == 3 and config['format'] == 'joint'
+
+    sc_restored = TimeFrequencyScattering.from_config(config)
+    assert sc_restored.get_config() == config

--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -1,6 +1,6 @@
 import pytest
 from tensorflow.keras.layers import Input, Flatten, Dense
-from kymatio.keras import Scattering1D
+from kymatio.keras import Scattering1D, TimeFrequencyScattering
 from tensorflow.keras.models import Model
 import os
 import numpy as np
@@ -89,3 +89,52 @@ def test_Q():
     Sc_tuple_out = model1.predict(x)
 
     assert Sc_int_out.shape == (Sc_tuple_out.shape[0], Sc_tuple_out.shape[1], Sc_tuple_out.shape[2])
+
+
+def test_TimeFrequencyScattering():
+    """
+    Applies scattering on a stored signal to make sure its output agrees with
+    a previously calculated version.
+    """
+    test_data_dir = os.path.dirname(__file__)
+    with open(os.path.join(test_data_dir, 'test_data_1d.npz'), 'rb') as f:
+        buffer = io.BytesIO(f.read())
+        data = np.load(buffer)
+    x = data['x']
+    J = data['J']
+    Q = int(data['Q'])
+    Sx0 = data['Sx']
+    # default
+    inputs0 = Input(shape=(x.shape[-1], ))
+    sc0 = TimeFrequencyScattering(J=J, J_fr=1, Q=Q)(inputs0)
+    model0 = Model(inputs0, sc0)
+    model0.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    Sg0 = model0.predict(x)
+    assert np.allclose(Sg0, Sx0, atol=1e-06)
+    # adjust T
+    sigma_low_scale_factor = 2
+    T = 2**(J-sigma_low_scale_factor)
+    inputs1 = Input(shape=(x.shape[-1], ))
+    sc1 = TimeFrequencyScattering(J=J, J_fr=0, Q=Q, T=T)(inputs1)
+    model1 = Model(inputs1, sc1)
+    model1.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    Sg1 = model1.predict(x)
+    assert Sg1.shape == (
+        Sg0.shape[0], Sg0.shape[1], Sg0.shape[2]*2**(sigma_low_scale_factor))
+
+    save_stdout = sys.stdout
+    result = io.StringIO()
+    sys.stdout = result
+    model1.summary()
+    sys.stdout = save_stdout
+    assert 'timefrequencyscattering' in result.getvalue()
+  
+    sc0 = TimeFrequencyScattering(J=J, J_fr=0, Q=Q)
+    sc0.build(inputs0.shape)
+    assert sc0.compute_output_shape(inputs0.shape)[-1] == 8
+
+

--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -7,6 +7,11 @@ import numpy as np
 import io
 import sys
 
+from kymatio.scattering1d.frontend.tensorflow_frontend import (
+    TimeFrequencyScatteringTensorFlow)
+from kymatio.scattering1d.frontend.numpy_frontend import (
+    TimeFrequencyScatteringNumPy)
+
 def test_Scattering1D():
     """
     Applies scattering on a stored signal to make sure its output agrees with
@@ -190,3 +195,53 @@ def test_TimeFrequencyScattering_get_config():
 
     sc_restored = TimeFrequencyScattering.from_config(config)
     assert sc_restored.get_config() == config
+
+
+def _jtfs_frontend_outputs(x, **kwargs):
+    """Compute the JTFS of ``x`` with the Keras, TensorFlow and NumPy frontends
+    using identical parameters, returning the three outputs as NumPy arrays.
+
+    The Keras layer wraps the TensorFlow transform, whereas the NumPy frontend
+    is an independent backend -- so agreement validates both the Keras wrapper
+    and cross-backend numerical consistency.
+    """
+    N = x.shape[-1]
+    inputs = Input(shape=(N,))
+    model = Model(inputs, TimeFrequencyScattering(**kwargs)(inputs))
+    model.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    keras_out = model.predict(x)
+    tf_out = np.asarray(TimeFrequencyScatteringTensorFlow(shape=(N,), **kwargs)(x))
+    np_out = np.asarray(TimeFrequencyScatteringNumPy(shape=(N,), **kwargs)(x))
+    return keras_out, tf_out, np_out
+
+
+def _assert_frontends_agree(x, **kwargs):
+    keras_out, tf_out, np_out = _jtfs_frontend_outputs(x, **kwargs)
+    assert keras_out.shape == tf_out.shape == np_out.shape, (
+        keras_out.shape, tf_out.shape, np_out.shape)
+    assert np.allclose(keras_out, tf_out, rtol=1e-4, atol=1e-5), \
+        "keras vs tensorflow max|diff|={}".format(np.abs(keras_out - tf_out).max())
+    assert np.allclose(keras_out, np_out, rtol=1e-4, atol=1e-5), \
+        "keras vs numpy max|diff|={}".format(np.abs(keras_out - np_out).max())
+    return keras_out
+
+
+def test_TimeFrequencyScattering_matches_tf_and_numpy_time():
+    """The Keras ``format='time'`` output matches the TensorFlow and NumPy
+    frontends, under both default (local) and global temporal averaging."""
+    rng = np.random.RandomState(0)
+    N = 2 ** 12
+    x = rng.randn(2, N).astype('float32')
+    _assert_frontends_agree(x, J=6, J_fr=2, Q=8, format='time')
+    _assert_frontends_agree(x, J=6, J_fr=2, Q=8, T='global', format='time')
+
+
+def test_TimeFrequencyScattering_matches_tf_and_numpy_joint():
+    """The Keras ``format='joint'`` (4D) output matches the TensorFlow and
+    NumPy frontends."""
+    rng = np.random.RandomState(0)
+    N = 2 ** 12
+    x = rng.randn(2, N).astype('float32')
+    _assert_frontends_agree(x, J=6, J_fr=2, Q=8, format='joint')

--- a/tests/scattering1d/test_keras_scattering1d.py
+++ b/tests/scattering1d/test_keras_scattering1d.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 import io
 import sys
+import tensorflow as tf
 
 def test_Scattering1D():
     """
@@ -136,5 +137,59 @@ def test_TimeFrequencyScattering():
     sc0 = TimeFrequencyScattering(J=J, J_fr=0, Q=Q)
     sc0.build(inputs0.shape)
     assert sc0.compute_output_shape(inputs0.shape)[-1] == 8
+
+
+from kymatio.scattering1d.frontend.tensorflow_frontend import TimeFrequencyScatteringTensorFlow
+from kymatio.scattering1d.frontend.tensorflow_frontend import ScatteringTensorFlow1D
+import torch
+
+def test_jtfs_torch_tf_frontends():
+    # Test __init__
+    kwargs = {"J": 8, "J_fr": 3, "Q": 3}
+    shape = (8192,)
+    x = np.zeros((1, 8192,))
+    x[:, shape[0] // 2] = 1
+    print(type(x))
+    tf.compat.v1.enable_eager_execution()  # Fixes eager execution
+    x = tf.convert_to_tensor(x)
+    inputs0 = Input(shape=(x.shape[-1], ))
+    # format='time'
+    S = TimeFrequencyScattering(T=None, F=0, format="time", **kwargs)(inputs0)
+    model0 = Model(inputs0, S)
+    model0.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    Sx = model0.predict(x)
+    print(Sx.shape)
+    print(type(Sx))
+    assert Sx.ndim == 3
+
+    # format='time' with global averaging
+    inputs1 = Input(shape=(x.shape[-1], ))
+    S = TimeFrequencyScattering(T="global", F=0, format="time", **kwargs)(inputs1)
+    model1 = Model(inputs1, S)
+    model1.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    Sx = model1.predict(x)
+    print(Sx.shape)
+    print(type(Sx))
+    assert Sx.ndim == 3
+
+    # Local averaging
+    inputs2 = Input(shape=(x.shape[-1], ))
+    S = TimeFrequencyScattering(format="joint", **kwargs)(inputs2)
+    model2 = Model(inputs2, S)
+    model2.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    Sx = model1.predict(x)
+
+    assert S.F == (2**S.J_fr)
+    print(Sx.shape)
+    print(type(Sx))
+    Sx = S(x)
+    assert isinstance(Sx, torch.Tensor) if frontend == "torch" else isinstance(Sx, tf.Tensor)
+    assert Sx.ndim == 4
 
 


### PR DESCRIPTION
Resolves #1053. We need to figure out how to `compute_output_shape`, given that #839 was not incorporated. 

@lostanlen your advices here would be appreciated. See #1053 for prior discussion. 