### PR TITLE
FIX scipy deprecated function

### DIFF
--- a/kymatio/scattering3d/filter_bank.py
+++ b/kymatio/scattering3d/filter_bank.py
@@ -1,7 +1,7 @@
 __all__ = ['solid_harmonic_filter_bank']
 
 import numpy as np
-from scipy.special import sph_harm, factorial
+from scipy.special import sph_harm_y, factorial
 from .utils import get_3d_angles, double_factorial, sqrt
 
 
@@ -164,7 +164,7 @@ def solid_harmonic_3d(M, N, O, sigma, l, fourier=True):
     polar, azimuthal = get_3d_angles(grid)
 
     for i_m, m in enumerate(range(-l, l + 1)):
-        solid_harm[i_m] = sph_harm(m, l, azimuthal, polar) * polynomial_gaussian
+        solid_harm[i_m] = sph_harm_y(m, l, azimuthal, polar) * polynomial_gaussian
 
     if l % 2 == 0:
         norm_factor = 1. / (2 * np.pi * np.sqrt(l + 0.5) * 


### PR DESCRIPTION
`scipy.special.sph_harm` has been deprecated since since scipy 1.15.0 (jan 2025) and removed in scipy 1.17.0 (jan 2026). 
Replaced by `scipy.special.sph_harm_y`