### PR TITLE
[Fix] Update to scipy 1.17 (#1068)

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -36,7 +36,7 @@ jobs:
                   conda create -q -n ${CONDA_ENV} python=${{ matrix.python-version }}
             - name: Install dependencies
               run: |
-                  conda install -n ${CONDA_ENV} numpy "scipy<1.15" pytest pytest-cov
+                  conda install -n ${CONDA_ENV} numpy "scipy>=1.17" pytest pytest-cov
                   conda install -n ${CONDA_ENV} pytorch=${{ matrix.pytorch-version }} torchvision cpuonly -c pytorch
 
                   conda run -n ${CONDA_ENV} python3 -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Andreux M., Angles T., Exarchakis G., Leonarduzzi R., Rochette G., Thiry L., Zar
 Kymatio requires:
 
 * Python (>= 3.7)
-* SciPy (>= 0.13)
+* SciPy (>= 1.17)
 
 
 ### Standard installation

--- a/kymatio/scattering3d/filter_bank.py
+++ b/kymatio/scattering3d/filter_bank.py
@@ -164,7 +164,7 @@ def solid_harmonic_3d(M, N, O, sigma, l, fourier=True):
     polar, azimuthal = get_3d_angles(grid)
 
     for i_m, m in enumerate(range(-l, l + 1)):
-        solid_harm[i_m] = sph_harm_y(m, l, polar, azimuthal) * polynomial_gaussian
+        solid_harm[i_m] = sph_harm_y(l, m, polar, azimuthal) * polynomial_gaussian
 
     if l % 2 == 0:
         norm_factor = 1. / (2 * np.pi * np.sqrt(l + 0.5) * 

--- a/kymatio/scattering3d/filter_bank.py
+++ b/kymatio/scattering3d/filter_bank.py
@@ -1,7 +1,7 @@
 __all__ = ['solid_harmonic_filter_bank']
 
 import numpy as np
-from scipy.special import sph_harm, factorial
+from scipy.special import sph_harm_y, factorial
 from .utils import get_3d_angles, double_factorial, sqrt
 
 
@@ -164,7 +164,7 @@ def solid_harmonic_3d(M, N, O, sigma, l, fourier=True):
     polar, azimuthal = get_3d_angles(grid)
 
     for i_m, m in enumerate(range(-l, l + 1)):
-        solid_harm[i_m] = sph_harm(m, l, azimuthal, polar) * polynomial_gaussian
+        solid_harm[i_m] = sph_harm_y(m, l, polar, azimuthal) * polynomial_gaussian
 
     if l % 2 == 0:
         norm_factor = 1. / (2 * np.pi * np.sqrt(l + 0.5) * 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-scipy<1.15
+scipy>=1.17
 appdirs
 configparser
 packaging


### PR DESCRIPTION
Because of the update to `scipy` 1.17, `sph_harm` [has been changed](https://docs.scipy.org/doc/scipy-1.16.1/reference/generated/scipy.special.sph_harm.html) to `sph_harm_y` (and inverted polar and azimutal angles).

This PR updates scipy to 1.17 in the requirements, workflows and readme, and updates the `sph_harm` implementation in `kymatio/scattering2d/filter_bank.py`.

> I hope this mitigate the workflow issues from #1065 