### PR TITLE
Fix Unit Tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -35,7 +35,7 @@ jobs:
                   conda create -q -n ${CONDA_ENV} python=${{ matrix.python-version }}
             - name: Install dependencies
               run: |
-                  conda install -n ${CONDA_ENV} numpy scipy pytest pytest-cov
+                  conda install -n ${CONDA_ENV} numpy=1.26.4 scipy pytest pytest-cov
                   conda install -n ${CONDA_ENV} pytorch=${{ matrix.pytorch-version }} torchvision cpuonly -c pytorch
 
                   conda run -n ${CONDA_ENV} python3 -m pip install --upgrade pip

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -35,7 +35,7 @@ jobs:
                   conda create -q -n ${CONDA_ENV} python=${{ matrix.python-version }}
             - name: Install dependencies
               run: |
-                  conda install -n ${CONDA_ENV} -c conda-forge numpy=1.24.0 scipy pytest pytest-cov
+                  conda install -n ${CONDA_ENV} numpy scipy pytest pytest-cov
                   conda install -n ${CONDA_ENV} pytorch=${{ matrix.pytorch-version }} torchvision cpuonly -c pytorch
 
                   conda run -n ${CONDA_ENV} python3 -m pip install --upgrade pip
@@ -47,6 +47,8 @@ jobs:
 
                   conda run -n ${CONDA_ENV} python3 -m pip install -r requirements.txt
                   conda run -n ${CONDA_ENV} python3 -m pip install -r requirements_optional.txt
+                  conda remove -n ${CONDA_ENV} --force numpy
+                  conda install -n ${CONDA_ENV} -c conda-forge numpy=1.24.0 
             - name: Set up Kymatio
               run: conda run -n ${CONDA_ENV} python3 setup.py develop
             - name: Test

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -35,7 +35,7 @@ jobs:
                   conda create -q -n ${CONDA_ENV} python=${{ matrix.python-version }}
             - name: Install dependencies
               run: |
-                  conda install -n ${CONDA_ENV} numpy=1.26.4 scipy pytest pytest-cov
+                  conda install -n ${CONDA_ENV} numpy=1.24.0 scipy pytest pytest-cov
                   conda install -n ${CONDA_ENV} pytorch=${{ matrix.pytorch-version }} torchvision cpuonly -c pytorch
 
                   conda run -n ${CONDA_ENV} python3 -m pip install --upgrade pip

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -47,6 +47,7 @@ jobs:
 
                   conda run -n ${CONDA_ENV} python3 -m pip install -r requirements.txt
                   conda run -n ${CONDA_ENV} python3 -m pip install -r requirements_optional.txt
+                  conda run -n ${CONDA_ENV} python3 -m pip install --upgrade typing-extensions
                   conda remove -n ${CONDA_ENV} --force numpy
                   conda install -n ${CONDA_ENV} -c conda-forge numpy=1.24.0 
             - name: Set up Kymatio

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -35,7 +35,7 @@ jobs:
                   conda create -q -n ${CONDA_ENV} python=${{ matrix.python-version }}
             - name: Install dependencies
               run: |
-                  conda install -n ${CONDA_ENV} numpy=1.24.0 scipy pytest pytest-cov
+                  conda install -n ${CONDA_ENV} -c conda-forge numpy=1.24.0 scipy pytest pytest-cov
                   conda install -n ${CONDA_ENV} pytorch=${{ matrix.pytorch-version }} torchvision cpuonly -c pytorch
 
                   conda run -n ${CONDA_ENV} python3 -m pip install --upgrade pip

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -49,6 +49,7 @@ jobs:
 
                   python3 -m pip install -r requirements.txt
                   python3 -m pip install -r requirements_optional.txt
+                  python3 -m pip install --upgrade --force-reinstall numpy==1.24.0
             - name: Set up Kymatio
               run: python3 setup.py develop
             - name: Test

--- a/tests/general/test_jnp_vs_np.py
+++ b/tests/general/test_jnp_vs_np.py
@@ -9,8 +9,7 @@ import numpy as np
 import scipy.fftpack
 
 import jax.numpy as jnp
-from jax import random, device_put
-import jax.config as config 
+from jax import random, device_put, config
 
 key = random.PRNGKey(0)
 


### PR DESCRIPTION
This PR fixes a jax unit test to import config directly from jax. The previous method (importing from jax.config module) has been deprecated. 

We also set the version of Numpy to 1.24.0 to get the Pytorch suite of unit tests running again. Should be discussed if this change is fine, or how we want to work around it. 

We should discuss how we want to handle the harmonic scattering test failing due to a OOM error on certain versions of Python + PyTorch. 